### PR TITLE
Add switch between pH or proton concentration

### DIFF
--- a/src/libcadet/model/binding/ColloidalBinding.cpp
+++ b/src/libcadet/model/binding/ColloidalBinding.cpp
@@ -51,7 +51,8 @@
 	"constantParameters":
 		[
 			{ "type": "ScalarParameter", "varName": "linThreshold", "confName": "COL_LINEAR_THRESHOLD"},
-			{ "type": "ScalarBoolParameter", "varName": "usePh", "confName": "COL_USE_PH"}
+			{ "type": "ScalarBoolParameter", "varName": "includePh", "confName": "COL_INCLUDE_PH"},
+			{ "type": "ScalarBoolParameter", "varName": "useProtonConcentration", "confName": "COL_USE_PROTON_CONCENTRATION"}
 		]
 }
 </codegen>*/
@@ -62,6 +63,8 @@
  kD = Desorption rate
  qMax = Capacity
 */
+
+// TODO: Actually use useProtonConcentration parameter
 
 namespace cadet
 {
@@ -180,10 +183,10 @@ protected:
 		if (_nBoundStates[0] != 0)
 			throw InvalidParameterException("Salt component (index 0) must be non-binding (NBOUND = 0)");
 
-		if (_paramHandler.usePh().get() && (_nComp <= 2))
+		if (_paramHandler.includePh().get() && (_nComp <= 2))
 			throw InvalidParameterException("No protein component present (existing two components are salt and PH)");
 
-		if (_paramHandler.usePh().get())
+		if (_paramHandler.includePh().get())
 		{
 			_startIdx = 2;
 			if (_nBoundStates[1] != 0)

--- a/src/libcadet/model/binding/GeneralizedIonExchangeBinding.cpp
+++ b/src/libcadet/model/binding/GeneralizedIonExchangeBinding.cpp
@@ -50,7 +50,8 @@
 	"constantParameters":
 		[
 			{ "type": "ReferenceConcentrationParameter", "varName": ["refC0", "refQ"], "objName": "refConcentration", "confPrefix": "GIEX_"},
-			{ "type": "ReferenceConcentrationParameter", "varName": ["refPhC0", "refPhQ"], "objName": "refConcentrationPh", "confPrefix": "GIEX_PH", "skipConfig": true}
+			{ "type": "ReferenceConcentrationParameter", "varName": ["refPhC0", "refPhQ"], "objName": "refConcentrationPh", "confPrefix": "GIEX_PH", "skipConfig": true},
+			{ "type": "ScalarBoolParameter", "varName": "useProtonConcentration", "confName": "GIEX_USE_PROTON_CONCENTRATION"}
 		]
 }
 </codegen>*/
@@ -65,6 +66,8 @@
  refC0, refQ = Reference concentrations
  refPhC0,refPhQ = Reference concentrations for pH dependent powers
 */
+
+// TODO: Actually use useProtonConcentration parameter
 
 namespace cadet
 {


### PR DESCRIPTION
For models that include pH effects two use-cases can be interesting:
1. Simulate the proton concentration (H+) as a component
2. Simulate the pH (-log10(H+)) as a component

Option 1 is thermodynamically correct, but could lead to numerical precision problems if a pH of 10-14 is to be simulated as the concentration of H+ would be as low as 1e-14. 
Option 2 leads to incorrect mixing results (a 1:1 mixture of pH 1 and pH 9 is not pH 5 but ~ pH 1.3) but is numerically easier and can still be useful if experiments with a constant pH are simulated.

As the CADET philosophy so far has been to give the user the choice, the suggestion is to add a switch parameter that decides if the model uses proton concentration or pH.

This PR is a starting point for that addition. 

ToDos:
- [ ] Decide on a good parameter name. 
    - [ ] My suggestion is ###_USE_PROTON_CONCENTRATION or ###_CALCULATE_PH_FROM_PROTON_CONCENTRATION for the toggle and ###_INCLUDE_PH_COMPONENT for an optional flag for the models that can be used with or without pH dependence entirely. This is only a first attempt and open to change.
- [ ] Extend the documentation
    - [ ] GIEX
    - [ ] Colloidal
    - [ ] Unified HIC (if merged before this is merged)
- [ ] Extend the flux implementations
    - [ ] GIEX
    - [ ] Colloidal
    - [ ] Unified HIC (if merged before this is merged)
- [ ] Extend the jacobian
    - [ ] GIEX
    - [ ] Colloidal
    - [ ] Unified HIC (if merged before this is merged)