### PR TITLE
Use a piecewise cubic polynomial for charateristic charge in GIEX adsorption model

### DIFF
--- a/doc/interface/binding/generalized_ion_exchange.rst
+++ b/doc/interface/binding/generalized_ion_exchange.rst
@@ -106,38 +106,70 @@ Generalized Ion Exchange
 
 **Unit:** :math:`m_{MP}^{3} mol^{-1}`
 
-===================  =========================  
+===================  ========================= 
 **Type:** double     **Length:** NCOMP
 ===================  ========================= 
 
 ``GIEX_NU``
    Base value for characteristic charges of the protein; The number of
    sites :math:`\nu` that the protein interacts with on the resin
-   surface
+   surface. If more than NCOMP values are provided, :math:`\nu` is given
+   by a piecewise cubic polynomial. Data is expected in component-major
+   ordering.
 
-===================  =========================  
-**Type:** double     **Length:** NCOMP
-===================  ========================= 
+===================  ===============================  
+**Type:** double     **Length:** multiples of NCOMP
+===================  =============================== 
 
 ``GIEX_NU_LIN``
    Coefficient of linear dependence of characteristic charge on modifier
-   component
+   component. If more than NCOMP values are provided, :math:`\nu` is given
+   by a piecewise cubic polynomial. This parameter is optional, it defaults
+   to all 0. Data is expected in component-major ordering.
 
 **Unit:** :math:`\text{[Mod]}^{-1}`
 
-===================  =========================  
-**Type:** double     **Length:** NCOMP
-===================  ========================= 
+===================  ===============================  
+**Type:** double     **Length:** same as GIEX_NU
+===================  =============================== 
 
 ``GIEX_NU_QUAD``
    Coefficient of quadratic dependence of characteristic charge on
-   modifier component
+   modifier component. If more than NCOMP values are provided,
+   :math:`\nu` is given by a piecewise cubic polynomial. This parameter
+   is optional, it defaults to all 0. Data is expected in component-major
+   ordering.
 
 **Unit:** :math:`\text{[Mod]}^{-2}`
 
-===================  =========================  
-**Type:** double     **Length:** NCOMP
-===================  ========================= 
+===================  ===============================  
+**Type:** double     **Length:** same as GIEX_NU
+===================  =============================== 
+
+``GIEX_NU_CUBE``
+   Coefficient of cubic dependence of characteristic charge on
+   modifier component. If more than NCOMP values are provided,
+   :math:`\nu` is given by a piecewise cubic polynomial. This
+   parameter is optional, it defaults to all 0. Data is expected
+   in component-major ordering.
+
+**Unit:** :math:`\text{[Mod]}^{-3}`
+
+===================  ===============================  
+**Type:** double     **Length:** same as GIEX_NU
+===================  =============================== 
+
+``GIEX_NU_BREAKS``
+   Optional, only required if a piecewise cubic polynomial is
+   used for :math:`\nu`. Contains the breaks of the pieces
+   in component-major ordering. Note that :math:`n` pieces
+   have :math:`n+1` breaks.
+
+**Unit:** :math:`\text{[Mod]}`
+
+===================  ======================================  
+**Type:** double     **Length:** length of GIEX_NU + NCOMP
+===================  ====================================== 
 
 ``GIEX_SIGMA``
    Steric factors of the protein; The number of sites :math:`\sigma` on

--- a/src/libcadet/Spline.hpp
+++ b/src/libcadet/Spline.hpp
@@ -1,0 +1,175 @@
+// =============================================================================
+//  CADET
+//  
+//  Copyright © 2008-2021: The CADET Authors
+//            Please see the AUTHORS and CONTRIBUTORS file.
+//  
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the GNU Public License v3.0 (or, at
+//  your option, any later version) which accompanies this distribution, and
+//  is available at http://www.gnu.org/licenses/gpl.html
+// =============================================================================
+
+#ifndef LIBCADET_SPLINE_HPP_
+#define LIBCADET_SPLINE_HPP_
+
+#include <algorithm>
+#include <tuple>
+
+#include "cadet/cadetCompilerInfo.hpp"
+#include "AutoDiff.hpp"
+
+namespace cadet 
+{
+
+	/**
+	 * @brief      Evaluates a piecewise cubic polynomial
+	 * @details    If the evaluation point @p x is outside the domain of the piecewise polynomial,
+	 *             constant extrapolation from the first and last value of the polynomial on its
+	 *             domain is applied.
+	 * @param[in]  x           Evaluation position
+	 * @param[in]  breaks      Array with @c nPieces+1 elements (strictly increasing) that defines the domain pieces
+	 * @param[in]  constCoeff  Array with constant coefficients of size @p nPieces
+	 * @param[in]  linCoeff    Array with linear coefficients of size @p nPieces
+	 * @param[in]  quadCoeff   Array with quadratic coefficients of size @p nPieces
+	 * @param[in]  cubeCoeff   Array with cubic coefficients of size @p nPieces
+	 * @param[in]  nPieces     Number of pieces (at least 1)
+	 * @tparam     value_t     Type of the evaluation point
+	 * @tparam     result_t    Type of the result
+	 * @return     Value of the piecewise cubic polynomial at the given point @p x
+	 */
+	template <typename value_t, typename result_t>
+	result_t evaluateCubicPiecewisePolynomial(const value_t& x, active const* breaks, active const* constCoeff,
+		active const* linCoeff, active const* quadCoeff, active const* cubeCoeff, int nPieces) CADET_NOEXCEPT
+	{
+		// Test if outside of domain, apply constant extrapolation
+		if (x < breaks[0])
+		{
+			return constCoeff[0];
+		}
+
+		if (x >= breaks[nPieces])
+		{
+			// Return the value at the right of the domain
+			const result_t y = static_cast<result_t>(breaks[nPieces]) - static_cast<result_t>(breaks[nPieces - 1]);
+			const int idx = nPieces - 1;
+			return static_cast<result_t>(constCoeff[idx]) + y * (
+				static_cast<result_t>(linCoeff[idx]) + y * (
+					static_cast<result_t>(quadCoeff[idx]) + y * static_cast<result_t>(cubeCoeff[idx]) 
+					)
+				);
+		}
+
+		// Find correct piece
+		int idx = 0;
+		for (; idx < nPieces; ++idx)
+		{
+			if (breaks[idx] >= x)
+				break;
+		}
+		
+		// Evaluate polynomial
+		const typename DoubleActivePromoter<value_t, result_t>::type y = x - static_cast<result_t>(breaks[idx]);
+		return static_cast<result_t>(constCoeff[idx]) + y * (
+			static_cast<result_t>(linCoeff[idx]) + y * (
+				static_cast<result_t>(quadCoeff[idx]) + y * static_cast<result_t>(cubeCoeff[idx]) 
+				)
+			);
+	}
+
+	/**
+	 * @brief      Evaluates a piecewise cubic polynomial and returns base and dependent values
+	 * @details    If the evaluation point @p x is outside the domain of the piecewise polynomial,
+	 *             constant extrapolation from the first and last value of the polynomial on its
+	 *             domain is applied.
+	 *             
+	 *             The function returns the constant base value and the variable part depending on @p x.
+	 * @param[in]  x           Evaluation position
+	 * @param[in]  breaks      Array with @c nPieces+1 elements (strictly increasing) that defines the domain pieces
+	 * @param[in]  constCoeff  Array with constant coefficients of size @p nPieces
+	 * @param[in]  linCoeff    Array with linear coefficients of size @p nPieces
+	 * @param[in]  quadCoeff   Array with quadratic coefficients of size @p nPieces
+	 * @param[in]  cubeCoeff   Array with cubic coefficients of size @p nPieces
+	 * @param[in]  nPieces     Number of pieces (at least 1)
+	 * @tparam     value_t     Type of the evaluation point
+	 * @tparam     result_t    Type of the result
+	 * @return     Constant and dynamic value of the piecewise cubic polynomial at the given point @p x
+	 */
+	template <typename value_t, typename result_t>
+	std::tuple<result_t, result_t> evaluateCubicPiecewisePolynomialSplit(const value_t& x, active const* breaks, active const* constCoeff,
+		active const* linCoeff, active const* quadCoeff, active const* cubeCoeff, int nPieces) CADET_NOEXCEPT
+	{
+		// Test if outside of domain, apply constant extrapolation
+		if (x < breaks[0])
+		{
+			return {static_cast<result_t>(constCoeff[0]), result_t(0.0)};
+		}
+
+		if (x >= breaks[nPieces])
+		{
+			// Return the value at the right of the domain
+			const result_t y = static_cast<result_t>(breaks[nPieces]) - static_cast<result_t>(breaks[nPieces - 1]);
+			const int idx = nPieces - 1;
+			return {static_cast<result_t>(constCoeff[idx]) + y * (
+				static_cast<result_t>(linCoeff[idx]) + y * (
+					static_cast<result_t>(quadCoeff[idx]) + y * static_cast<result_t>(cubeCoeff[idx]) 
+					)
+				), result_t(0.0)};
+		}
+
+		// Find correct piece
+		int idx = 0;
+		for (; idx < nPieces; ++idx)
+		{
+			if (breaks[idx] >= x)
+				break;
+		}
+		
+		// Evaluate polynomial
+		const typename DoubleActivePromoter<value_t, result_t>::type y = x - static_cast<result_t>(breaks[idx]);
+		return {static_cast<result_t>(constCoeff[idx]), y * (
+			static_cast<result_t>(linCoeff[idx]) + y * (
+				static_cast<result_t>(quadCoeff[idx]) + y * static_cast<result_t>(cubeCoeff[idx]) 
+				)
+			)};
+	}
+
+	/**
+	 * @brief      Evaluates the derivative of a piecewise cubic polynomial
+	 * @details    If the evaluation point @p x is outside the domain of the piecewise polynomial,
+	 *             constant extrapolation from the first and last value of the polynomial on its
+	 *             domain is applied.
+	 * @param[in]  x           Evaluation position
+	 * @param[in]  breaks      Array with @c nPieces+1 elements (strictly increasing) that defines the domain pieces
+	 * @param[in]  linCoeff    Array with linear coefficients of size @p nPieces
+	 * @param[in]  quadCoeff   Array with quadratic coefficients of size @p nPieces
+	 * @param[in]  cubeCoeff   Array with cubic coefficients of size @p nPieces
+	 * @param[in]  nPieces     Number of pieces (at least 1)
+	 * @return     Derivative of the piecewise cubic polynomial at the given point @p x
+	 */
+	inline double evaluateCubicPiecewisePolynomialDerivative(double x, active const* breaks, active const* linCoeff,
+		active const* quadCoeff, active const* cubeCoeff, int nPieces) CADET_NOEXCEPT
+	{
+		// Test if outside of domain, apply constant extrapolation
+		if (x < breaks[0])
+			return 0.0;
+
+		if (x >= breaks[nPieces])
+			return 0.0;
+
+		// Find correct piece
+		int idx = 0;
+		for (; idx < nPieces; ++idx)
+		{
+			if (breaks[idx] >= x)
+				break;
+		}
+		
+		// Evaluate polynomial
+		const double y = x - static_cast<double>(breaks[idx]);
+		return static_cast<double>(linCoeff[idx]) + y * (2.0 * static_cast<double>(quadCoeff[idx]) + 3.0 * y * static_cast<double>(cubeCoeff[idx]));
+	}
+
+} // namespace cadet
+
+#endif  // LIBCADET_SPLINE_HPP_

--- a/src/libcadet/model/binding/AntiLangmuirBinding.cpp
+++ b/src/libcadet/model/binding/AntiLangmuirBinding.cpp
@@ -52,7 +52,7 @@ namespace model
 
 inline const char* AntiLangmuirParamHandler::identifier() CADET_NOEXCEPT { return "MULTI_COMPONENT_ANTILANGMUIR"; }
 
-inline bool AntiLangmuirParamHandler::validateConfig(unsigned int nComp, unsigned int const* nBoundStates)
+inline bool AntiLangmuirParamHandler::validate(unsigned int nComp, unsigned int const* nBoundStates)
 {
 	if ((_kA.size() != _kD.size()) || (_kA.size() != _qMax.size()) || (_kA.size() != _antiLangmuir.size()) || (_kA.size() < nComp))
 		throw InvalidParameterException("MCAL_KA, MCAL_KD, MCAL_QMAX, and MCAL_ANTILANGMUIR have to have the same size");
@@ -62,7 +62,7 @@ inline bool AntiLangmuirParamHandler::validateConfig(unsigned int nComp, unsigne
 
 inline const char* ExtAntiLangmuirParamHandler::identifier() CADET_NOEXCEPT { return "EXT_MULTI_COMPONENT_ANTILANGMUIR"; }
 
-inline bool ExtAntiLangmuirParamHandler::validateConfig(unsigned int nComp, unsigned int const* nBoundStates)
+inline bool ExtAntiLangmuirParamHandler::validate(unsigned int nComp, unsigned int const* nBoundStates)
 {
 	if ((_kA.size() != _kD.size()) || (_kA.size() != _qMax.size()) || (_kA.size() != _antiLangmuir.size()) || (_kA.size() < nComp))
 		throw InvalidParameterException("MCAL_KA, MCAL_KD, MCAL_QMAX, and MCAL_ANTILANGMUIR have to have the same size");

--- a/src/libcadet/model/binding/BiLangmuirBinding.cpp
+++ b/src/libcadet/model/binding/BiLangmuirBinding.cpp
@@ -51,7 +51,7 @@ namespace model
 
 inline const char* BiLangmuirParamHandler::identifier() CADET_NOEXCEPT { return "MULTI_COMPONENT_BILANGMUIR"; }
 
-inline bool BiLangmuirParamHandler::validateConfig(unsigned int nComp, unsigned int const* nBoundStates)
+inline bool BiLangmuirParamHandler::validate(unsigned int nComp, unsigned int const* nBoundStates)
 {
 	if ((_kA.size() != _kD.size()) || (_kA.size() != _qMax.size()) || (_kA.size() < nComp))
 		throw InvalidParameterException("MCBL_KA, MCBL_KD, and MCBL_QMAX have to have the same size");
@@ -61,7 +61,7 @@ inline bool BiLangmuirParamHandler::validateConfig(unsigned int nComp, unsigned 
 
 inline const char* ExtBiLangmuirParamHandler::identifier() CADET_NOEXCEPT { return "EXT_MULTI_COMPONENT_BILANGMUIR"; }
 
-inline bool ExtBiLangmuirParamHandler::validateConfig(unsigned int nComp, unsigned int const* nBoundStates)
+inline bool ExtBiLangmuirParamHandler::validate(unsigned int nComp, unsigned int const* nBoundStates)
 {
 	if ((_kA.size() != _kD.size()) || (_kA.size() != _qMax.size()) || (_kA.size() < nComp))
 		throw InvalidParameterException("EXT_MCBL_KA, EXT_MCBL_KD, and EXT_MCBL_QMAX have to have the same size");

--- a/src/libcadet/model/binding/BiStericMassActionBinding.cpp
+++ b/src/libcadet/model/binding/BiStericMassActionBinding.cpp
@@ -62,7 +62,7 @@ namespace model
 
 inline const char* BiSMAParamHandler::identifier() CADET_NOEXCEPT { return "BI_STERIC_MASS_ACTION"; }
 
-inline bool BiSMAParamHandler::validateConfig(unsigned int nComp, unsigned int const* nBoundStates)
+inline bool BiSMAParamHandler::validate(unsigned int nComp, unsigned int const* nBoundStates)
 {
 	const unsigned int numStates = firstNonEmptyBoundStates(nBoundStates, nComp);
 
@@ -83,7 +83,7 @@ inline bool BiSMAParamHandler::validateConfig(unsigned int nComp, unsigned int c
 
 inline const char* ExtBiSMAParamHandler::identifier() CADET_NOEXCEPT { return "EXT_BI_STERIC_MASS_ACTION"; }
 
-inline bool ExtBiSMAParamHandler::validateConfig(unsigned int nComp, unsigned int const* nBoundStates)
+inline bool ExtBiSMAParamHandler::validate(unsigned int nComp, unsigned int const* nBoundStates)
 {
 	const unsigned int numStates = firstNonEmptyBoundStates(nBoundStates, nComp);
 

--- a/src/libcadet/model/binding/BindingModelBase.hpp
+++ b/src/libcadet/model/binding/BindingModelBase.hpp
@@ -133,12 +133,12 @@ protected:
 	virtual bool configureImpl(IParameterProvider& paramProvider, UnitOpIdx unitOpIdx, ParticleTypeIdx parTypeIdx)
 	{
 		// Read parameters
-		_paramHandler.configure(paramProvider, _nComp, _nBoundStates);
+		const bool valid = _paramHandler.configureAndValidate(paramProvider, _nComp, _nBoundStates);
 
 		// Register parameters
 		_paramHandler.registerParameters(_parameters, unitOpIdx, parTypeIdx, _nComp, _nBoundStates);
 
-		return true;
+		return valid;
 	}
 };
 

--- a/src/libcadet/model/binding/ColloidalBinding.cpp
+++ b/src/libcadet/model/binding/ColloidalBinding.cpp
@@ -71,7 +71,7 @@ namespace model
 
 inline const char* ColloidalParamHandler::identifier() CADET_NOEXCEPT { return "MULTI_COMPONENT_COLLOIDAL"; }
 
-inline bool ColloidalParamHandler::validateConfig(unsigned int nComp, unsigned int const* nBoundStates)
+inline bool ColloidalParamHandler::validate(unsigned int nComp, unsigned int const* nBoundStates)
 {
 	if ((_kEqPhExp.size() != _kEqSaltPowerExp.size()) 
 			|| (_kEqPhExp.size() != _kEqSaltPowerFact.size())
@@ -97,7 +97,7 @@ inline bool ColloidalParamHandler::validateConfig(unsigned int nComp, unsigned i
 
 inline const char* ExtColloidalParamHandler::identifier() CADET_NOEXCEPT { return "EXT_MULTI_COMPONENT_COLLOIDAL"; }
 
-inline bool ExtColloidalParamHandler::validateConfig(unsigned int nComp, unsigned int const* nBoundStates)
+inline bool ExtColloidalParamHandler::validate(unsigned int nComp, unsigned int const* nBoundStates)
 {
 	if ((_kEqPhExp.size() != _kEqSaltPowerExp.size()) 
 			|| (_kEqPhExp.size() != _kEqSaltPowerFact.size())

--- a/src/libcadet/model/binding/ExtendedMobilePhaseModulatorLangmuirBinding.cpp
+++ b/src/libcadet/model/binding/ExtendedMobilePhaseModulatorLangmuirBinding.cpp
@@ -55,7 +55,7 @@ namespace model
 
 inline const char* EMPMLangmuirParamHandler::identifier() CADET_NOEXCEPT { return "EXTENDED_MOBILE_PHASE_MODULATOR"; }
 
-inline bool EMPMLangmuirParamHandler::validateConfig(unsigned int nComp, unsigned int const* nBoundStates)
+inline bool EMPMLangmuirParamHandler::validate(unsigned int nComp, unsigned int const* nBoundStates)
 {
 	if ((_kA.size() != _kD.size()) || (_kA.size() != _qMax.size()) || (_kA.size() != _gamma.size())
 		|| (_kA.size() != _beta.size()) || (_kA.size() < nComp))
@@ -66,7 +66,7 @@ inline bool EMPMLangmuirParamHandler::validateConfig(unsigned int nComp, unsigne
 
 inline const char* ExtEMPMLangmuirParamHandler::identifier() CADET_NOEXCEPT { return "EXT_EXTENDED_MOBILE_PHASE_MODULATOR"; }
 
-inline bool ExtEMPMLangmuirParamHandler::validateConfig(unsigned int nComp, unsigned int const* nBoundStates)
+inline bool ExtEMPMLangmuirParamHandler::validate(unsigned int nComp, unsigned int const* nBoundStates)
 {
 	if ((_kA.size() != _kD.size()) || (_kA.size() != _qMax.size()) || (_kA.size() != _gamma.size())
 		|| (_kA.size() != _beta.size()) || (_kA.size() < nComp))

--- a/src/libcadet/model/binding/ExternalFunctionTemplate.cpp
+++ b/src/libcadet/model/binding/ExternalFunctionTemplate.cpp
@@ -83,7 +83,7 @@ public:
 {% endif %}
 	{ }
 
-	inline bool configure(IParameterProvider& paramProvider, unsigned int nComp, unsigned int const* nBoundStates)
+	inline void configure(IParameterProvider& paramProvider, unsigned int nComp, unsigned int const* nBoundStates)
 	{
 {% for p in parameters %}
 	{% if not existsIn(p, "skipConfig") %}
@@ -109,7 +109,12 @@ public:
 		{% endif %}
 	{% endfor %}
 {% endif %}
-		return validateConfig(nComp, nBoundStates);
+	}
+
+	inline bool configureAndValidate(IParameterProvider& paramProvider, unsigned int nComp, unsigned int const* nBoundStates)
+	{
+		configure(paramProvider, nComp, nBoundStates);
+		return validate(nComp, nBoundStates);
 	}
 
 	inline void registerParameters(std::unordered_map<ParameterId, active*>& parameters, UnitOpIdx unitOpIdx, ParticleTypeIdx parTypeIdx, unsigned int nComp, unsigned int const* nBoundStates)
@@ -171,9 +176,9 @@ public:
 {% endif %}
 
 	inline char const* prefixInConfiguration() const CADET_NOEXCEPT { return ""; }
+	inline bool validate(unsigned int nComp, unsigned int const* nBoundStates);
 
 protected:
-	inline bool validateConfig(unsigned int nComp, unsigned int const* nBoundStates);
 	
 	ConstParams _localParams;
 
@@ -262,7 +267,7 @@ public:
 {% endif %}
 	{ }
 
-	inline bool configure(IParameterProvider& paramProvider, unsigned int nComp, unsigned int const* nBoundStates)
+	inline void configure(IParameterProvider& paramProvider, unsigned int nComp, unsigned int const* nBoundStates)
 	{
 {% for p in parameters %}
 	{% if not existsIn(p, "skipConfig") %}
@@ -289,7 +294,12 @@ public:
 	{% endfor %}
 {% endif %}
 		ExternalParamHandlerBase::configure(paramProvider, {{ length(parameters) }});
-		return validateConfig(nComp, nBoundStates);
+	}
+
+	inline bool configureAndValidate(IParameterProvider& paramProvider, unsigned int nComp, unsigned int const* nBoundStates)
+	{
+		configure(paramProvider, nComp, nBoundStates);
+		return validate(nComp, nBoundStates);
 	}
 
 	inline void registerParameters(std::unordered_map<ParameterId, active*>& parameters, UnitOpIdx unitOpIdx, ParticleTypeIdx parTypeIdx, unsigned int nComp, unsigned int const* nBoundStates)
@@ -409,9 +419,9 @@ public:
 {% endif %}
 
 	inline char const* prefixInConfiguration() const CADET_NOEXCEPT { return "EXT_"; }
+	inline bool validate(unsigned int nComp, unsigned int const* nBoundStates);
 
 protected:
-	inline bool validateConfig(unsigned int nComp, unsigned int const* nBoundStates);
 	
 	ConstParams _constParams;
 

--- a/src/libcadet/model/binding/GeneralizedIonExchangeBinding.cpp
+++ b/src/libcadet/model/binding/GeneralizedIonExchangeBinding.cpp
@@ -110,7 +110,6 @@ namespace
 		{
 			const int offset = comp * nPieces;
 			const auto [nuConst, nuVar] = cadet::evaluateCubicPiecewisePolynomialSplit<ph_t, typename cadet::DoubleActivePromoter<param_t, cp_state_t>::type>(pH, p.nuBreaks.data() + comp * (nPieces + 1), p.nu.data() + offset, p.nuLin.data() + offset, p.nuQuad.data() + offset, p.nuCube.data() + offset, nPieces);
-			LOG(Debug) << "cpQNuPowers " << comp << ": at " << static_cast<double>(pH) << ":" << static_cast<double>(nuConst) << " + " << static_cast<double>(nuVar) << " = " << static_cast<double>(nuConst) + static_cast<double>(nuVar);
 			const cp_state_t nu_i_0_over_nu0 = static_cast<param_t>(nuConst) / static_cast<param_t>(p.nu[0]);
 			const cp_state_t nu_i_pH_over_nu0 = nuVar / static_cast<param_t>(p.nu[0]);
 			return {pow(cpBase, nu_i_0_over_nu0) * pow(cpVar, nu_i_pH_over_nu0), pow(qBase, nu_i_0_over_nu0) * pow(qVar, nu_i_pH_over_nu0)};
@@ -127,10 +126,7 @@ namespace
 		else
 		{
 			const int offset = comp * nPieces;
-//			return cadet::evaluateCubicPiecewisePolynomialSplit<ph_t, result_t>(pH, p.nuBreaks.data() + comp * (nPieces + 1), p.nu.data() + offset, p.nuLin.data() + offset, p.nuQuad.data() + offset, p.nuCube.data() + offset, nPieces);
-			const auto [nuConst, nuVar] = cadet::evaluateCubicPiecewisePolynomialSplit<ph_t, result_t>(pH, p.nuBreaks.data() + comp * (nPieces + 1), p.nu.data() + offset, p.nuLin.data() + offset, p.nuQuad.data() + offset, p.nuCube.data() + offset, nPieces);
-			LOG(Debug) << "evalNu " << comp << ": at " << static_cast<double>(pH) << ": " << static_cast<double>(nuConst) << " + " << static_cast<double>(nuVar) << " = " << static_cast<double>(nuConst) + static_cast<double>(nuVar);
-			return std::make_tuple(nuConst, nuVar);
+			return cadet::evaluateCubicPiecewisePolynomialSplit<ph_t, result_t>(pH, p.nuBreaks.data() + comp * (nPieces + 1), p.nu.data() + offset, p.nuLin.data() + offset, p.nuQuad.data() + offset, p.nuCube.data() + offset, nPieces);
 		}
 	}
 

--- a/src/libcadet/model/binding/GeneralizedIonExchangeBinding.cpp
+++ b/src/libcadet/model/binding/GeneralizedIonExchangeBinding.cpp
@@ -153,7 +153,7 @@ namespace model
 
 inline const char* GIEXParamHandler::identifier() CADET_NOEXCEPT { return "GENERALIZED_ION_EXCHANGE"; }
 
-inline bool GIEXParamHandler::validateConfig(unsigned int nComp, unsigned int const* nBoundStates)
+inline bool GIEXParamHandler::validate(unsigned int nComp, unsigned int const* nBoundStates)
 {
 	if (nComp <= 2)
 		throw InvalidParameterException("GENERALIZED_ION_EXCHANGE requires at least 3 components");
@@ -198,7 +198,7 @@ inline bool GIEXParamHandler::validateConfig(unsigned int nComp, unsigned int co
 
 inline const char* ExtGIEXParamHandler::identifier() CADET_NOEXCEPT { return "EXT_GENERALIZED_ION_EXCHANGE"; }
 
-inline bool ExtGIEXParamHandler::validateConfig(unsigned int nComp, unsigned int const* nBoundStates)
+inline bool ExtGIEXParamHandler::validate(unsigned int nComp, unsigned int const* nBoundStates)
 {
 	if (nComp <= 2)
 		throw InvalidParameterException("EXT_GENERALIZED_ION_EXCHANGE requires at least 3 components");
@@ -349,10 +349,12 @@ protected:
 	using ParamHandlerBindingModelBase<ParamHandler_t>::_reactionQuasistationarity;
 	using ParamHandlerBindingModelBase<ParamHandler_t>::_nComp;
 	using ParamHandlerBindingModelBase<ParamHandler_t>::_nBoundStates;
+	using ParamHandlerBindingModelBase<ParamHandler_t>::_parameters;
 
 	virtual bool configureImpl(IParameterProvider& paramProvider, UnitOpIdx unitOpIdx, ParticleTypeIdx parTypeIdx)
 	{
-		const bool valid = ParamHandlerBindingModelBase<ParamHandler_t>::configureImpl(paramProvider, unitOpIdx, parTypeIdx);
+		// Read parameters
+		_paramHandler.configure(paramProvider, _nComp, _nBoundStates);
 
 		if (paramProvider.exists(std::string(_paramHandler.prefixInConfiguration()) + "GIEX_NU_LIN"))
 			_paramHandler.nuLin().configure("GIEX_PH", paramProvider, _nComp, _nBoundStates);
@@ -386,7 +388,10 @@ protected:
 			_paramHandler.refConcentrationPh().getQ() = _paramHandler.refConcentration().getQ();
 		}
 
-		return valid;
+		// Register parameters
+		_paramHandler.registerParameters(_parameters, unitOpIdx, parTypeIdx, _nComp, _nBoundStates);
+
+		return _paramHandler.validate(_nComp, _nBoundStates);
 	}
 
 	template <typename StateType, typename CpStateType, typename ResidualType, typename ParamType>

--- a/src/libcadet/model/binding/GeneralizedIonExchangeBinding.cpp
+++ b/src/libcadet/model/binding/GeneralizedIonExchangeBinding.cpp
@@ -194,14 +194,17 @@ inline bool GIEXParamHandler::validate(unsigned int nComp, unsigned int const* n
 	}
 
 	// Check breaks
-	for (int i = 0; i < nComp; ++i)
+	if (_nuBreaks.size() > 1)
 	{
-		cadet::active const* const b = _nuBreaks.get().data() + nPieces * i;
-		for (int j = 0; j < nPieces; ++j)
+		for (int i = 0; i < nComp; ++i)
 		{
-			if (b[j] >= b[j+1])
+			cadet::active const* const b = _nuBreaks.get().data() + (nPieces + 1) * i;
+			for (int j = 0; j < nPieces; ++j)
 			{
-				throw InvalidParameterException("GIEX_NU_BREAKS must be strictly increasing for each component");
+				if (b[j] >= b[j+1])
+				{
+					throw InvalidParameterException("GIEX_NU_BREAKS must be strictly increasing for each component");
+				}
 			}
 		}
 	}

--- a/src/libcadet/model/binding/KumarLangmuirBinding.cpp
+++ b/src/libcadet/model/binding/KumarLangmuirBinding.cpp
@@ -58,7 +58,7 @@ namespace model
 
 inline const char* KumarLangmuirParamHandler::identifier() CADET_NOEXCEPT { return "KUMAR_MULTI_COMPONENT_LANGMUIR"; }
 
-inline bool KumarLangmuirParamHandler::validateConfig(unsigned int nComp, unsigned int const* nBoundStates)
+inline bool KumarLangmuirParamHandler::validate(unsigned int nComp, unsigned int const* nBoundStates)
 {
 	if ((_kA.size() != _kAct.size()) || (_kA.size() != _kD.size()) || (_kA.size() != _qMax.size()) || (_kA.size() != _nu.size()) || (_kA.size() < nComp))
 		throw InvalidParameterException("KMCL_KA, KMCL_KD, KMCL_KACT, KMCL_NU, and KMCL_QMAX have to have the same size");
@@ -68,7 +68,7 @@ inline bool KumarLangmuirParamHandler::validateConfig(unsigned int nComp, unsign
 
 inline const char* ExtKumarLangmuirParamHandler::identifier() CADET_NOEXCEPT { return "EXT_KUMAR_MULTI_COMPONENT_LANGMUIR"; }
 
-inline bool ExtKumarLangmuirParamHandler::validateConfig(unsigned int nComp, unsigned int const* nBoundStates)
+inline bool ExtKumarLangmuirParamHandler::validate(unsigned int nComp, unsigned int const* nBoundStates)
 {
 	if ((_kA.size() != _kAct.size()) || (_kA.size() != _kD.size()) || (_kA.size() != _qMax.size()) || (_kA.size() != _nu.size()) || (_kA.size() < nComp))
 		throw InvalidParameterException("KMCL_KA, KMCL_KD, KMCL_KACT, KMCL_NU, and KMCL_QMAX have to have the same size");

--- a/src/libcadet/model/binding/LangmuirBinding.cpp
+++ b/src/libcadet/model/binding/LangmuirBinding.cpp
@@ -51,7 +51,7 @@ namespace model
 
 inline const char* LangmuirParamHandler::identifier() CADET_NOEXCEPT { return "MULTI_COMPONENT_LANGMUIR"; }
 
-inline bool LangmuirParamHandler::validateConfig(unsigned int nComp, unsigned int const* nBoundStates)
+inline bool LangmuirParamHandler::validate(unsigned int nComp, unsigned int const* nBoundStates)
 {
 	if ((_kA.size() != _kD.size()) || (_kA.size() != _qMax.size()) || (_kA.size() < nComp))
 		throw InvalidParameterException("MCL_KA, MCL_KD, and MCL_QMAX have to have the same size");
@@ -61,7 +61,7 @@ inline bool LangmuirParamHandler::validateConfig(unsigned int nComp, unsigned in
 
 inline const char* ExtLangmuirParamHandler::identifier() CADET_NOEXCEPT { return "EXT_MULTI_COMPONENT_LANGMUIR"; }
 
-inline bool ExtLangmuirParamHandler::validateConfig(unsigned int nComp, unsigned int const* nBoundStates)
+inline bool ExtLangmuirParamHandler::validate(unsigned int nComp, unsigned int const* nBoundStates)
 {
 	if ((_kA.size() != _kD.size()) || (_kA.size() != _qMax.size()) || (_kA.size() < nComp))
 		throw InvalidParameterException("EXT_MCL_KA, EXT_MCL_KD, and EXT_MCL_QMAX have to have the same size");

--- a/src/libcadet/model/binding/LinearBinding.cpp
+++ b/src/libcadet/model/binding/LinearBinding.cpp
@@ -99,11 +99,11 @@ public:
 	 * @param [in] nBoundStates Array with number of bound states for each component
 	 * @return @c true if the parameters were read and validated successfully, otherwise @c false
 	 */
-	inline bool configure(IParameterProvider& paramProvider, unsigned int nComp, unsigned int const* nBoundStates)
+	inline bool configureAndValidate(IParameterProvider& paramProvider, unsigned int nComp, unsigned int const* nBoundStates)
 	{
 		_kA.configure("LIN_KA", paramProvider, nComp, nBoundStates);
 		_kD.configure("LIN_KD", paramProvider, nComp, nBoundStates);
-		return validateConfig(nComp, nBoundStates);
+		return validate(nComp, nBoundStates);
 	}
 
 	/**
@@ -164,21 +164,21 @@ public:
 		return std::make_tuple<ParamsHandle, ParamsHandle>(&_localParams, nullptr);
 	}
 
-protected:
-
 	/**
 	 * @brief Validates recently read parameters
 	 * @param [in] nComp Number of components
 	 * @param [in] nBoundStates Array with number of bound states for each component
 	 * @return @c true if the parameters were validated successfully, otherwise @c false
 	 */
-	inline bool validateConfig(unsigned int nComp, unsigned int const* nBoundStates)
+	inline bool validate(unsigned int nComp, unsigned int const* nBoundStates)
 	{
 		if ((_kA.size() != _kD.size()) || (_kA.size() < nComp))
 			throw InvalidParameterException("LIN_KA and LIN_KD have to have the same size");
 
 		return true;
 	}
+
+protected:
 
 	ConstParams _localParams; //!< Actual parameter data
 
@@ -228,14 +228,14 @@ public:
 	 * @param [in] nBoundStates Array with number of bound states for each component
 	 * @return @c true if the parameters were read and validated successfully, otherwise @c false
 	 */
-	inline bool configure(IParameterProvider& paramProvider, unsigned int nComp, unsigned int const* nBoundStates)
+	inline bool configureAndValidate(IParameterProvider& paramProvider, unsigned int nComp, unsigned int const* nBoundStates)
 	{
 		_kA.configure("LIN_KA", paramProvider, nComp, nBoundStates);
 		_kD.configure("LIN_KD", paramProvider, nComp, nBoundStates);
 		
 		// Number of externally dependent parameters (2) needs to be given to ExternalParamHandlerBase::configure()
 		ExternalParamHandlerBase::configure(paramProvider, 2);
-		return validateConfig(nComp, nBoundStates);
+		return validate(nComp, nBoundStates);
 	}
 
 	/**
@@ -358,21 +358,21 @@ public:
 			+ 2 * (_kA.additionalDynamicMemory(nComp, totalNumBoundStates, nBoundStates) + _kD.additionalDynamicMemory(nComp, totalNumBoundStates, nBoundStates));
 	}
 
-protected:
-
 	/**
 	 * @brief Validates recently read parameters
 	 * @param [in] nComp Number of components
 	 * @param [in] nBoundStates Array with number of bound states for each component
 	 * @return @c true if the parameters were validated successfully, otherwise @c false
 	 */
-	inline bool validateConfig(unsigned int nComp, unsigned int const* nBoundStates)
+	inline bool validate(unsigned int nComp, unsigned int const* nBoundStates)
 	{
 		if ((_kA.size() != _kD.size()) || (_kA.size() < nComp))
 			throw InvalidParameterException("LIN_KA and LIN_KD have to have the same size");
 
 		return true;
 	}
+
+protected:
 
 	// Handlers provide configure(), reserve(), and registerParam() for parameters
 	ExternalScalarComponentDependentParameter _kA; //!< Handler for adsorption rate
@@ -446,12 +446,12 @@ public:
 		_parameters.clear();
 
 		// Read parameters (k_a and k_d)
-		_paramHandler.configure(paramProvider, _nComp, _nBoundStates);
+		const bool valid = _paramHandler.configureAndValidate(paramProvider, _nComp, _nBoundStates);
 
 		// Register parameters
 		_paramHandler.registerParameters(_parameters, unitOpIdx, parTypeIdx, _nComp, _nBoundStates);
 
-		return true;
+		return valid;
 	}
 
 	virtual void fillBoundPhaseInitialParameters(ParameterId* params, UnitOpIdx unitOpIdx, ParticleTypeIdx parTypeIdx) const CADET_NOEXCEPT

--- a/src/libcadet/model/binding/MobilePhaseModulatorLangmuirBinding.cpp
+++ b/src/libcadet/model/binding/MobilePhaseModulatorLangmuirBinding.cpp
@@ -55,7 +55,7 @@ namespace model
 
 inline const char* MPMLangmuirParamHandler::identifier() CADET_NOEXCEPT { return "MOBILE_PHASE_MODULATOR"; }
 
-inline bool MPMLangmuirParamHandler::validateConfig(unsigned int nComp, unsigned int const* nBoundStates)
+inline bool MPMLangmuirParamHandler::validate(unsigned int nComp, unsigned int const* nBoundStates)
 {
 	if ((_kA.size() != _kD.size()) || (_kA.size() != _qMax.size()) || (_kA.size() != _gamma.size())
 		|| (_kA.size() != _beta.size()) || (_kA.size() < nComp))
@@ -66,7 +66,7 @@ inline bool MPMLangmuirParamHandler::validateConfig(unsigned int nComp, unsigned
 
 inline const char* ExtMPMLangmuirParamHandler::identifier() CADET_NOEXCEPT { return "EXT_MOBILE_PHASE_MODULATOR"; }
 
-inline bool ExtMPMLangmuirParamHandler::validateConfig(unsigned int nComp, unsigned int const* nBoundStates)
+inline bool ExtMPMLangmuirParamHandler::validate(unsigned int nComp, unsigned int const* nBoundStates)
 {
 	if ((_kA.size() != _kD.size()) || (_kA.size() != _qMax.size()) || (_kA.size() != _gamma.size())
 		|| (_kA.size() != _beta.size()) || (_kA.size() < nComp))

--- a/src/libcadet/model/binding/MultiComponentSpreadingBinding.cpp
+++ b/src/libcadet/model/binding/MultiComponentSpreadingBinding.cpp
@@ -55,7 +55,7 @@ namespace model
 
 inline const char* SpreadingParamHandler::identifier() CADET_NOEXCEPT { return "MULTI_COMPONENT_SPREADING"; }
 
-inline bool SpreadingParamHandler::validateConfig(unsigned int nComp, unsigned int const* nBoundStates)
+inline bool SpreadingParamHandler::validate(unsigned int nComp, unsigned int const* nBoundStates)
 {
 	if ((_kA.size() != _kD.size()) || (_kA.size() != _qMax.size()) || (_kA.size() < nComp * 2))
 		throw InvalidParameterException("MCSPR_KA, MCSPR_KD, and MCSPR_QMAX have to have the same size");
@@ -67,7 +67,7 @@ inline bool SpreadingParamHandler::validateConfig(unsigned int nComp, unsigned i
 
 inline const char* ExtSpreadingParamHandler::identifier() CADET_NOEXCEPT { return "EXT_MULTI_COMPONENT_SPREADING"; }
 
-inline bool ExtSpreadingParamHandler::validateConfig(unsigned int nComp, unsigned int const* nBoundStates)
+inline bool ExtSpreadingParamHandler::validate(unsigned int nComp, unsigned int const* nBoundStates)
 {
 	if ((_kA.size() != _kD.size()) || (_kA.size() != _qMax.size()) || (_kA.size() < nComp * 2))
 		throw InvalidParameterException("EXT_MCSPR_KA, EXT_MCSPR_KD, and EXT_MCSPR_QMAX have to have the same size");

--- a/src/libcadet/model/binding/MultiStateStericMassActionBinding.cpp
+++ b/src/libcadet/model/binding/MultiStateStericMassActionBinding.cpp
@@ -64,7 +64,7 @@ namespace model
 
 inline const char* MSSMAParamHandler::identifier() CADET_NOEXCEPT { return "MULTISTATE_STERIC_MASS_ACTION"; }
 
-inline bool MSSMAParamHandler::validateConfig(unsigned int nComp, unsigned int const* nBoundStates)
+inline bool MSSMAParamHandler::validate(unsigned int nComp, unsigned int const* nBoundStates)
 {
 	const unsigned int totalBoundStates = numBoundStates(nBoundStates, nComp);
 
@@ -91,7 +91,7 @@ inline bool MSSMAParamHandler::validateConfig(unsigned int nComp, unsigned int c
 
 inline const char* ExtMSSMAParamHandler::identifier() CADET_NOEXCEPT { return "EXT_MULTISTATE_STERIC_MASS_ACTION"; }
 
-inline bool ExtMSSMAParamHandler::validateConfig(unsigned int nComp, unsigned int const* nBoundStates)
+inline bool ExtMSSMAParamHandler::validate(unsigned int nComp, unsigned int const* nBoundStates)
 {
 	const unsigned int totalBoundStates = numBoundStates(nBoundStates, nComp);
 

--- a/src/libcadet/model/binding/SaskaBinding.cpp
+++ b/src/libcadet/model/binding/SaskaBinding.cpp
@@ -50,7 +50,7 @@ namespace model
 
 inline const char* SaskaParamHandler::identifier() CADET_NOEXCEPT { return "SASKA"; }
 
-inline bool SaskaParamHandler::validateConfig(unsigned int nComp, unsigned int const* nBoundStates)
+inline bool SaskaParamHandler::validate(unsigned int nComp, unsigned int const* nBoundStates)
 {
 	if ((_h.size() != _k.slices()) || (_k.size() != nComp * nComp) || (_h.size() < nComp))
 		throw InvalidParameterException("SASKA_K has to have NCOMP^2 and SASKA_H NCOMP many elements");
@@ -60,7 +60,7 @@ inline bool SaskaParamHandler::validateConfig(unsigned int nComp, unsigned int c
 
 inline const char* ExtSaskaParamHandler::identifier() CADET_NOEXCEPT { return "EXT_SASKA"; }
 
-inline bool ExtSaskaParamHandler::validateConfig(unsigned int nComp, unsigned int const* nBoundStates)
+inline bool ExtSaskaParamHandler::validate(unsigned int nComp, unsigned int const* nBoundStates)
 {
 	if ((_h.size() != _k.slices()) || (_k.size() != nComp * nComp) || (_h.size() < nComp))
 		throw InvalidParameterException("EXT_SASKA_K has to have NCOMP^2 and EXT_SASKA_H NCOMP many elements");

--- a/src/libcadet/model/binding/SelfAssociationBinding.cpp
+++ b/src/libcadet/model/binding/SelfAssociationBinding.cpp
@@ -64,7 +64,7 @@ namespace model
 
 inline const char* SelfAssociationParamHandler::identifier() CADET_NOEXCEPT { return "SELF_ASSOCIATION"; }
 
-inline bool SelfAssociationParamHandler::validateConfig(unsigned int nComp, unsigned int const* nBoundStates)
+inline bool SelfAssociationParamHandler::validate(unsigned int nComp, unsigned int const* nBoundStates)
 {
 	if ((_kA.size() != _kA2.size()) || (_kA.size() != _kD.size()) || (_kA.size() != _nu.size()) 
 		|| (_kA.size() != _sigma.size()) || (_kA.size() < nComp))
@@ -79,7 +79,7 @@ inline bool SelfAssociationParamHandler::validateConfig(unsigned int nComp, unsi
 
 inline const char* ExtSelfAssociationParamHandler::identifier() CADET_NOEXCEPT { return "EXT_SELF_ASSOCIATION"; }
 
-inline bool ExtSelfAssociationParamHandler::validateConfig(unsigned int nComp, unsigned int const* nBoundStates)
+inline bool ExtSelfAssociationParamHandler::validate(unsigned int nComp, unsigned int const* nBoundStates)
 {
 	if ((_kA.size() != _kA2.size()) || (_kA.size() != _kD.size()) || (_kA.size() != _nu.size()) 
 		|| (_kA.size() != _sigma.size()) || (_kA.size() < nComp))

--- a/src/libcadet/model/binding/StericMassActionBinding.cpp
+++ b/src/libcadet/model/binding/StericMassActionBinding.cpp
@@ -62,7 +62,7 @@ namespace model
 
 inline const char* SMAParamHandler::identifier() CADET_NOEXCEPT { return "STERIC_MASS_ACTION"; }
 
-inline bool SMAParamHandler::validateConfig(unsigned int nComp, unsigned int const* nBoundStates)
+inline bool SMAParamHandler::validate(unsigned int nComp, unsigned int const* nBoundStates)
 {
 	if ((_kA.size() != _kD.size()) || (_kA.size() != _nu.size()) || (_kA.size() != _sigma.size()) || (_kA.size() < nComp))
 		throw InvalidParameterException("SMA_KA, SMA_KD, SMA_NU, and SMA_SIGMA have to have the same size");
@@ -76,7 +76,7 @@ inline bool SMAParamHandler::validateConfig(unsigned int nComp, unsigned int con
 
 inline const char* ExtSMAParamHandler::identifier() CADET_NOEXCEPT { return "EXT_STERIC_MASS_ACTION"; }
 
-inline bool ExtSMAParamHandler::validateConfig(unsigned int nComp, unsigned int const* nBoundStates)
+inline bool ExtSMAParamHandler::validate(unsigned int nComp, unsigned int const* nBoundStates)
 {
 	if ((_kA.size() != _kD.size()) || (_kA.size() != _nu.size()) || (_kA.size() != _sigma.size()) || (_kA.size() < nComp))
 		throw InvalidParameterException("EXT_SMA_KA, EXT_SMA_KD, EXT_SMA_NU, and EXT_SMA_SIGMA have to have the same size");

--- a/src/libcadet/model/reaction/ExternalFunctionTemplate.cpp
+++ b/src/libcadet/model/reaction/ExternalFunctionTemplate.cpp
@@ -83,7 +83,7 @@ public:
 {% endif %}
 	{ }
 
-	inline bool configure(IParameterProvider& paramProvider, unsigned int nReactions, unsigned int nComp, unsigned int const* nBoundStates)
+	inline void configure(IParameterProvider& paramProvider, unsigned int nReactions, unsigned int nComp, unsigned int const* nBoundStates)
 	{
 {% for p in parameters %}
 	{% if not existsIn(p, "skipConfig") %}
@@ -109,7 +109,12 @@ public:
 		{% endif %}
 	{% endfor %}
 {% endif %}
-		return validateConfig(nReactions, nComp, nBoundStates);
+	}
+
+	inline bool configureAndValidate(IParameterProvider& paramProvider, unsigned int nReactions, unsigned int nComp, unsigned int const* nBoundStates)
+	{
+		configure(paramProvider, nReactions, nComp, nBoundStates);
+		return validate(nReactions, nComp, nBoundStates);
 	}
 
 	inline void registerParameters(std::unordered_map<ParameterId, active*>& parameters, UnitOpIdx unitOpIdx, ParticleTypeIdx parTypeIdx, unsigned int nComp, unsigned int const* nBoundStates)
@@ -171,9 +176,9 @@ public:
 {% endif %}
 
 	inline char const* prefixInConfiguration() const CADET_NOEXCEPT { return ""; }
+	inline bool validate(unsigned int nReactions, unsigned int nComp, unsigned int const* nBoundStates);
 
 protected:
-	inline bool validateConfig(unsigned int nReactions, unsigned int nComp, unsigned int const* nBoundStates);
 
 	ConstParams _localParams;
 
@@ -262,7 +267,7 @@ public:
 {% endif %}
 	{ }
 
-	inline bool configure(IParameterProvider& paramProvider, unsigned int nReactions, unsigned int nComp, unsigned int const* nBoundStates)
+	inline void configure(IParameterProvider& paramProvider, unsigned int nReactions, unsigned int nComp, unsigned int const* nBoundStates)
 	{
 {% for p in parameters %}
 	{% if not existsIn(p, "skipConfig") %}
@@ -289,7 +294,12 @@ public:
 	{% endfor %}
 {% endif %}
 		ExternalParamHandlerBase::configure(paramProvider, {{ length(parameters) }});
-		return validateConfig(nReactions, nComp, nBoundStates);
+	}
+
+	inline bool configureAndValidate(IParameterProvider& paramProvider, unsigned int nReactions, unsigned int nComp, unsigned int const* nBoundStates)
+	{
+		configure(paramProvider, nReactions, nComp, nBoundStates);
+		return validate(nReactions, nComp, nBoundStates);
 	}
 
 	inline void registerParameters(std::unordered_map<ParameterId, active*>& parameters, UnitOpIdx unitOpIdx, ParticleTypeIdx parTypeIdx, unsigned int nComp, unsigned int const* nBoundStates)
@@ -409,9 +419,9 @@ public:
 {% endif %}
 
 	inline char const* prefixInConfiguration() const CADET_NOEXCEPT { return "EXT_"; }
+	inline bool validate(unsigned int nReactions, unsigned int nComp, unsigned int const* nBoundStates);
 
 protected:
-	inline bool validateConfig(unsigned int nReactions, unsigned int nComp, unsigned int const* nBoundStates);
 
 	ConstParams _constParams;
 

--- a/src/libcadet/model/reaction/MassActionLawReaction.cpp
+++ b/src/libcadet/model/reaction/MassActionLawReaction.cpp
@@ -60,14 +60,14 @@ namespace model
 
 inline const char* MassActionLawParamHandler::identifier() CADET_NOEXCEPT { return "MASS_ACTION_LAW"; }
 
-inline bool MassActionLawParamHandler::validateConfig(unsigned int nReactions, unsigned int nComp, unsigned int const* nBoundStates)
+inline bool MassActionLawParamHandler::validate(unsigned int nReactions, unsigned int nComp, unsigned int const* nBoundStates)
 {
 	return true;
 }
 
 inline const char* ExtMassActionLawParamHandler::identifier() CADET_NOEXCEPT { return "EXT_MASS_ACTION_LAW"; }
 
-inline bool ExtMassActionLawParamHandler::validateConfig(unsigned int nReactions, unsigned int nComp, unsigned int const* nBoundStates)
+inline bool ExtMassActionLawParamHandler::validate(unsigned int nReactions, unsigned int nComp, unsigned int const* nBoundStates)
 {
 	return true;
 }
@@ -546,7 +546,7 @@ protected:
 		readAndRegisterExponents(paramProvider, _parameters, unitOpIdx, parTypeIdx, "MAL_EXPONENTS_SOLID_FWD_MODLIQUID", _expSolidFwdLiquid, _nComp, nullptr);
 		readAndRegisterExponents(paramProvider, _parameters, unitOpIdx, parTypeIdx, "MAL_EXPONENTS_SOLID_BWD_MODLIQUID", _expSolidBwdLiquid, _nComp, nullptr);
 
-		return true;
+		return _paramHandler.validate(maxNumReactions(), _nComp, _nBoundStates);
 	}
 
 	template <typename StateType, typename ResidualType, typename ParamType, typename FactorType>


### PR DESCRIPTION
The characteristic charge nu is extended to a piecewise cubic polynomial in the GIEX adsorption model. The nu of each component can have different polynomial coefficients and breaks, but their amount must be the same over all components.

If the breaks are not provided, a single global polynomial is applied. This maintains backwards compatibility.

The code compiles but is untested. Only the file format docs have been added.