### PR TITLE
Add linearization to Mobile Phase Modulator Langmuir Binding

### DIFF
--- a/src/libcadet/model/binding/MobilePhaseModulatorLangmuirBinding.cpp
+++ b/src/libcadet/model/binding/MobilePhaseModulatorLangmuirBinding.cpp
@@ -237,7 +237,7 @@ protected:
 			const double beta = static_cast<double>(p->beta[i]);
 			const double qMax = static_cast<double>(p->qMax[i]);
 			const double ka = static_cast<double>(p->kA[i]);
-			double kaEGammaC0;
+			double kaEGammaC0 = 1.0;
 			const double kdRaw = static_cast<double>(p->kD[i]);
 
 			if (yCp[0] <= linearThreshold)

--- a/test/BindingModels.cpp
+++ b/test/BindingModels.cpp
@@ -238,7 +238,68 @@ CADET_BINDINGTEST("MULTI_COMPONENT_ANTILANGMUIR", "EXT_MULTI_COMPONENT_ANTILANGM
 	1e-10, 1e-10, CADET_NONBINDING_LIQUIDPHASE_COMP_UNUSED, CADET_COMPARE_BINDING_VS_NONBINDING)
 
 
-CADET_BINDINGTEST("MOBILE_PHASE_MODULATOR", "EXT_MOBILE_PHASE_MODULATOR", (1,1,1), (1,1,0,1), (-1e-11, 1.5, 2.0, 0.5, 1.5, 1.8), (-1e-11, 1.5, 0.0, 2.0, 0.5, 1.5, 1.8), \
+CADET_BINDINGTEST("MOBILE_PHASE_MODULATOR", "EXT_MOBILE_PHASE_MODULATOR", (1,1,1), (1,1,0,1), (1.2, 1.5, 2.0, 0.5, 1.5, 1.8), (1.2, 1.5, 1.0, 2.0, 0.5, 1.5, 1.8), \
+	R"json( "MPM_KA": [0.0, 1.14, 2.0],
+	        "MPM_KD": [0.0, 0.004, 0.008],
+	        "MPM_QMAX": [0.0, 4.88, 3.5],
+	        "MPM_GAMMA": [0.0, 0.5, -1.0],
+	        "MPM_BETA": [0.0, 1.5, 2.0],
+			"MPM_LINEAR_THRESHOLD": 1e-10
+	)json", \
+	R"json( "MPM_KA": [0.0, 1.14, 1.0, 2.0],
+	        "MPM_KD": [0.0, 0.004, 2.0, 0.008],
+	        "MPM_QMAX": [0.0, 4.88, 3.0, 3.5],
+	        "MPM_GAMMA": [0.0, 0.5, 0.0, -1.0],
+	        "MPM_BETA": [0.0, 1.5, 0.0, 2.0],
+			"MPM_LINEAR_THRESHOLD": 1e-10
+	)json", \
+	R"json( "EXT_MPM_KA": [0.0, 0.0, 0.0],
+	        "EXT_MPM_KA_T": [0.0, 1.14, 2.0],
+	        "EXT_MPM_KA_TT": [0.0, 0.0, 0.0],
+	        "EXT_MPM_KA_TTT": [0.0, 0.0, 0.0],
+	        "EXT_MPM_KD": [0.0, 0.0, 0.0],
+	        "EXT_MPM_KD_T": [0.0, 0.004, 0.008],
+	        "EXT_MPM_KD_TT": [0.0, 0.0, 0.0],
+	        "EXT_MPM_KD_TTT": [0.0, 0.0, 0.0],
+	        "EXT_MPM_QMAX": [0.0, 0.0, 0.0],
+	        "EXT_MPM_QMAX_T": [0.0, 4.88, 3.5],
+	        "EXT_MPM_QMAX_TT": [0.0, 0.0, 0.0],
+	        "EXT_MPM_QMAX_TTT": [0.0, 0.0, 0.0],
+	        "EXT_MPM_GAMMA": [0.0, 0.0, 0.0],
+	        "EXT_MPM_GAMMA_T": [0.0, 0.5, -1.0],
+	        "EXT_MPM_GAMMA_TT": [0.0, 0.0, 0.0],
+	        "EXT_MPM_GAMMA_TTT": [0.0, 0.0, 0.0],
+	        "EXT_MPM_BETA": [0.0, 0.0, 0.0],
+	        "EXT_MPM_BETA_T": [0.0, 1.5, 2.0],
+	        "EXT_MPM_BETA_TT": [0.0, 0.0, 0.0],
+	        "EXT_MPM_BETA_TTT": [0.0, 0.0, 0.0],
+			"EXT_MPM_LINEAR_THRESHOLD": 1e-10
+	)json", \
+	R"json( "EXT_MPM_KA": [0.0, 0.0, 0.0, 0.0],
+	        "EXT_MPM_KA_T": [0.0, 1.14, 1.0, 2.0],
+	        "EXT_MPM_KA_TT": [0.0, 0.0, 0.0, 0.0],
+	        "EXT_MPM_KA_TTT": [0.0, 0.0, 0.0, 0.0],
+	        "EXT_MPM_KD": [0.0, 0.0, 0.0, 0.0],
+	        "EXT_MPM_KD_T": [0.0, 0.004, 2.0, 0.008],
+	        "EXT_MPM_KD_TT": [0.0, 0.0, 0.0, 0.0],
+	        "EXT_MPM_KD_TTT": [0.0, 0.0, 0.0, 0.0],
+	        "EXT_MPM_QMAX": [0.0, 0.0, 0.0, 0.0],
+	        "EXT_MPM_QMAX_T": [0.0, 4.88, 3.0, 3.5],
+	        "EXT_MPM_QMAX_TT": [0.0, 0.0, 0.0, 0.0],
+	        "EXT_MPM_QMAX_TTT": [0.0, 0.0, 0.0, 0.0],
+	        "EXT_MPM_GAMMA": [0.0, 0.0, 0.0, 0.0],
+	        "EXT_MPM_GAMMA_T": [0.0, 0.5, 0.0, -1.0],
+	        "EXT_MPM_GAMMA_TT": [0.0, 0.0, 0.0, 0.0],
+	        "EXT_MPM_GAMMA_TTT": [0.0, 0.0, 0.0, 0.0],
+	        "EXT_MPM_BETA": [0.0, 0.0, 0.0, 0.0],
+	        "EXT_MPM_BETA_T": [0.0, 1.5, 0.0, 2.0],
+	        "EXT_MPM_BETA_TT": [0.0, 0.0, 0.0, 0.0],
+	        "EXT_MPM_BETA_TTT": [0.0, 0.0, 0.0, 0.0],
+			"EXT_MPM_LINEAR_THRESHOLD": 1e-10
+	)json", \
+	1e-10, 1e-10, CADET_NONBINDING_LIQUIDPHASE_COMP_UNUSED, CADET_COMPARE_BINDING_VS_NONBINDING)
+	
+	CADET_BINDINGTEST_MULTI("MOBILE_PHASE_MODULATOR", "EXT_MOBILE_PHASE_MODULATOR", "_NEGATIVE", (1, 1, 1), (1, 1, 0, 1), (-1e-11, 1.5, 2.0, 0.5, 1.5, 1.8), (-1e-11, 1.5, 0.5, 2.0, 0.5, 1.5, 1.8), \
 	R"json( "MPM_KA": [0.0, 1.14, 2.0],
 	        "MPM_KD": [0.0, 0.004, 0.008],
 	        "MPM_QMAX": [0.0, 4.88, 3.5],

--- a/test/BindingModels.cpp
+++ b/test/BindingModels.cpp
@@ -238,18 +238,20 @@ CADET_BINDINGTEST("MULTI_COMPONENT_ANTILANGMUIR", "EXT_MULTI_COMPONENT_ANTILANGM
 	1e-10, 1e-10, CADET_NONBINDING_LIQUIDPHASE_COMP_UNUSED, CADET_COMPARE_BINDING_VS_NONBINDING)
 
 
-CADET_BINDINGTEST("MOBILE_PHASE_MODULATOR", "EXT_MOBILE_PHASE_MODULATOR", (1,1,1), (1,1,0,1), (1.2, 1.5, 2.0, 0.5, 1.5, 1.8), (1.2, 1.5, 0.0, 2.0, 0.5, 1.5, 1.8), \
+CADET_BINDINGTEST("MOBILE_PHASE_MODULATOR", "EXT_MOBILE_PHASE_MODULATOR", (1,1,1), (1,1,0,1), (-1e-11, 1.5, 2.0, 0.5, 1.5, 1.8), (-1e-11, 1.5, 0.0, 2.0, 0.5, 1.5, 1.8), \
 	R"json( "MPM_KA": [0.0, 1.14, 2.0],
 	        "MPM_KD": [0.0, 0.004, 0.008],
 	        "MPM_QMAX": [0.0, 4.88, 3.5],
 	        "MPM_GAMMA": [0.0, 0.5, -1.0],
-	        "MPM_BETA": [0.0, 1.5, 2.0]
+	        "MPM_BETA": [0.0, 1.5, 2.0],
+			"MPM_LINEAR_THRESHOLD": 1e-10
 	)json", \
 	R"json( "MPM_KA": [0.0, 1.14, 1.0, 2.0],
 	        "MPM_KD": [0.0, 0.004, 2.0, 0.008],
 	        "MPM_QMAX": [0.0, 4.88, 3.0, 3.5],
 	        "MPM_GAMMA": [0.0, 0.5, 0.0, -1.0],
-	        "MPM_BETA": [0.0, 1.5, 0.0, 2.0]
+	        "MPM_BETA": [0.0, 1.5, 0.0, 2.0],
+			"MPM_LINEAR_THRESHOLD": 1e-10
 	)json", \
 	R"json( "EXT_MPM_KA": [0.0, 0.0, 0.0],
 	        "EXT_MPM_KA_T": [0.0, 1.14, 2.0],
@@ -270,7 +272,8 @@ CADET_BINDINGTEST("MOBILE_PHASE_MODULATOR", "EXT_MOBILE_PHASE_MODULATOR", (1,1,1
 	        "EXT_MPM_BETA": [0.0, 0.0, 0.0],
 	        "EXT_MPM_BETA_T": [0.0, 1.5, 2.0],
 	        "EXT_MPM_BETA_TT": [0.0, 0.0, 0.0],
-	        "EXT_MPM_BETA_TTT": [0.0, 0.0, 0.0]
+	        "EXT_MPM_BETA_TTT": [0.0, 0.0, 0.0],
+			"EXT_MPM_LINEAR_THRESHOLD": 1e-10
 	)json", \
 	R"json( "EXT_MPM_KA": [0.0, 0.0, 0.0, 0.0],
 	        "EXT_MPM_KA_T": [0.0, 1.14, 1.0, 2.0],
@@ -291,7 +294,8 @@ CADET_BINDINGTEST("MOBILE_PHASE_MODULATOR", "EXT_MOBILE_PHASE_MODULATOR", (1,1,1
 	        "EXT_MPM_BETA": [0.0, 0.0, 0.0, 0.0],
 	        "EXT_MPM_BETA_T": [0.0, 1.5, 0.0, 2.0],
 	        "EXT_MPM_BETA_TT": [0.0, 0.0, 0.0, 0.0],
-	        "EXT_MPM_BETA_TTT": [0.0, 0.0, 0.0, 0.0]
+	        "EXT_MPM_BETA_TTT": [0.0, 0.0, 0.0, 0.0],
+			"EXT_MPM_LINEAR_THRESHOLD": 1e-10
 	)json", \
 	1e-10, 1e-10, CADET_NONBINDING_LIQUIDPHASE_COMP_UNUSED, CADET_COMPARE_BINDING_VS_NONBINDING)
 


### PR DESCRIPTION
This PR stabilizes the Mobile Phase Modulator Langmuir Binding for $c_{p,0} <= 0$. 

The isotherm equation:

$$$
    \begin{aligned}
        \frac{\mathrm{d} q_i}{\mathrm{d} t} = k_{a,i} e^{\gamma_i c_{p,0}} c_{p,i} q_{\text{max},i} \left( 1 - \sum_{j=1}^{N_{\text{comp}} - 1} \frac{q_j}{q_{\text{max},j}} \right) - k_{d,i} c_{p,0}^{\beta_i}  q_i && i = 1, \dots, N_{\text{comp}} - 1.
    \end{aligned}
$$$

can be undefined for $c_{p,0} <= 0$ for two reasons:

1. The flux implementation is not defined for $c_{p,0} < 0$ due to $c_{p,0}^{\beta_i}$ if $\beta_i$ is a fraction with an even denominator.
2. For $c_{p,0} == 0$ and $\beta_i < 1.0$ the first derivative is also not defined.

Therefore a Taylor series linearization with respect to $c_{p,0}$ has been introduced around $c_{p,0} <= \epsilon$ where $\epsilon$ is a small number. 

The CADET-core tests failed with the old formulation for $c_{p,0} <= 0$ and now pass. A full simulation where $c_{p,0}$ dips below zero due to oscillations has been performed to confirm that the linarization works.

Once this is merged we can merge https://github.com/fau-advanced-separations/CADET-Process/pull/163.