### PR TITLE
Improve parameter checks for flowrate_filter

### DIFF
--- a/include/common/Driver.hpp
+++ b/include/common/Driver.hpp
@@ -253,23 +253,23 @@ public:
 
 		// Configure main solver parameters
 		pp.pushScope("solver");
-		_sim->configure(pp);
-		
+
 		// Configure section times
 		std::vector<double> secTimes;
 		std::vector<bool> secCont;
 		extractSectionTimes(pp, secTimes, secCont);
+		_sim->setSectionTimes(secTimes, secCont);
+		_sim->configure(pp);
 
 		pp.popScope(); // solver scope
 
+		// Create and configure model
 		pp.pushScope("model");
 
-		// Create and configure model
 		cadet::IModelSystem* model = _builder->createSystem(pp);
 
 		// Hand model over to simulator
 		_sim->initializeModel(*model);
-		_sim->setSectionTimes(secTimes, secCont);
 
 		// Specify initial values
 		if (pp.exists("INIT_STATE_Y"))

--- a/src/libcadet/SimulatorImpl.cpp
+++ b/src/libcadet/SimulatorImpl.cpp
@@ -1490,6 +1490,11 @@ namespace cadet
 		if (paramProvider.exists("USER_SOLUTION_TIMES"))
 			_solutionTimes = paramProvider.getDoubleArray("USER_SOLUTION_TIMES");
 
+		if (static_cast<double>(_solutionTimes.back()) > static_cast<double>(_sectionTimes.back()))
+		{
+			throw InvalidParameterException("USER_SOLUTION_TIMES exceed section times");
+		}
+
 		if (paramProvider.exists("CONSISTENT_INIT_MODE"))
 			_consistentInitMode = toConsistentInitialization(paramProvider.getInt("CONSISTENT_INIT_MODE"));
 

--- a/src/libcadet/model/StirredTankModel.cpp
+++ b/src/libcadet/model/StirredTankModel.cpp
@@ -420,7 +420,7 @@ void CSTRModel::notifyDiscontinuousSectionTransition(double t, unsigned int secI
 {
 	if (_flowRateFilter.size() > 1)
 	{
-		_curFlowRateFilter = _flowRateFilter[secIdx];
+		_curFlowRateFilter = getSectionDependentScalar(_flowRateFilter, secIdx);
 	}
 	else if (_flowRateFilter.size() == 1)
 	{

--- a/src/libcadet/model/StirredTankModel.cpp
+++ b/src/libcadet/model/StirredTankModel.cpp
@@ -418,14 +418,7 @@ void CSTRModel::useAnalyticJacobian(const bool analyticJac)
 
 void CSTRModel::notifyDiscontinuousSectionTransition(double t, unsigned int secIdx, const ConstSimulationState& simState, const AdJacobianParams& adJac)
 {
-	if (_flowRateFilter.size() > 1)
-	{
-		_curFlowRateFilter = getSectionDependentScalar(_flowRateFilter, secIdx);
-	}
-	else if (_flowRateFilter.size() == 1)
-	{
-		_curFlowRateFilter = _flowRateFilter[0];
-	}
+	_curFlowRateFilter = getSectionDependentScalar(_flowRateFilter, secIdx);
 }
 
 void CSTRModel::reportSolution(ISolutionRecorder& recorder, double const* const solution) const


### PR DESCRIPTION
This is an initial draft to improve parameter checks. 

In the given example, the `FLOWRATE_FILTER` accidentally did not have enough entries. Because its length was still > 0, CADET assumed it was a section depenent parameter. However, when compiled with g++, the CADET would exceed the bounds of the array and only (sometimes) crash much later. On Windows, it crashes immediately when exceeding the bounds of the array.

By calling `getSectionDependentScalar(_flowRateFilter, secIdx)` instead of indexing directly, it also crashes on Linux.

A more elegant approach would be to check the length of section dependent parameters before even starting the simulation. This way, the user knows directly that the configuration is invalid. @sleweke is this done somewhere in CADET for other section dependent parameters? I couldn't find anything.

[Example](https://github.com/modsim/CADET/files/7890951/lrm_linear_1e-12_replace_0.zip)

Partially fixes #28 

