### PR TITLE
Add option to specify cross section area for 2D-GRM

### DIFF
--- a/doc/interface/unit_operations/2d_general_rate_model.rst
+++ b/doc/interface/unit_operations/2d_general_rate_model.rst
@@ -182,10 +182,20 @@ For information on model equations, refer to :ref:`2d_general_rate_model_model`.
    Column radius
 
    **Unit:** :math:`\mathrm{m}`
-   
+
    ================  ======================  =============
    **Type:** double  **Range:** :math:`> 0`  **Length:** 1
    ================  ======================  =============
+
+``CROSS_SECTION_AREA``
+
+   Cross section area of the column. If `COL_RADIUS` is present, this parameter will be ignored.
+
+   **Unit:** :math:`\mathrm{m}^{2}`
+
+   ================  =====================  =============
+   **Type:** double  **Range:** :math:`>0`  **Length:** 1
+   ================  =====================  =============
    
 ``COL_POROSITY``
 

--- a/doc/interface/unit_operations/2d_general_rate_model.rst
+++ b/doc/interface/unit_operations/2d_general_rate_model.rst
@@ -179,7 +179,7 @@ For information on model equations, refer to :ref:`2d_general_rate_model_model`.
    
 ``COL_RADIUS``
 
-   Column radius
+   Column radius. This parameter is optional if ``CROSS_SECTION_AREA`` is provided.
 
    **Unit:** :math:`\mathrm{m}`
 
@@ -189,7 +189,7 @@ For information on model equations, refer to :ref:`2d_general_rate_model_model`.
 
 ``CROSS_SECTION_AREA``
 
-   Cross section area of the column. If `COL_RADIUS` is present, this parameter will be ignored.
+   Cross section area of the column. This parameter is optional and will be ignored if `COL_RADIUS` is provided.
 
    **Unit:** :math:`\mathrm{m}^{2}`
 

--- a/src/libcadet/model/parts/TwoDimensionalConvectionDispersionOperator.cpp
+++ b/src/libcadet/model/parts/TwoDimensionalConvectionDispersionOperator.cpp
@@ -758,12 +758,15 @@ bool TwoDimensionalConvectionDispersionOperator::configure(UnitOpIdx unitOpIdx, 
     {
         _colRadius = paramProvider.getDouble("COL_RADIUS");
     }
-    else
+    else if(paramProvider.exists("CROSS_SECTION_AREA"))
     {
         const double cross_section_area = paramProvider.getDouble("CROSS_SECTION_AREA");
         const double pi = 3.1415926535897932384626434;
         _colRadius = std::sqrt(cross_section_area / pi);
     }
+	else
+		throw InvalidParameterException("Either COL_RADIUS or CROSS_SECTION_AREA must be provided");
+
 	readScalarParameterOrArray(_colPorosities, paramProvider, "COL_POROSITY", 1);
 
 	if ((_colPorosities.size() != 1) && (_colPorosities.size() != _nRad))

--- a/src/libcadet/model/parts/TwoDimensionalConvectionDispersionOperator.cpp
+++ b/src/libcadet/model/parts/TwoDimensionalConvectionDispersionOperator.cpp
@@ -754,7 +754,16 @@ bool TwoDimensionalConvectionDispersionOperator::configure(UnitOpIdx unitOpIdx, 
 {
 	// Read geometry parameters
 	_colLength = paramProvider.getDouble("COL_LENGTH");
-	_colRadius = paramProvider.getDouble("COL_RADIUS");
+	if (paramProvider.exists("COL_RADIUS"))
+    {
+        _colRadius = paramProvider.getDouble("COL_RADIUS");
+    }
+    else
+    {
+        const double cross_section_area = paramProvider.getDouble("CROSS_SECTION_AREA");
+        const double pi = 3.1415926535897932384626434;
+        _colRadius = std::sqrt(cross_section_area / pi);
+    }
 	readScalarParameterOrArray(_colPorosities, paramProvider, "COL_POROSITY", 1);
 
 	if ((_colPorosities.size() != 1) && (_colPorosities.size() != _nRad))


### PR DESCRIPTION
This PR adds the option to specify the cross section area for the 2D-GRM. If `COL_RADIUS` is given, cross section area will be ignored.

Fixes #270 

Open question: Do we need to add the parameter to the "map"?

e.g.

```
parameters[makeParamId(hashString("COL_LENGTH"), unitOpIdx, CompIndep, ParTypeIndep, BoundStateIndep, ReactionIndep, SectionIndep)] = &_colLength;
```

