### PR TITLE
Fix narrowing conversion in LRMP_DG for CADET_PARALLELIZE code block

### DIFF
--- a/src/libcadet/model/GeneralRateModelDG-InitialConditions.cpp
+++ b/src/libcadet/model/GeneralRateModelDG-InitialConditions.cpp
@@ -356,7 +356,7 @@ void GeneralRateModelDG::consistentInitialState(const SimulationTime& simTime, d
 			LinearBufferAllocator tlmAlloc = threadLocalMem.get();
 
 			// Reuse memory of sparse matrix for dense matrix
-			linalg::DenseMatrixView fullJacobianMatrix(_globalJacDisc.valuePtr() + _globalJacDisc.outerIndexPtr()[idxr.offsetCp(ParticleTypeIndex{ type }) + pblk], nullptr, mask.len, mask.len);
+			linalg::DenseMatrixView fullJacobianMatrix(_globalJacDisc.valuePtr() + _globalJacDisc.outerIndexPtr()[idxr.offsetCp(ParticleTypeIndex{ type }, ParticleIndex{ static_cast<unsigned int>(pblk) })], nullptr, mask.len, mask.len);
 
 			// z coordinate (column length normed to 1) of current node - needed in externally dependent adsorption kinetic
 			const double z = _convDispOp.relativeCoordinate(pblk);

--- a/src/libcadet/model/LumpedRateModelWithPoresDG-InitialConditions.cpp
+++ b/src/libcadet/model/LumpedRateModelWithPoresDG-InitialConditions.cpp
@@ -343,7 +343,7 @@ namespace cadet
 					LinearBufferAllocator tlmAlloc = threadLocalMem.get();
 
 					// Reuse memory of band matrix for dense matrix
-					linalg::DenseMatrixView fullJacobianMatrix(_globalJacDisc.valuePtr() + _globalJacDisc.outerIndexPtr()[idxr.offsetCp(ParticleTypeIndex{ type }, ParticleIndex{ pblk }) - idxr.offsetC()], nullptr, mask.len, mask.len);
+					linalg::DenseMatrixView fullJacobianMatrix(_globalJacDisc.valuePtr() + _globalJacDisc.outerIndexPtr()[idxr.offsetCp(ParticleTypeIndex{ type }, ParticleIndex{ static_cast<unsigned int>(pblk) }) - idxr.offsetC()], nullptr, mask.len, mask.len);
 
 					// z coordinate (column length normed to 1) of current node - needed in externally dependent adsorption kinetic
 					const double z = _convDispOp.relativeCoordinate(pblk);


### PR DESCRIPTION
LumpedRateModelWithoutPoresDG-InitialConditions.cpp would not build with multithreading enabled since narrowing conversion from unsigned __int64 to unsigned int requires type casting.

wondering why this doesnt happen for the GRM_DG, i found that theres an offset error when reusing the Jaocbian memory for consistent initialization. This probably doesnt cause any issues but fixed it anyways.