### PR TITLE
Implement missing CAPI methods

### DIFF
--- a/doc/interface/return_data.rst
+++ b/doc/interface/return_data.rst
@@ -16,7 +16,7 @@ Group /input/return
    
 ``WRITE_SOLUTION_LAST``
 
-   Write full solution state vector at last time point (optional, defaults to 0)
+   Write full solution state vector at last time point, including the state derivative vector (optional, defaults to 0)
    
    =============  ==========================
    **Type:** int  **Range:** :math:`\{0,1\}`
@@ -24,7 +24,7 @@ Group /input/return
    
 ``WRITE_SENS_LAST``
 
-   Write full sensitivity state vectors at last time point (optional, defaults to 0)
+   Write full sensitivity state vectors at last time point, including the state derivative vector (optional, defaults to 0)
    
    =============  ==========================
    **Type:** int  **Range:** :math:`\{0,1\}`
@@ -292,8 +292,16 @@ Group /input/return/unit_XXX
    
 ``WRITE_SOLUTION_LAST_UNIT``
 
-   Write solution state vector of this unit at last time point
+   Write solution state vector of this unit at last time point, including the state derivative vector (optional, defaults to 0)
    
+   =============  ==========================
+   **Type:** int  **Range:** :math:`\{0,1\}`
+   =============  ==========================
+
+``WRITE_SENS_LAST_UNIT``
+
+   Write sensitivity state vector of this unit at last time point, including the state derivative vector (optional, defaults to 0)
+
    =============  ==========================
    **Type:** int  **Range:** :math:`\{0,1\}`
    =============  ==========================

--- a/doc/interface/system.rst
+++ b/doc/interface/system.rst
@@ -32,7 +32,7 @@ Group /input/model
    
 ``INIT_STATE_SENSY_XXX``
 
-   Number of unit operations in the system
+   Initial full time derivative state vector of the :math:`\texttt{XXX}` th sensitivity system (optional, can currently not be specified on unit operation level)
    
    ================  ==================================
    **Type:** double  **Length:** :math:`\texttt{NDOF}`
@@ -40,15 +40,7 @@ Group /input/model
    
 ``INIT_STATE_SENSYDOT_XXX``
 
-   Initial full state vector of the :math:`\texttt{XXX}` th sensitivity system (optional, unit operation specific initial data is ignored)
-   
-   ================  ==================================
-   **Type:** double  **Length:** :math:`\texttt{NDOF}`
-   ================  ==================================
-   
-``NUNITS``
-
-   Initial full time derivative state vector of the :math:`\texttt{XXX}` th sensitivity system (optional, unit operation specific initial data is ignored)
+   Initial full state vector of the :math:`\texttt{XXX}` th sensitivity system (optional, can currently not be specified on unit operation level)
    
    ================  ==================================
    **Type:** double  **Length:** :math:`\texttt{NDOF}`

--- a/include/cadet/LibVersionInfo.hpp
+++ b/include/cadet/LibVersionInfo.hpp
@@ -81,6 +81,13 @@ namespace cadet
 	 * @return Git refspec
 	 */
 	CADET_API const char* getLibraryBuildHost() CADET_NOEXCEPT;
+
+	/**
+	 * @brief Returns the latest C-API version implemented by CADET
+	 * @sa cadetGetLatestCAPIVersion()
+	 * @return C-API Version number
+	 */
+	CADET_API const char* getLatestCAPIVersion() CADET_NOEXCEPT;
 } // namespace cadet
 
 #endif  // LIBCADET_LIBVERSIONINFO_HPP_

--- a/include/cadet/cadet.h
+++ b/include/cadet/cadet.h
@@ -78,7 +78,11 @@ extern "C"
 	 */
 	CADET_API const char* cdtGetLibraryBuildHost();
 
-
+	/**
+	 * @brief Returns the latest C-API version implemented by CADET
+	 * @return C-API Version number
+	 */
+	CADET_API const char* cdtGetLatestCAPIVersion();
 
 
 	/**
@@ -160,6 +164,10 @@ extern "C"
 	 */
 	enum cdtErrors
 	{
+		/**
+		 * @brief Requested data has not been stored / is not available
+		 */
+		cdtDataNotStored = -3,
 		/**
 		 * @brief Input arguments invalid
 		 */
@@ -363,6 +371,12 @@ extern "C"
 	typedef struct
 	{
 		/**
+		 * @brief Return the current file format version
+		 * @param [out] fileFormat The current file format
+		 */
+		cdtResult (*getFileFormat)(int* fileFormat);
+
+		/**
 		 * @brief Creates a driver that handles simulation on a high level
 		 * @return Driver handle or @c NULL if an error occurred
 		 */
@@ -383,7 +397,46 @@ extern "C"
 		cdtResult (*runSimulation)(cdtDriver* drv, cdtParameterProvider const* paramProvider);
 
 		/**
-		 * @brief Returns the solution of the last simulation
+		 * @brief Returns the number of unit operations
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 * @param [in] drv Driver handle
+		 * @param [out] nUnits Number of unit operations
+		 */
+		cdtResult (*getNumUnitOp)(cdtDriver* drv, int* nUnits);
+
+		/**
+		 * @brief Returns the number of particle types
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 * @param [in] drv Driver handle
+		 * @param [in] unitOpId ID of the unit operation whose solution is returned
+		 * @param [out] nParTypes Number of particle types
+		 */
+		cdtResult (*getNumParTypes)(cdtDriver* drv, int unitOpId, int* nParTypes);
+
+		/**
+		 * @brief Returns the number of parameter sensitivities
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 * @param [in] drv Driver handle
+		 * @param [out] nSens Number of parameter sensitivities
+		 */
+		cdtResult (*getNumSensitivities)(cdtDriver* drv, int* nSens);
+
+		/**
+		 * @brief Returns the solution of the last simulation at unit inlet
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 *          The array pointers are only valid until a new simulation is started.
+		 * @param [in] drv Driver handle
+		 * @param [in] unitOpId ID of the unit operation whose solution is returned
+		 * @param [out] time Time array pointer
+		 * @param [out] data Data array pointer
+		 * @param [out] nTime Number of time points
+		 * @param [out] nPort Number of ports
+		 * @param [out] nComp Number of components
+		 */
+		cdtResult (*getSolutionInlet)(cdtDriver* drv, int unitOpId, double const** time, double const** data, int* nTime, int* nPort, int* nComp);
+
+		/**
+		 * @brief Returns the solution of the last simulation at unit outlet
 		 * @details Before this function is called, a simulation has to be run successfully.
 		 *          The array pointers are only valid until a new simulation is started.
 		 * @param [in] drv Driver handle
@@ -395,6 +448,563 @@ extern "C"
 		 * @param [out] nComp Number of components
 		 */
 		cdtResult (*getSolutionOutlet)(cdtDriver* drv, int unitOpId, double const** time, double const** data, int* nTime, int* nPort, int* nComp);
+
+		/**
+		 * @brief Returns the solution of the last simulation of the column bulk phase
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 *          The array pointers are only valid until a new simulation is started.
+		 * @param [in] drv Driver handle
+		 * @param [in] unitOpId ID of the unit operation whose solution is returned
+		 * @param [out] time Time array pointer
+		 * @param [out] data Data array pointer
+		 * @param [out] nTime Number of time points
+		 * @param [out] nAxialCells Number of axial cells
+		 * @param [out] nRadialCells Number of radial cells
+		 * @param [out] nComp Number of components
+		 * @param [out] keepAxialSingletonDimension Keep axial singleton dimension
+		 */
+		cdtResult (*getSolutionBulk)(cdtDriver* drv, int unitOpId, double const** time, double const** data, int* nTime, int* nAxialCells, int* nRadialCells, int* nComp, bool* keepAxialSingletonDimension);
+
+		/**
+		 * @brief Returns the solution of the last simulation of the column particle liquid phase
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 *          The array pointers are only valid until a new simulation is started.
+		 * @param [in] drv Driver handle
+		 * @param [in] unitOpId ID of the unit operation whose solution is returned
+		 * @param [out] parType Particle type index
+		 * @param [out] time Time array pointer
+		 * @param [out] data Data array pointer
+		 * @param [out] nTime Number of time points
+		 * @param [out] nAxialCells Number of axial cells
+		 * @param [out] nRadialCells Number of ports
+		 * @param [out] nParShells Number of particle shells
+		 * @param [out] nComp Number of components
+		 * @param [out] keepAxialSingletonDimension Keep axial singleton dimension
+		 * @param [out] keepParticleSingletonDimension Keep particle singleton dimension
+		 */
+		cdtResult (*getSolutionParticle)(cdtDriver* drv, int unitOpId, int parType, double const** time, double const** data, int* nTime, int* nAxialCells, int* nRadialCells, int* nParShells, int* nComp, bool* keepAxialSingletonDimension, bool* keepParticleSingletonDimension);
+		/**
+		 * @brief Returns the solution of the last simulation of the column particle solid phase
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 *          The array pointers are only valid until a new simulation is started.
+		 * @param [in] drv Driver handle
+		 * @param [in] unitOpId ID of the unit operation whose solution is returned
+		 * @param [out] parType Particle type index
+		 * @param [out] time Time array pointer
+		 * @param [out] data Data array pointer
+		 * @param [out] nTime Number of time points
+		 * @param [out] nAxialCells Number of axial cells
+		 * @param [out] nRadialCells Number of ports
+		 * @param [out] nParShells Number of particle shells
+		 * @param [out] nBound Number of bound states
+		 * @param [out] keepAxialSingletonDimension Keep axial singleton dimension
+		 * @param [out] keepParticleSingletonDimension Keep particle singleton dimension
+		 */
+		cdtResult (*getSolutionSolid)(cdtDriver* drv, int unitOpId, int parType, double const** time, double const** data, int* nTime, int* nAxialCells, int* nRadialCells, int* nParShells, int* nBound, bool* keepAxialSingletonDimension, bool* keepParticleSingletonDimension);
+
+		/**
+		 * @brief Returns the solution of the last simulation of the column particle flux
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 *          The array pointers are only valid until a new simulation is started.
+		 * @param [in] drv Driver handle
+		 * @param [in] unitOpId ID of the unit operation whose solution is returned
+		 * @param [out] time Time array pointer
+		 * @param [out] data Data array pointer
+		 * @param [out] nTime Number of time points
+		 * @param [out] nAxialCells Number of axial cells
+		 * @param [out] nRadialCells Number of ports
+		 * @param [out] nParticleTypes Number of particle types
+		 * @param [out] nComp Number of components
+		 * @param [out] keepAxialSingletonDimension Keep axial singleton dimension
+		 */
+		cdtResult (*getSolutionFlux)(cdtDriver* drv, int unitOpId, double const** time, double const** data, int* nTime, int* nAxialCells, int* nRadialCells, int* nParticleTypes, int* nComp, bool* keepAxialSingletonDimension);
+
+		/**
+		 * @brief Returns the solution of the last simulation of the unit volume
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 *          The array pointers are only valid until a new simulation is started.
+		 * @param [in] drv Driver handle
+		 * @param [in] unitOpId ID of the unit operation whose solution is returned
+		 * @param [out] time Time array pointer
+		 * @param [out] data Data array pointer
+		 */
+		cdtResult (*getSolutionVolume)(cdtDriver* drv, int unitOpId, double const** time, double const** data, int* nTime);
+
+		/**
+		 * @brief Returns the solution derivative of the last simulation at unit inlet
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 *          The array pointers are only valid until a new simulation is started.
+		 * @param [in] drv Driver handle
+		 * @param [in] unitOpId ID of the unit operation whose solution is returned
+		 * @param [out] time Time array pointer
+		 * @param [out] data Data array pointer
+		 * @param [out] nTime Number of time points
+		 * @param [out] nPort Number of ports
+		 * @param [out] nComp Number of components
+		 */
+		cdtResult (*getSolutionDerivativeInlet)(cdtDriver* drv, int unitOpId, double const** time, double const** data, int* nTime, int* nPort, int* nComp);
+
+		/**
+		 * @brief Returns the solution derivative of the last simulation at unit outlet
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 *          The array pointers are only valid until a new simulation is started.
+		 * @param [in] drv Driver handle
+		 * @param [in] unitOpId ID of the unit operation whose solution is returned
+		 * @param [out] time Time array pointer
+		 * @param [out] data Data array pointer
+		 * @param [out] nTime Number of time points
+		 * @param [out] nPort Number of ports
+		 * @param [out] nComp Number of components
+		 */
+		cdtResult (*getSolutionDerivativeOutlet)(cdtDriver* drv, int unitOpId, double const** time, double const** data, int* nTime, int* nPort, int* nComp);
+
+		/**
+		 * @brief Returns the solution derivative of the last simulation of the column bulk phase
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 *          The array pointers are only valid until a new simulation is started.
+		 * @param [in] drv Driver handle
+		 * @param [in] unitOpId ID of the unit operation whose solution is returned
+		 * @param [out] time Time array pointer
+		 * @param [out] data Data array pointer
+		 * @param [out] nTime Number of time points
+		 * @param [out] nAxialCells Number of axial cells
+		 * @param [out] nRadialCells Number of radial cells
+		 * @param [out] nComp Number of components
+		 * @param [out] keepAxialSingletonDimension Keep axial singleton dimension
+		 */
+		cdtResult (*getSolutionDerivativeBulk)(cdtDriver* drv, int unitOpId, double const** time, double const** data, int* nTime, int* nAxialCells, int* nRadialCells, int* nComp, bool* keepAxialSingletonDimension);
+
+		/**
+		 * @brief Returns the solution derivative of the last simulation of the column particle liquid phase
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 *          The array pointers are only valid until a new simulation is started.
+		 * @param [in] drv Driver handle
+		 * @param [in] unitOpId ID of the unit operation whose solution is returned
+		 * @param [out] parType Particle type index
+		 * @param [out] time Time array pointer
+		 * @param [out] data Data array pointer
+		 * @param [out] nTime Number of time points
+		 * @param [out] nAxialCells Number of axial cells
+		 * @param [out] nRadialCells Number of ports
+		 * @param [out] nParShells Number of particle shells
+		 * @param [out] nComp Number of components
+		 * @param [out] keepAxialSingletonDimension Keep axial singleton dimension
+		 * @param [out] keepParticleSingletonDimension Keep particle singleton dimension
+		 */
+		cdtResult (*getSolutionDerivativeParticle)(cdtDriver* drv, int unitOpId, int parType, double const** time, double const** data, int* nTime, int* nAxialCells, int* nRadialCells, int* nParShells, int* nComp, bool* keepAxialSingletonDimension, bool* keepParticleSingletonDimension);
+
+		/**
+		 * @brief Returns the solution derivative of the last simulation of the column particle solid phase
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 *          The array pointers are only valid until a new simulation is started.
+		 * @param [in] drv Driver handle
+		 * @param [in] unitOpId ID of the unit operation whose solution is returned
+		 * @param [out] parType Particle type index
+		 * @param [out] time Time array pointer
+		 * @param [out] data Data array pointer
+		 * @param [out] nTime Number of time points
+		 * @param [out] nAxialCells Number of axial cells
+		 * @param [out] nRadialCells Number of ports
+		 * @param [out] nParShells Number of particle shells
+		 * @param [out] nBound Number of bound states
+		 * @param [out] keepAxialSingletonDimension Keep axial singleton dimension
+		 * @param [out] keepParticleSingletonDimension Keep particle singleton dimension
+		 */
+		cdtResult (*getSolutionDerivativeSolid)(cdtDriver* drv, int unitOpId, int parType, double const** time, double const** data, int* nTime, int* nAxialCells, int* nRadialCells, int* nParShells, int* nBound, bool* keepAxialSingletonDimension, bool* keepParticleSingletonDimension);
+
+		/**
+		 * @brief Returns the solution derivative of the last simulation of the column particle flux
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 *          The array pointers are only valid until a new simulation is started.
+		 * @param [in] drv Driver handle
+		 * @param [in] unitOpId ID of the unit operation whose solution is returned
+		 * @param [out] time Time array pointer
+		 * @param [out] data Data array pointer
+		 * @param [out] nTime Number of time points
+		 * @param [out] nAxialCells Number of axial cells
+		 * @param [out] nRadialCells Number of ports
+		 * @param [out] nParticleTypes Number of particle types
+		 * @param [out] nComp Number of components
+		 * @param [out] keepAxialSingletonDimension Keep axial singleton dimension
+		 */
+		cdtResult (*getSolutionDerivativeFlux)(cdtDriver* drv, int unitOpId, double const** time, double const** data, int* nTime, int* nAxialCells, int* nRadialCells, int* nParticleTypes, int* nComp, bool* keepAxialSingletonDimension);
+
+		/**
+		 * @brief Returns the solution derivative of the last simulation of the unit volume
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 *          The array pointers are only valid until a new simulation is started.
+		 * @param [in] drv Driver handle
+		 * @param [in] unitOpId ID of the unit operation whose solution is returned
+		 * @param [out] time Time array pointer
+		 * @param [out] data Data array pointer
+		 */
+		cdtResult (*getSolutionDerivativeVolume)(cdtDriver* drv, int unitOpId, double const** time, double const** data, int* nTime);
+
+		/**
+		 * @brief Returns the parameter sensitivity of the last simulation at unit inlet
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 *          The array pointers are only valid until a new simulation is started.
+		 * @param [in] drv Driver handle
+		 * @param [in] unitOpId ID of the unit operation whose solution is returned
+		 * @param [out] time Time array pointer
+		 * @param [out] data Data array pointer
+		 * @param [out] nTime Number of time points
+		 * @param [out] nPort Number of ports
+		 * @param [out] nComp Number of components
+		 */
+		cdtResult (*getSensitivityInlet)(cdtDriver* drv, int unitOpId, int sensIdx, double const** time, double const** data, int* nTime, int* nPort, int* nComp);
+
+		/**
+		 * @brief Returns the parameter sensitivity of the last simulation at unit outlet
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 *          The array pointers are only valid until a new simulation is started.
+		 * @param [in] drv Driver handle
+		 * @param [in] unitOpId ID of the unit operation whose solution is returned
+		 * @param [in] sensIdx Sensitivity ID
+		 * @param [out] time Time array pointer
+		 * @param [out] data Data array pointer
+		 * @param [out] nTime Number of time points
+		 * @param [out] nPort Number of ports
+		 * @param [out] nComp Number of components
+		 */
+		cdtResult (*getSensitivityOutlet)(cdtDriver* drv, int unitOpId, int sensIdx, double const** time, double const** data, int* nTime, int* nPort, int* nComp);
+
+		/**
+		 * @brief Returns the parameter sensitivity of the last simulation of the column bulk phase
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 *          The array pointers are only valid until a new simulation is started.
+		 * @param [in] drv Driver handle
+		 * @param [in] unitOpId ID of the unit operation whose solution is returned
+		 * @param [in] sensIdx Sensitivity ID
+		 * @param [out] time Time array pointer
+		 * @param [out] data Data array pointer
+		 * @param [out] nTime Number of time points
+		 * @param [out] nAxialCells Number of axial cells
+		 * @param [out] nRadialCells Number of radial cells
+		 * @param [out] nComp Number of components
+		 * @param [out] keepAxialSingletonDimension Keep axial singleton dimension
+		 */
+		cdtResult (*getSensitivityBulk)(cdtDriver* drv, int unitOpId, int sensIdx, double const** time, double const** data, int* nTime, int* nAxialCells, int* nRadialCells, int* nComp, bool* keepAxialSingletonDimension);
+
+		/**
+		 * @brief Returns the parameter sensitivity of the last simulation of the column particle liquid phase
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 *          The array pointers are only valid until a new simulation is started.
+		 * @param [in] drv Driver handle
+		 * @param [in] unitOpId ID of the unit operation whose solution is returned
+		 * @param [in] sensIdx Sensitivity ID
+		 * @param [out] parType Particle type index
+		 * @param [out] time Time array pointer
+		 * @param [out] data Data array pointer
+		 * @param [out] nTime Number of time points
+		 * @param [out] nAxialCells Number of axial cells
+		 * @param [out] nRadialCells Number of ports
+		 * @param [out] nParShells Number of particle shells
+		 * @param [out] nComp Number of components
+		 * @param [out] keepAxialSingletonDimension Keep axial singleton dimension
+		 * @param [out] keepParticleSingletonDimension Keep particle singleton dimension
+		 */
+		cdtResult (*getSensitivityParticle)(cdtDriver* drv, int unitOpId, int sensIdx, int parType, double const** time, double const** data, int* nTime, int* nAxialCells, int* nRadialCells, int* nParShells, int* nComp, bool* keepAxialSingletonDimension, bool* keepParticleSingletonDimension);
+
+		/**
+		 * @brief Returns the parameter sensitivity of the last simulation of the column particle solid phase
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 *          The array pointers are only valid until a new simulation is started.
+		 * @param [in] drv Driver handle
+		 * @param [in] unitOpId ID of the unit operation whose solution is returned
+		 * @param [in] sensIdx Sensitivity ID
+		 * @param [out] parType Particle type index
+		 * @param [out] time Time array pointer
+		 * @param [out] data Data array pointer
+		 * @param [out] nTime Number of time points
+		 * @param [out] nAxialCells Number of axial cells
+		 * @param [out] nRadialCells Number of ports
+		 * @param [out] nParShells Number of particle shells
+		 * @param [out] nBound Number of bound states
+		 * @param [out] keepAxialSingletonDimension Keep axial singleton dimension
+		 * @param [out] keepParticleSingletonDimension Keep particle singleton dimension
+		 */
+		cdtResult (*getSensitivitySolid)(cdtDriver* drv, int unitOpId, int sensIdx, int parType, double const** time, double const** data, int* nTime, int* nAxialCells, int* nRadialCells, int* nParShells, int* nBound, bool* keepAxialSingletonDimension, bool* keepParticleSingletonDimension);
+
+		/**
+		 * @brief Returns the parameter sensitivity of the last simulation of the column particle flux
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 *          The array pointers are only valid until a new simulation is started.
+		 * @param [in] drv Driver handle
+		 * @param [in] unitOpId ID of the unit operation whose solution is returned
+		 * @param [in] sensIdx Sensitivity ID
+		 * @param [out] time Time array pointer
+		 * @param [out] data Data array pointer
+		 * @param [out] nTime Number of time points
+		 * @param [out] nAxialCells Number of axial cells
+		 * @param [out] nRadialCells Number of ports
+		 * @param [out] nParticleTypes Number of particle types
+		 * @param [out] nComp Number of components
+		 * @param [out] keepAxialSingletonDimension Keep axial singleton dimension
+		 */
+		cdtResult (*getSensitivityFlux)(cdtDriver* drv, int unitOpId, int sensIdx, double const** time, double const** data, int* nTime, int* nAxialCells, int* nRadialCells, int* nParticleTypes, int* nComp, bool* keepAxialSingletonDimension);
+
+		/**
+		 * @brief Returns the parameter sensitivity of the last simulation of the unit volume
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 *          The array pointers are only valid until a new simulation is started.
+		 * @param [in] drv Driver handle
+		 * @param [in] unitOpId ID of the unit operation whose solution is returned
+		 * @param [in] sensIdx Sensitivity ID
+		 * @param [out] time Time array pointer
+		 * @param [out] data Data array pointer
+		 */
+		cdtResult (*getSensitivityVolume)(cdtDriver* drv, int unitOpId, int sensIdx, double const** time, double const** data, int* nTime);
+
+		/**
+		 * @brief Returns the parameter sensitivity derivative of the last simulation at unit inlet
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 *          The array pointers are only valid until a new simulation is started.
+		 * @param [in] drv Driver handle
+		 * @param [in] unitOpId ID of the unit operation whose solution is returned
+		 * @param [in] sensIdx Sensitivity ID
+		 * @param [out] time Time array pointer
+		 * @param [out] data Data array pointer
+		 * @param [out] nTime Number of time points
+		 * @param [out] nPort Number of ports
+		 * @param [out] nComp Number of components
+		 */
+		cdtResult (*getSensitivityDerivativeInlet)(cdtDriver* drv, int unitOpId, int sensIdx, double const** time, double const** data, int* nTime, int* nPort, int* nComp);
+
+		/**
+		 * @brief Returns the parameter sensitivity derivative of the last simulation at unit outlet
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 *          The array pointers are only valid until a new simulation is started.
+		 * @param [in] drv Driver handle
+		 * @param [in] unitOpId ID of the unit operation whose solution is returned
+		 * @param [in] sensIdx Sensitivity ID
+		 * @param [out] time Time array pointer
+		 * @param [out] data Data array pointer
+		 * @param [out] nTime Number of time points
+		 * @param [out] nPort Number of ports
+		 * @param [out] nComp Number of components
+		 */
+		cdtResult (*getSensitivityDerivativeOutlet)(cdtDriver* drv, int unitOpId, int sensIdx, double const** time, double const** data, int* nTime, int* nPort, int* nComp);
+
+		/**
+		 * @brief Returns the parameter sensitivity derivative of the last simulation of the column bulk phase
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 *          The array pointers are only valid until a new simulation is started.
+		 * @param [in] drv Driver handle
+		 * @param [in] unitOpId ID of the unit operation whose solution is returned
+		 * @param [in] sensIdx Sensitivity ID
+		 * @param [out] time Time array pointer
+		 * @param [out] data Data array pointer
+		 * @param [out] nTime Number of time points
+		 * @param [out] nAxialCells Number of axial cells
+		 * @param [out] nRadialCells Number of radial cells
+		 * @param [out] nComp Number of components
+		 * @param [out] keepAxialSingletonDimension Keep axial singleton dimension
+		 */
+		cdtResult (*getSensitivityDerivativeBulk)(cdtDriver* drv, int unitOpId, int sensIdx, double const** time, double const** data, int* nTime, int* nAxialCells, int* nRadialCells, int* nComp, bool* keepAxialSingletonDimension);
+
+		/**
+		 * @brief Returns the parameter sensitivity derivative of the last simulation of the column particle liquid phase
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 *          The array pointers are only valid until a new simulation is started.
+		 * @param [in] drv Driver handle
+		 * @param [in] unitOpId ID of the unit operation whose solution is returned
+		 * @param [in] sensIdx Sensitivity ID
+		 * @param [out] parType Particle type index
+		 * @param [out] time Time array pointer
+		 * @param [out] data Data array pointer
+		 * @param [out] nTime Number of time points
+		 * @param [out] nAxialCells Number of axial cells
+		 * @param [out] nRadialCells Number of ports
+		 * @param [out] nParShells Number of particle shells
+		 * @param [out] nComp Number of components
+		 * @param [out] keepAxialSingletonDimension Keep axial singleton dimension
+		 * @param [out] keepParticleSingletonDimension Keep particle singleton dimension
+		 */
+		cdtResult (*getSensitivityDerivativeParticle)(cdtDriver* drv, int unitOpId, int sensIdx, int parType, double const** time, double const** data, int* nTime, int* nAxialCells, int* nRadialCells, int* nParShells, int* nComp, bool* keepAxialSingletonDimension, bool* keepParticleSingletonDimension);
+
+		/**
+		 * @brief Returns the parameter sensitivity derivative of the last simulation of the column particle solid phase
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 *          The array pointers are only valid until a new simulation is started.
+		 * @param [in] drv Driver handle
+		 * @param [in] unitOpId ID of the unit operation whose solution is returned
+		 * @param [in] sensIdx Sensitivity ID
+		 * @param [out] parType Particle type index
+		 * @param [out] time Time array pointer
+		 * @param [out] data Data array pointer
+		 * @param [out] nTime Number of time points
+		 * @param [out] nAxialCells Number of axial cells
+		 * @param [out] nRadialCells Number of ports
+		 * @param [out] nParShells Number of particle shells
+		 * @param [out] nBound Number of bound states
+		 * @param [out] keepAxialSingletonDimension Keep axial singleton dimension
+		 * @param [out] keepParticleSingletonDimension Keep particle singleton dimension
+		 */
+		cdtResult (*getSensitivityDerivativeSolid)(cdtDriver* drv, int unitOpId, int sensIdx, int parType, double const** time, double const** data, int* nTime, int* nAxialCells, int* nRadialCells, int* nParShells, int* nBound, bool* keepAxialSingletonDimension, bool* keepParticleSingletonDimension);
+
+		/**
+		 * @brief Returns the parameter sensitivity derivative of the last simulation of the column particle flux
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 *          The array pointers are only valid until a new simulation is started.
+		 * @param [in] drv Driver handle
+		 * @param [in] unitOpId ID of the unit operation whose solution is returned
+		 * @param [in] sensIdx Sensitivity ID
+		 * @param [out] time Time array pointer
+		 * @param [out] data Data array pointer
+		 * @param [out] nTime Number of time points
+		 * @param [out] nAxialCells Number of axial cells
+		 * @param [out] nRadialCells Number of ports
+		 * @param [out] nParticleTypes Number of particle types
+		 * @param [out] nComp Number of components
+		 * @param [out] keepAxialSingletonDimension Keep axial singleton dimension
+		 */
+		cdtResult (*getSensitivityDerivativeFlux)(cdtDriver* drv, int unitOpId, int sensIdx, double const** time, double const** data, int* nTime, int* nAxialCells, int* nRadialCells, int* nParticleTypes, int* nComp, bool* keepAxialSingletonDimension);
+
+		/**
+		 * @brief Returns the parameter sensitivity derivative of the last simulation of the unit volume
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 *          The array pointers are only valid until a new simulation is started.
+		 * @param [in] drv Driver handle
+		 * @param [in] unitOpId ID of the unit operation whose solution is returned
+		 * @param [in] sensIdx Sensitivity ID
+		 * @param [out] time Time array pointer
+		 * @param [out] data Data array pointer
+		 * @param [out] nTime Number of time points
+		 */
+		cdtResult (*getSensitivityDerivativeVolume)(cdtDriver* drv, int unitOpId, int sensIdx, double const** time, double const** data, int* nTime);
+
+		/**
+		 * @brief Returns the last state of the simulation
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 * @param [in] drv Driver handle
+		 * @param [out] state State vector pointer
+		 * @param [out] nStates Number of entries in the state vector
+		*/
+		cdtResult (*getLastState)(cdtDriver* drv, double const** state, int* nStates);
+
+		/**
+		 * @brief Returns the last time derivative state of the simulation
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 * @param [in] drv Driver handle
+		 * @param [out] state State vector pointer
+		 * @param [out] nStates Number of entries in the state vector
+		*/
+		cdtResult (*getLastStateTimeDerivative)(cdtDriver* drv, double const** state, int* nStates);
+
+		/**
+		 * @brief Returns the last state of the unit operation of the simulation
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 * @param [in] drv Driver handle
+		 * @param [in] unitOpId ID of the unit operation whose solution is returned
+		 * @param [out] state State vector pointer
+		 * @param [out] nStates Number of entries in the state vector
+		*/
+		cdtResult (*getLastUnitState)(cdtDriver* drv, int unitOpId, double const** state, int* nStates);
+
+		/**
+		 * @brief Returns the last time derivative state of the unit operation of the simulation
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 * @param [in] drv Driver handle
+		 * @param [in] unitOpId ID of the unit operation whose solution is returned
+		 * @param [out] state State vector pointer
+		 * @param [out] nStates Number of entries in the state vector
+		*/
+		cdtResult (*getLastUnitStateTimeDerivative)(cdtDriver* drv, int unitOpId, double const** state, int* nStates);
+
+		/**
+		 * @brief Returns the last sensitivity state of the simulation
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 * @param [in] drv Driver handle
+		 * @param [in] sensIdx Sensitivity ID
+		 * @param [out] state State vector pointer
+		 * @param [out] nStates Number of entries in the state vector
+		*/
+		cdtResult (*getLastSensitivityState)(cdtDriver* drv, int sensIdx, double const** state, int* nStates);
+
+		/**
+		 * @brief Returns the last time derivative sensitivity state of the simulation
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 * @param [in] drv Driver handle
+		 * @param [in] sensIdx Sensitivity ID
+		 * @param [out] state State vector pointer
+		 * @param [out] nStates Number of entries in the state vector
+		*/
+		cdtResult (*getLastSensitivityStateTimeDerivative)(cdtDriver* drv, int sensIdx, double const** state, int* nStates);
+
+		/**
+		 * @brief Returns the last sensitivity state of the unit operation of the simulation
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 * @param [in] drv Driver handle
+		 * @param [in] sensIdx Sensitivity ID
+		 * @param [in] unitOpId ID of the unit operation whose solution is returned
+		 * @param [out] state State vector pointer
+		 * @param [out] nStates Number of entries in the state vector
+		*/
+		cdtResult (*getLastSensitivityUnitState)(cdtDriver* drv, int sensIdx, int unitOpId, double const** state, int* nStates);
+
+		/**
+		 * @brief Returns the last time derivative sensitivity state of the unit operation of the simulation
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 * @param [in] drv Driver handle
+		 * @param [in] sensIdx Sensitivity ID
+		 * @param [in] unitOpId ID of the unit operation whose solution is returned
+		 * @param [out] state State vector pointer
+		 * @param [out] nStates Number of entries in the state vector
+		*/
+		cdtResult (*getLastSensitivityUnitStateTimeDerivative)(cdtDriver* drv, int sensIdx, int unitOpId, double const** state, int* nStates);
+
+		/**
+		 * @brief Returns the primary coordinates of the given unit operation
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 *          The array pointers are only valid until a new simulation is started.
+		 * @param [in] drv Driver handle
+		 * @param [in] unitOpId ID of the unit operation whose solution is returned
+		 * @param [out] data Data array pointer
+		 * @param [out] nCoords Number of coordinates
+		 */
+		cdtResult (*getPrimaryCoordinates)(cdtDriver* drv, int unitOpId, double const** data, int* nCoords);
+
+		/**
+		 * @brief Returns the secondary coordinates of the given unit operation
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 *          The array pointers are only valid until a new simulation is started.
+		 * @param [in] drv Driver handle
+		 * @param [in] unitOpId ID of the unit operation whose solution is returned
+		 * @param [out] data Data array pointer
+		 * @param [out] nCoords Number of coordinates
+		 */
+		cdtResult (*getSecondaryCoordinates)(cdtDriver* drv, int unitOpId, double const** data, int* nCoords);
+
+		/**
+		 * @brief Returns the secondary coordinates of the given unit operation
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 *          The array pointers are only valid until a new simulation is started.
+		 * @param [in] drv Driver handle
+		 * @param [in] unitOpId ID of the unit operation whose solution is returned
+		 * @param [in] parType Particle type index
+		 * @param [out] data Data array pointer
+		 * @param [out] nCoords Number of coordinates
+		 */
+		cdtResult (*getParticleCoordinates)(cdtDriver* drv, int unitOpId, int parType, double const** data, int* nCoords);
+
+		/**
+		 * @brief Returns the time points at which the solution was computed
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 *          The array pointers are only valid until a new simulation is started.
+		 * @param [in] drv Driver handle
+		 * @param [out] time Time array pointer
+		 * @param [out] nTime Number of time points
+		 */
+		cdtResult (*getSolutionTimes)(cdtDriver* drv, double const** time, int* nTime);
+
+		/**
+		 * @brief Returns the run time of the simulation
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 * @param [in] drv Driver handle
+		 * @param [out] timeSim Simulation run time pointer
+		 */
+		cdtResult (*getTimeSim)(cdtDriver* drv, double* timeSim);
 
 	} cdtAPIv010000;
 

--- a/include/common/SolutionRecorderImpl.hpp
+++ b/include/common/SolutionRecorderImpl.hpp
@@ -461,6 +461,11 @@ public:
 	inline unsigned int numComponents() const CADET_NOEXCEPT { return _nComp; }
 	inline unsigned int numInletPorts() const CADET_NOEXCEPT { return _nInletPorts; }
 	inline unsigned int numOutletPorts() const CADET_NOEXCEPT { return _nOutletPorts; }
+	inline unsigned int numAxialCells() const CADET_NOEXCEPT { return _nAxialCells; }
+	inline unsigned int numRadialCells() const CADET_NOEXCEPT { return _nRadialCells; }
+	inline unsigned int numParticleTypes() const CADET_NOEXCEPT { return _nParShells.size(); }
+	inline unsigned int numParticleShells(unsigned int parType = 0) const CADET_NOEXCEPT { return _nParShells[parType]; }
+	inline unsigned int numBoundStates(unsigned int parType = 0) const CADET_NOEXCEPT { return _nBoundStates[parType]; }
 
 	inline double const* time() const CADET_NOEXCEPT { return _time.data(); }
 	inline double const* inlet() const CADET_NOEXCEPT { return _data.inlet.data(); }
@@ -491,6 +496,9 @@ public:
 	inline double const* sensSolidDot(unsigned int idx, unsigned int parType = 0) const CADET_NOEXCEPT { return _sensDot[idx].solid[parType].data(); }
 	inline double const* sensFluxDot(unsigned int idx) const CADET_NOEXCEPT { return _sensDot[idx].flux.data(); }
 	inline double const* sensVolumeDot(unsigned int idx) const CADET_NOEXCEPT { return _sensDot[idx].volume.data(); }
+	inline double const* primaryCoordinates() const CADET_NOEXCEPT { return _axialCoords.data(); }
+	inline double const* secondaryCoordinates() const CADET_NOEXCEPT { return _radialCoords.data(); }
+	inline double const* particleCoordinates() const CADET_NOEXCEPT { return _particleCoords.data(); }
 protected:
 
 	struct Storage
@@ -1181,6 +1189,11 @@ public:
 	inline InternalStorageUnitOpRecorder* recorder(unsigned int idx) CADET_NOEXCEPT { return _recorders[idx]; }
 	inline InternalStorageUnitOpRecorder* recorder(unsigned int idx) const CADET_NOEXCEPT { return _recorders[idx]; }
 
+	inline int nUnitOperations() CADET_NOEXCEPT
+	{
+		return _recorders.size();
+	}
+	
 	inline InternalStorageUnitOpRecorder* unitOperation(UnitOpIdx idx) CADET_NOEXCEPT
 	{
 		for (InternalStorageUnitOpRecorder* rec : _recorders)
@@ -1208,6 +1221,7 @@ public:
 	}
 
 	inline double const* time() const CADET_NOEXCEPT { return _time.data(); }
+	inline unsigned int numSensitivites() const CADET_NOEXCEPT { return _numSens; }
 
 protected:
 

--- a/src/libcadet/VersionInfo.cpp.in
+++ b/src/libcadet/VersionInfo.cpp.in
@@ -23,6 +23,7 @@ namespace cadet
 	const char COMPILER[] = "@CMAKE_CXX_COMPILER_ID@ @CMAKE_CXX_COMPILER_VERSION@";
 	const char BUILD_HOST[] = "@CMAKE_SYSTEM@";
 	const char COMPILER_FLAGS[] = "@CMAKE_CXX_FLAGS@";
+	const char LATEST_CAPI_VERSION[] = "1.0.0";
 
 	const char* getLibraryVersion() CADET_NOEXCEPT
 	{
@@ -62,6 +63,11 @@ namespace cadet
 	const char* getLibraryBuildHost() CADET_NOEXCEPT
 	{
 		return cadet::BUILD_HOST;
+	}
+
+	const char* getLatestCAPIVersion() CADET_NOEXCEPT
+	{
+		return cadet::LATEST_CAPI_VERSION;
 	}
 }
 
@@ -106,5 +112,10 @@ extern "C"
 	CADET_API const char* cdtGetLibraryBuildHost()
 	{
 		return cadet::getLibraryBuildHost();
+	}
+
+	CADET_API const char* cdtGetLatestCAPIVersion()
+	{
+		return cadet::getLatestCAPIVersion();
 	}
 }

--- a/src/libcadet/model/LumpedRateModelWithPores.hpp
+++ b/src/libcadet/model/LumpedRateModelWithPores.hpp
@@ -427,11 +427,7 @@ protected:
 			return _disc.nCol;
 		}
 		virtual int writeSecondaryCoordinates(double* coords) const { return 0; }
-		virtual int writeParticleCoordinates(unsigned int parType, double* coords) const
-		{
-			coords[0] = static_cast<double>(_model._parRadius[parType]) * 0.5;
-			return 1;
-		}
+		virtual int writeParticleCoordinates(unsigned int parType, double* coords) const { return 0; }
 
 	protected:
 		const Discretization& _disc;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -122,10 +122,11 @@ endforeach()
 
 # ---------------------------------------------------
 
-if (WIN32)
-	add_executable(testCAPIv1 "${CMAKE_CURRENT_BINARY_DIR}/Paths_$<CONFIG>.cpp" testCAPIv1.cpp)
-	target_include_directories(testCAPIv1 PRIVATE ${CMAKE_SOURCE_DIR}/include ${CMAKE_SOURCE_DIR}/ThirdParty/json)
-endif()
+add_executable(testCAPIv1 "${CMAKE_CURRENT_BINARY_DIR}/Paths_$<CONFIG>.cpp" testCAPIv1.cpp)
+target_include_directories(testCAPIv1 PRIVATE ${CMAKE_SOURCE_DIR}/include ${CMAKE_SOURCE_DIR}/ThirdParty/json)
+
+# Set C++ standard for the target
+target_compile_features(testCAPIv1 PRIVATE cxx_std_23)
 
 # ---------------------------------------------------
 


### PR DESCRIPTION
Since PR #59 was closed prematurely, this is a continuation.

Original description:
Adds a simple C interface to libcadet. The parameter provider interface
is realized by callback functions. A simulation can be performed and
the solution at the outlet of the unit operations can be queried.

Also includes a test application that dynamically loads the library at
runtime (only Windows) and executes a simulation specified in JSON
format internally.

This commit provides the first steps regarding #16 and, thus, #12.

To do:
- [x] Inlet
- [x] Outlet
- [x] Bulk
- [x] Particle
- [x] Solid
- [x] Flux
- [x] Volume
- [x] InletDot
- [x] OutletDot
- [x] BulkDot
- [x] ParticleDot
- [x] SolidDot
- [x] FluxDot
- [x] VolumeDot
- [x] InletSens
- [x] OutletSens
- [x] BulkSens
- [x] ParticleSens
- [x] SolidSens
- [x] FluxSens
- [x] InletDotSens
- [x] OutletDotSens
- [x] BulkDotSens
- [x] ParticleDotSens
- [x] SolidDotSens
- [x] FluxDotSens
- [x] VolumeDotSens
- [x] LastState
- [x] LastStateTimeDot
- [x] LastUnitState
- [x] LastUnitStateDot
- [x] LastSensitivityState
- [x] LastSensitivityStateDot
- [x] LastSensitivityUnitState
- [x] LastSensitivityUnitStateDot
- [x] Coordinates
- [x] SolutionTimes
- [x] getNumUnits
- [x] Simulation runtime (`/meta/time_sim`)
- [x] `/meta/file_format`

---

Moreover, some things are still unclear / inconsitent and will be addressed later, see #283 

