### PR TITLE
Improve compilation speed on MS Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,5 +82,10 @@ compile_commands.json
 
 # Ignore build and install directories
 build
+build_RELEASE
+build_RELEASE_with_Debug_Info
+build_RELEASE_with_Tests
+build_DEBUG
+build_DEBUG_with_Tests
 install
 vcpkg_installed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -463,13 +463,13 @@ if (CMAKE_BUILD_TYPE STREQUAL "Debug")
 	target_compile_options(CADET::CompileOptions INTERFACE $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
 		-Wall -pedantic-errors -Wextra -Wno-unused-parameter -Wno-unused-function> #-Wconversion -Wsign-conversion
 	$<$<CXX_COMPILER_ID:MSVC>:
-		/W4 /wd4100 /bigobj>
+		/W4 /wd4100 /bigobj /MP>
 )
 else()
 	target_compile_options(CADET::CompileOptions INTERFACE $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
 		-Wall -pedantic-errors -Wextra -Wno-unused-parameter -Wno-unused-function> #-Wconversion -Wsign-conversion
 	$<$<CXX_COMPILER_ID:MSVC>:
-		/W4 /wd4100>
+		/W4 /wd4100 /MP>
 )
 endif()
 

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -13,7 +13,7 @@
       "generator": "Visual Studio 17 2022 Win64",
       "configurationType": "Debug",
       "inheritEnvironments": [ "msvc_x64_x64" ],
-      "buildRoot": "${env.BUILDROOT}",
+      "buildRoot": "${env.BUILDROOT}_DEBUG",
       "cmakeCommandArgs": "-DVCPKG_TARGET_TRIPLET=x64-windows-static -DENABLE_STATIC_LINK_LAPACK=ON -DENABLE_STATIC_LINK_DEPS=ON -DENABLE_TESTS=OFF -DENABLE_ANALYTIC_JACOBIAN_CHECK=OFF --fresh",
       "buildCommandArgs": "-m -v:minimal",
       "variables": [
@@ -43,12 +43,13 @@
           "type": "STRING"
         }
       ]
-    },{
+    },
+    {
       "name": "DEBUG_with_Tests",
       "generator": "Visual Studio 17 2022 Win64",
       "configurationType": "Debug",
       "inheritEnvironments": [ "msvc_x64_x64" ],
-      "buildRoot": "${env.BUILDROOT}",
+      "buildRoot": "${env.BUILDROOT}_DEBUG_with_Tests",
       "cmakeCommandArgs": "-DVCPKG_TARGET_TRIPLET=x64-windows-static -DENABLE_STATIC_LINK_LAPACK=ON -DENABLE_STATIC_LINK_DEPS=ON -DENABLE_TESTS=ON -DENABLE_ANALYTIC_JACOBIAN_CHECK=OFF --fresh",
       "buildCommandArgs": "-m -v:minimal",
       "variables": [
@@ -84,7 +85,7 @@
       "generator": "Visual Studio 17 2022 Win64",
       "configurationType": "Release",
       "inheritEnvironments": [ "msvc_x64_x64" ],
-      "buildRoot": "${env.BUILDROOT}",
+      "buildRoot": "${env.BUILDROOT}_RELEASE",
       "cmakeCommandArgs": "-DVCPKG_TARGET_TRIPLET=x64-windows-static -DENABLE_STATIC_LINK_LAPACK=ON -DENABLE_STATIC_LINK_DEPS=ON -DENABLE_TESTS=OFF -DENABLE_ANALYTIC_JACOBIAN_CHECK=OFF --fresh",
       "buildCommandArgs": "-m -v:minimal",
       "variables": [
@@ -120,7 +121,7 @@
       "generator": "Visual Studio 17 2022 Win64",
       "configurationType": "RelWithDebInfo",
       "inheritEnvironments": [ "msvc_x64_x64" ],
-      "buildRoot": "${env.BUILDROOT}",
+      "buildRoot": "${env.BUILDROOT}_RELEASE_with_Debug_Info",
       "cmakeCommandArgs": "-DVCPKG_TARGET_TRIPLET=x64-windows-static -DENABLE_STATIC_LINK_LAPACK=ON -DENABLE_STATIC_LINK_DEPS=ON -DENABLE_TESTS=OFF -DENABLE_ANALYTIC_JACOBIAN_CHECK=OFF --fresh",
       "buildCommandArgs": "-m -v:minimal",
       "variables": [
@@ -156,7 +157,7 @@
       "generator": "Visual Studio 17 2022 Win64",
       "configurationType": "RelWithDebInfo",
       "inheritEnvironments": [ "msvc_x64_x64" ],
-      "buildRoot": "${env.BUILDROOT}",
+      "buildRoot": "${env.BUILDROOT}_RELEASE_with_Tests",
       "cmakeCommandArgs": "-DVCPKG_TARGET_TRIPLET=x64-windows-static -DENABLE_STATIC_LINK_LAPACK=ON -DENABLE_STATIC_LINK_DEPS=ON -DENABLE_TESTS=ON -DENABLE_ANALYTIC_JACOBIAN_CHECK=OFF --fresh",
       "buildCommandArgs": "-m -v:minimal",
       "variables": [


### PR DESCRIPTION
This PR adds two simple changes to improve compilation and development speed on Windows:

1. Add multiprocessing to cadet compilation.
2. Use separate build folders for RELEASE and DEBUG (and all other build types). This allows the build system to fall back onto previously done work when re-compiling cadet after switching the build type.