### PR TITLE
Add organic modifier LangmuirLDF binding

### DIFF
--- a/src/libcadet/model/binding/LangmuirLDFBinding.cpp
+++ b/src/libcadet/model/binding/LangmuirLDFBinding.cpp
@@ -187,7 +187,7 @@ namespace cadet
 						continue;
 
 					// Residual
-					res[bndIdx] = static_cast<ParamType>(p->kkin[i]) * (y[bndIdx] - static_cast<ParamType>(p->keq[i]) * exp(-static_cast<ParamType>(p->SolSA[i] * yCp[0])) * yCp[i] / cpSum);
+					res[bndIdx] = static_cast<ParamType>(p->kkin[i]) * (y[bndIdx] - static_cast<ParamType>(p->keq[i]) * exp(-static_cast<ParamType>(p->SolSA[i]) * yCp[0]) * yCp[i] / cpSum);
 
 					// Next bound component
 					++bndIdx;

--- a/src/libcadet/model/binding/LangmuirLDFBinding.cpp
+++ b/src/libcadet/model/binding/LangmuirLDFBinding.cpp
@@ -1,7 +1,7 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2022: The CADET Authors
+//  Copyright © 2008-2024: The CADET Authors
 //            Please see the AUTHORS and CONTRIBUTORS file.
 //  
 //  All rights reserved. This program and the accompanying materials
@@ -18,6 +18,7 @@
 #include "LocalVector.hpp"
 #include "SimulationTypes.hpp"
 
+#include <cmath>
 #include <functional>
 #include <unordered_map>
 #include <string>
@@ -29,11 +30,11 @@
 	"externalName": "ExtLangmuirLDFParamHandler",
 	"parameters":
 		[
-			{ "type": "ScalarComponentDependentParameter", "varName": "keq", "confName": "KEQ"},
-			{ "type": "ScalarComponentDependentParameter", "varName": "kkin", "confName": "KKIN"},
-			{ "type": "ScalarComponentDependentParameter", "varName": "qMax", "confName": "QMAX"},
-			{ "type": "ScalarComponentDependentParameter", "varName": "SolSA", "confName": "SOLSA"},
-			{ "type": "ScalarComponentDependentParameter", "varName": "SolSB", "confName": "SOLSB"}
+			{ "type": "ScalarComponentDependentParameter", "varName": "keq", "confName": "MCLLDF_KEQ"},
+			{ "type": "ScalarComponentDependentParameter", "varName": "kkin", "confName": "MCLLDF_KKIN"},
+			{ "type": "ScalarComponentDependentParameter", "varName": "qMax", "confName": "MCLLDF_QMAX"},
+			{ "type": "ScalarComponentDependentParameter", "varName": "SolSA", "confName": "MCLLDF_SOLSA"},
+			{ "type": "ScalarComponentDependentParameter", "varName": "SolSB", "confName": "MCLLDF_SOLSB"}
 		]
 }
 </codegen>*/
@@ -50,241 +51,231 @@
  q = keq * exp(-solsa * phi) * C_p/(1 + keq/qmax * exp(-solsb * phi) Cp)
 */
 
-
 namespace cadet
 {
 
-namespace model
-{
-
-inline const char* LangmuirLDFParamHandler::identifier() CADET_NOEXCEPT { return "MULTI_COMPONENT_LANGMUIR_LDF"; }
-
-inline bool LangmuirLDFParamHandler::validateConfig(unsigned int nComp, unsigned int const* nBoundStates)
-{
-	if ((_keq.size() != _kkin.size()) || (_keq.size() != _qMax.size()) || (_keq.size() < nComp))
-		throw InvalidParameterException("MCLLDF_KEQ, MCLLDF_KKIN, and MCLLDF_QMAX have to have the same size");
-
-	return true;
-}
-
-inline const char* ExtLangmuirLDFParamHandler::identifier() CADET_NOEXCEPT { return "EXT_MULTI_COMPONENT_LANGMUIR_LDF"; }
-
-inline bool ExtLangmuirLDFParamHandler::validateConfig(unsigned int nComp, unsigned int const* nBoundStates)
-{
-	if ((_keq.size() != _kkin.size()) || (_keq.size() != _qMax.size()) || (_keq.size() < nComp))
-		throw InvalidParameterException("EXT_MCLLDF_KEQ, EXT_MCLLDF_KKIN, and EXT_MCLLDF_QMAX have to have the same size");
-
-	return true;
-}
-
-
-/**
- * @brief Defines the multi component Langmuir binding model
- * @details Implements the Langmuir adsorption model: \f[ \begin{align} 
- *              \frac{\mathrm{d}q_i}{\mathrm{d}t} &= k_{a,i} c_{p,i} q_{\text{max},i} \left( 1 - \sum_j \frac{q_j}{q_{\text{max},j}} \right) - k_{d,i} q_i
- *          \end{align} \f]
- *          Multiple bound states are not supported. 
- *          Components without bound state (i.e., non-binding components) are supported.
- *          
- *          See @cite Langmuir1916.
- * @tparam ParamHandler_t Type that can add support for external function dependence
- */
-template <class ParamHandler_t>
-class LangmuirLDFBindingBase : public ParamHandlerBindingModelBase<ParamHandler_t>
-{
-public:
-
-	LangmuirLDFBindingBase() { }
-	virtual ~LangmuirLDFBindingBase() CADET_NOEXCEPT { }
-
-	static const char* identifier() { return ParamHandler_t::identifier(); }
-
-	virtual bool implementsAnalyticJacobian() const CADET_NOEXCEPT { return true; }
-
-	/*virtual void timeDerivativeQuasiStationaryFluxes(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* yCp, double const* y, double* dResDt, LinearBufferAllocator workSpace) const
+	namespace model
 	{
-		if (!this->hasQuasiStationaryReactions())
-			return;
 
-		if (!ParamHandler_t::dependsOnTime())
-			return;
+		inline const char* LangmuirLDFParamHandler::identifier() CADET_NOEXCEPT { return "MULTI_COMPONENT_LANGMUIR_LDF"; }
 
-		// Update external function and compute time derivative of parameters
-		typename ParamHandler_t::ParamsHandle p;
-		typename ParamHandler_t::ParamsHandle dpDt;
-		std::tie(p, dpDt) = _paramHandler.updateTimeDerivative(t, secIdx, colPos, _nComp, _nBoundStates, workSpace);
-
-		// Protein fluxes: k_{kin,i}q_i - k_{kin,i} \frac{q_{m,i}k_{eq,i}c_i}{1+\sum_{j=1}^{n_{comp}} k_{eq,j}c_j}
-		double cpSum = 1.0;
-		double cpSumT = 0.0;
-		unsigned int bndIdx = 0;
-		for (int i = 0; i < _nComp; ++i)
+		inline bool LangmuirLDFParamHandler::validateConfig(unsigned int nComp, unsigned int const* nBoundStates)
 		{
-			// Skip components without bound states (bound state index bndIdx is not advanced)
-			if (_nBoundStates[i] == 0)
-				continue;
+			if ((_keq.size() != _kkin.size()) || (_keq.size() != _qMax.size()) || (_keq.size() < nComp))
+				throw InvalidParameterException("MCLLDF_KEQ, MCLLDF_KKIN, and MCLLDF_QMAX have to have the same size");
 
-			const double summand = y[bndIdx] / static_cast<double>(p->qMax[i]);
-			cpSum -= summand;
-			cpSumT += summand / static_cast<double>(p->qMax[i]) * static_cast<double>(dpDt->qMax[i]);
-
-			// Next bound component
-			++bndIdx;
+			return true;
 		}
 
-		bndIdx = 0;
-		for (int i = 0; i < _nComp; ++i)
+		inline const char* ExtLangmuirLDFParamHandler::identifier() CADET_NOEXCEPT { return "EXT_MULTI_COMPONENT_LANGMUIR_LDF"; }
+
+		inline bool ExtLangmuirLDFParamHandler::validateConfig(unsigned int nComp, unsigned int const* nBoundStates)
 		{
-			// Skip components without bound states (bound state index bndIdx is not advanced)
-			if (_nBoundStates[i] == 0)
-				continue;
+			if ((_keq.size() != _kkin.size()) || (_keq.size() != _qMax.size()) || (_keq.size() < nComp))
+				throw InvalidParameterException("EXT_MCLLDF_KEQ, EXT_MCLLDF_KKIN, and EXT_MCLLDF_QMAX have to have the same size");
 
-			// Residual
-			dResDt[bndIdx] = static_cast<double>(dpDt->kD[i]) * y[bndIdx] 
-				- yCp[i] * (static_cast<double>(dpDt->kA[i]) * static_cast<double>(p->qMax[i]) * cpSum
-				           + static_cast<double>(p->kA[i]) * static_cast<double>(dpDt->qMax[i]) * cpSum
-				           + static_cast<double>(p->kA[i]) * static_cast<double>(p->qMax[i]) * cpSumT);
-
-			// Next bound component
-			++bndIdx;
-		}
-	}*/
-
-	CADET_BINDINGMODELBASE_BOILERPLATE
-
-protected:
-	using ParamHandlerBindingModelBase<ParamHandler_t>::_paramHandler;
-	using ParamHandlerBindingModelBase<ParamHandler_t>::_reactionQuasistationarity;
-	using ParamHandlerBindingModelBase<ParamHandler_t>::_nComp;
-	using ParamHandlerBindingModelBase<ParamHandler_t>::_nBoundStates;
-
-	template <typename StateType, typename CpStateType, typename ResidualType, typename ParamType>
-	int fluxImpl(double t, unsigned int secIdx, const ColumnPosition& colPos, StateType const* y,
-		CpStateType const* yCp, ResidualType* res, LinearBufferAllocator workSpace) const
-	{
-		typename ParamHandler_t::ParamsHandle const p = _paramHandler.update(t, secIdx, colPos, _nComp, _nBoundStates, workSpace);
-
-		// Protein fluxes: k_{kin,i}q_i - k_{kin,i} \frac{q_{m,i}k_{eq,i}c_i}{1+\sum_{j=1}^{n_{comp}} k_{eq,j}c_j}
-		ResidualType cpSum = 1.0;
-		unsigned int bndIdx = 0;
-		for (int i = 0; i < _nComp; ++i)
-		{
-			// Skip components without bound states (bound state index bndIdx is not advanced)
-			if (_nBoundStates[i] == 0)
-				continue;
-
-			cpSum += yCp[i] * static_cast<ParamType>(p->keq[i]) * exp(-static_cast<ParamType>(p->SolSB[i]) * yCp[0]) / static_cast<ParamType>(p->qMax[i]);
-
-			// Next bound component
-			++bndIdx;
+			return true;
 		}
 
-		bndIdx = 0;
-		for (int i = 0; i < _nComp; ++i)
+
+		/**
+		 * @brief Defines the multi component Langmuir binding model
+		 * @details Implements the Langmuir adsorption model: \f[ \begin{align}
+		 *              \frac{\mathrm{d}q_i}{\mathrm{d}t} &= k_{a,i} c_{p,i} q_{\text{max},i} \left( 1 - \sum_j \frac{q_j}{q_{\text{max},j}} \right) - k_{d,i} q_i
+		 *          \end{align} \f]
+		 *          Multiple bound states are not supported.
+		 *          Components without bound state (i.e., non-binding components) are supported.
+		 *
+		 *          See @cite Langmuir1916.
+		 * @tparam ParamHandler_t Type that can add support for external function dependence
+		 */
+		template <class ParamHandler_t>
+		class LangmuirLDFBindingBase : public ParamHandlerBindingModelBase<ParamHandler_t>
 		{
-			// Skip components without bound states (bound state index bndIdx is not advanced)
-			if (_nBoundStates[i] == 0)
-				continue;
+		public:
 
-			// Residual
-			res[bndIdx] = static_cast<ParamType>(p->kkin[i]) * (y[bndIdx] - static_cast<ParamType>(p->keq[i]) * exp(-static_cast<ParamType>(p->SolSA[i] * yCp[0])) * yCp[i] / cpSum);
+			LangmuirLDFBindingBase() { }
+			virtual ~LangmuirLDFBindingBase() CADET_NOEXCEPT { }
 
-			// Next bound component
-			++bndIdx;
-		}
+			static const char* identifier() { return ParamHandler_t::identifier(); }
 
-		return 0;
-	}
+			virtual bool implementsAnalyticJacobian() const CADET_NOEXCEPT { return true; }
 
-	template <typename RowIterator>
-	void jacobianImpl(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double const* yCp, int offsetCp, RowIterator jac, LinearBufferAllocator workSpace) const
-	{
-		typename ParamHandler_t::ParamsHandle const p = _paramHandler.update(t, secIdx, colPos, _nComp, _nBoundStates, workSpace);
-
-		// Protein fluxes: k_{kin,i}q_i - k_{kin,i} \frac{q_{m,i}k_{eq,i}c_i}{1+\sum_{j=1}^{n_{comp}} k_{eq,j}c_j}
-		double cpSum = 0.0;
-		int bndIdx = 0;
-		for (int i = 0; i < _nComp; ++i)
-		{
-			// Skip components without bound states (bound state index bndIdx is not advanced)
-			if (_nBoundStates[i] == 0)
-				continue;
-
-			const double keq = static_cast<double>(p->keq[i]);
-			const double qMax = static_cast<double>(p->qMax[i]);
-			const double kkin = static_cast<double>(p->kkin[i]);
-			const double solsa = static_cast<double>(p->SolSA[i]);
-			const double solsb = static_cast<double>(p->SolSB[i]);
-
-			cpSum += yCp[i] * keq + qMax * exp(solsb * yCp[0]);
-
-			// Next bound component
-			++bndIdx;
-		}
-
-		bndIdx = 0;
-		for (int i = 0; i < _nComp; ++i)
-		{
-			// Skip components without bound states (bound state index bndIdx is not advanced)
-			if (_nBoundStates[i] == 0)
-				continue;
-
-			const double keq = static_cast<double>(p->keq[i]);
-			const double qMax = static_cast<double>(p->qMax[i]);
-			const double kkin = static_cast<double>(p->kkin[i]);
-			const double solsa = static_cast<double>(p->SolSA[i]);
-			const double solsb = static_cast<double>(p->SolSB[i]);
-
-			//(keq *keq *static_cast<double>(p->qMax[i]) * yCp[i] / (cpSum*cpSum))
-			// dres_i / dc_{p,i}
-			jac[i - bndIdx - offsetCp] = -kkin * keq * qMax * exp((-solsa + solsb) * yCp[0]) / cpSum;
-			// Getting to c_{p,i}: -bndIdx takes us to q_0, another -offsetCp to c_{p,0} and a +i to c_{p,i}.
-			//                     This means jac[i - bndIdx - offsetCp] corresponds to c_{p,i}.
-
-			// Fill dres_i / dc_j
-
-			int bndIdx2 = 0;
-			for (int j = 0; j < _nComp; ++j)
+			/*virtual void timeDerivativeQuasiStationaryFluxes(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* yCp, double const* y, double* dResDt, LinearBufferAllocator workSpace) const
 			{
-				// Skip components without bound states (bound state index bndIdx is not advanced)
-				if (_nBoundStates[j] == 0)
-					continue;
-				const double keq = static_cast<double>(p->keq[j]);
-				const double qMax = static_cast<double>(p->qMax[j]);
-				const double kkin = static_cast<double>(p->kkin[j]);
-				const double solsa = static_cast<double>(p->SolSA[j]);
-				const double solsb = static_cast<double>(p->SolSB[j]);
-				// dres_i / dc_j
-				jac[j - bndIdx - offsetCp] += pow(keq, 2.0) * kkin * qMax * yCp[j] * exp((-solsa + solsb) * yCp[0]) / pow(cpSum, 2.0);
-				// Getting to c_{p,j}: -bndIdx takes us to q_0, another -offsetCp to c_{p,0} and a +j to c_{p,j}.
-				//                     This means jac[j - bndIdx - offsetCp] corresponds to c_{p,j}.
+				if (!this->hasQuasiStationaryReactions())
+					return;
 
+				if (!ParamHandler_t::dependsOnTime())
+					return;
 
-				++bndIdx2;
+				// Update external function and compute time derivative of parameters
+				typename ParamHandler_t::ParamsHandle p;
+				typename ParamHandler_t::ParamsHandle dpDt;
+				std::tie(p, dpDt) = _paramHandler.updateTimeDerivative(t, secIdx, colPos, _nComp, _nBoundStates, workSpace);
+
+				// Protein fluxes: k_{kin,i}q_i - k_{kin,i} \frac{q_{m,i}k_{eq,i}c_i}{1+\sum_{j=1}^{n_{comp}} k_{eq,j}c_j}
+				double cpSum = 1.0;
+				double cpSumT = 0.0;
+				unsigned int bndIdx = 0;
+				for (int i = 0; i < _nComp; ++i)
+				{
+					// Skip components without bound states (bound state index bndIdx is not advanced)
+					if (_nBoundStates[i] == 0)
+						continue;
+
+					const double summand = y[bndIdx] / static_cast<double>(p->qMax[i]);
+					cpSum -= summand;
+					cpSumT += summand / static_cast<double>(p->qMax[i]) * static_cast<double>(dpDt->qMax[i]);
+
+					// Next bound component
+					++bndIdx;
+				}
+
+				bndIdx = 0;
+				for (int i = 0; i < _nComp; ++i)
+				{
+					// Skip components without bound states (bound state index bndIdx is not advanced)
+					if (_nBoundStates[i] == 0)
+						continue;
+
+					// Residual
+					dResDt[bndIdx] = static_cast<double>(dpDt->kD[i]) * y[bndIdx]
+						- yCp[i] * (static_cast<double>(dpDt->kA[i]) * static_cast<double>(p->qMax[i]) * cpSum
+								   + static_cast<double>(p->kA[i]) * static_cast<double>(dpDt->qMax[i]) * cpSum
+								   + static_cast<double>(p->kA[i]) * static_cast<double>(p->qMax[i]) * cpSumT);
+
+					// Next bound component
+					++bndIdx;
+				}
+			}*/
+
+			CADET_BINDINGMODELBASE_BOILERPLATE
+
+		protected:
+			using ParamHandlerBindingModelBase<ParamHandler_t>::_paramHandler;
+			using ParamHandlerBindingModelBase<ParamHandler_t>::_reactionQuasistationarity;
+			using ParamHandlerBindingModelBase<ParamHandler_t>::_nComp;
+			using ParamHandlerBindingModelBase<ParamHandler_t>::_nBoundStates;
+
+			template <typename StateType, typename CpStateType, typename ResidualType, typename ParamType>
+			int fluxImpl(double t, unsigned int secIdx, const ColumnPosition& colPos, StateType const* y,
+				CpStateType const* yCp, ResidualType* res, LinearBufferAllocator workSpace) const
+			{
+				typename ParamHandler_t::ParamsHandle const p = _paramHandler.update(t, secIdx, colPos, _nComp, _nBoundStates, workSpace);
+
+				// Protein fluxes: k_{kin,i}q_i - k_{kin,i} \frac{q_{m,i}k_{eq,i}c_i}{1+\sum_{j=1}^{n_{comp}} k_{eq,j}c_j}
+				ResidualType cpSum = 1.0;
+				unsigned int bndIdx = 0;
+				for (int i = 0; i < _nComp; ++i)
+				{
+					// Skip components without bound states (bound state index bndIdx is not advanced)
+					if (_nBoundStates[i] == 0)
+						continue;
+
+					cpSum += yCp[i] * static_cast<ParamType>(p->keq[i]) * exp(-static_cast<ParamType>(p->SolSB[i]) * yCp[0]) / static_cast<ParamType>(p->qMax[i]);
+
+					// Next bound component
+					++bndIdx;
+				}
+
+				bndIdx = 0;
+				for (int i = 0; i < _nComp; ++i)
+				{
+					// Skip components without bound states (bound state index bndIdx is not advanced)
+					if (_nBoundStates[i] == 0)
+						continue;
+
+					// Residual
+					res[bndIdx] = static_cast<ParamType>(p->kkin[i]) * (y[bndIdx] - static_cast<ParamType>(p->keq[i]) * exp(-static_cast<ParamType>(p->SolSA[i] * yCp[0])) * yCp[i] / cpSum);
+
+					// Next bound component
+					++bndIdx;
+				}
+
+				return 0;
 			}
 
-			// Add to dres_i / dq_i
-			jac[0] += static_cast<double>(p->kkin[i]);
+			template <typename RowIterator>
+			void jacobianImpl(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double const* yCp, int offsetCp, RowIterator jac, LinearBufferAllocator workSpace) const
+			{
+				typename ParamHandler_t::ParamsHandle const p = _paramHandler.update(t, secIdx, colPos, _nComp, _nBoundStates, workSpace);
 
-			// Advance to next flux and Jacobian row
-			++bndIdx;
-			++jac;
-		}
-	}
-};
+				// Protein fluxes: k_{kin,i}q_i - k_{kin,i} \frac{q_{m,i}k_{eq,i}c_i}{1+\sum_{j=1}^{n_{comp}} k_{eq,j}c_j}
+				double cpSum = 1.0;
+				int bndIdx = 0;
+				for (int i = 0; i < _nComp; ++i)
+				{
+					// Skip components without bound states (bound state index bndIdx is not advanced)
+					if (_nBoundStates[i] == 0)
+						continue;
 
-typedef LangmuirLDFBindingBase<LangmuirLDFParamHandler> LangmuirLDFBinding;
-typedef LangmuirLDFBindingBase<ExtLangmuirLDFParamHandler> ExternalLangmuirLDFBinding;
+					const double keq = static_cast<double>(p->keq[i]);
+					const double qMax = static_cast<double>(p->qMax[i]);
+					const double kkin = static_cast<double>(p->kkin[i]);
+					const double solsa = static_cast<double>(p->SolSA[i]);
+					const double solsb = static_cast<double>(p->SolSB[i]);
 
-namespace binding
-{
-	void registerLangmuirLDFModel(std::unordered_map<std::string, std::function<model::IBindingModel* ()>>& bindings)
-	{
-		bindings[LangmuirLDFBinding::identifier()] = []() { return new LangmuirLDFBinding(); };
-		bindings[ExternalLangmuirLDFBinding::identifier()] = []() { return new ExternalLangmuirLDFBinding(); };
-	}
-}  // namespace binding
+					cpSum += yCp[i] * static_cast<double>(p->keq[i]) * exp(-static_cast<double>(p->SolSB[i]) * yCp[0]) / static_cast<double>(p->qMax[i]);
 
-}  // namespace model
+					// Next bound component
+					++bndIdx;
+				}
+
+				bndIdx = 0;
+				for (int i = 0; i < _nComp; ++i)
+				{
+					// Skip components without bound states (bound state index bndIdx is not advanced)
+					if (_nBoundStates[i] == 0)
+						continue;
+
+					//(keq *keq *static_cast<double>(p->qMax[i]) * yCp[i] / (cpSum*cpSum))
+					// dres_i / dc_{p,i}
+					jac[i - bndIdx - offsetCp] = -static_cast<double>(p->kkin[i]) * static_cast<double>(p->keq[i]) * exp(-static_cast<double>(p->SolSA[i]) * yCp[0]) / cpSum;
+					// Getting to c_{p,i}: -bndIdx takes us to q_0, another -offsetCp to c_{p,0} and a +i to c_{p,i}.
+					//                     This means jac[i - bndIdx - offsetCp] corresponds to c_{p,i}.
+
+					// Fill dres_i / dc_j
+					const double commonFactor = static_cast<double>(p->keq[i]) * static_cast<double>(p->kkin[i]) * yCp[i] * exp(-static_cast<double>(p->SolSA[i]) * yCp[0]) / (cpSum * cpSum);
+
+					int bndIdx2 = 0;
+					for (int j = 0; j < _nComp; ++j)
+					{
+						// Skip components without bound states (bound state index bndIdx is not advanced)
+						if (_nBoundStates[j] == 0)
+							continue;
+
+						// dres_i / dc_j
+						jac[j - bndIdx - offsetCp] += static_cast<double>(p->keq[j]) * exp(-static_cast<double>(p->SolSB[j]) * yCp[0]) / static_cast<double>(p->qMax[j]) * commonFactor;
+						// Getting to c_{p,j}: -bndIdx takes us to q_0, another -offsetCp to c_{p,0} and a +j to c_{p,j}.
+						//                     This means jac[j - bndIdx - offsetCp] corresponds to c_{p,j}.
+
+
+						++bndIdx2;
+					}
+
+					// Add to dres_i / dq_i
+					jac[0] += static_cast<double>(p->kkin[i]);
+
+					// Advance to next flux and Jacobian row
+					++bndIdx;
+					++jac;
+				}
+			}
+		};
+
+		typedef LangmuirLDFBindingBase<LangmuirLDFParamHandler> LangmuirLDFBinding;
+		typedef LangmuirLDFBindingBase<ExtLangmuirLDFParamHandler> ExternalLangmuirLDFBinding;
+
+		namespace binding
+		{
+			void registerLangmuirLDFModel(std::unordered_map<std::string, std::function<model::IBindingModel* ()>>& bindings)
+			{
+				bindings[LangmuirLDFBinding::identifier()] = []() { return new LangmuirLDFBinding(); };
+				bindings[ExternalLangmuirLDFBinding::identifier()] = []() { return new ExternalLangmuirLDFBinding(); };
+			}
+		}  // namespace binding
+
+	}  // namespace model
 
 }  // namespace cadet


### PR DESCRIPTION
A slightly transformed equilibrium approach to the Langmuir isotherm that accounts for gradient conditions. When disabling kinetics IS_KINETIC = 0, kkin has still an impact on the output. 

**Edit:** This PR is a follow-up to a discussion in our [Forum](https://forum.cadet-web.de/t/kinetic-parameter-affects-the-output-while-kinetics-are-desabled/884/9).