### PR TITLE
Remove temporary devguide branch from website

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -46,7 +46,7 @@ source_suffix = {
 # Multiversion
 smv_released_pattern = r'^refs/tags/.*$'    # Tags only
 smv_tag_whitelist = r'^v\d+\.\d+\.\d+$'     # Include tags like "v2.1.1"
-smv_branch_whitelist = r"^(master|chore/developer_guide)$"          # Only use master branch
+smv_branch_whitelist = r"^master$"          # Only use master branch
 smv_remote_whitelist = r"^origin$"          # Use branches from remote origin
 smv_outputdir_format = '{ref.name}'         # Use the branch/tag name
 


### PR DESCRIPTION
Once the devguide has a section on all major topics the dev-guide-branch can be removed from the website as all information is contained within the master branch.