### PR TITLE
Update version output from cadet-cli

### DIFF
--- a/include/common/TclapUtils.hpp
+++ b/include/common/TclapUtils.hpp
@@ -36,6 +36,7 @@ namespace TCLAP
 		{
 			std::cout << "This is " << _progName << " version " << cadet::getLibraryVersion() << " (" << cadet::getLibraryBranchRefspec() << " branch)\n";
 			std::cout << "Built from commit " << cadet::getLibraryCommitHash() << "\n";
+			std::cout << "Build variant " << cadet::getLibraryBuildType() << "\n";
 		    std::cout << "CADET homepage: <https://cadet.github.io>\n";
 		    std::cout << "Fork CADET on GitHub: <https://github.com/cadet/CADET-Core>\n";
 		    std::cout << "Report bugs to the issue tracker on GitHub or <cadet@fz-juelich.de>\n";

--- a/include/common/TclapUtils.hpp
+++ b/include/common/TclapUtils.hpp
@@ -36,8 +36,8 @@ namespace TCLAP
 		{
 			std::cout << "This is " << _progName << " version " << cadet::getLibraryVersion() << " (" << cadet::getLibraryBranchRefspec() << " branch)\n";
 			std::cout << "Built from commit " << cadet::getLibraryCommitHash() << "\n";
-		    std::cout << "CADET homepage: <http://www.cadet-web.de>\n";
-		    std::cout << "Fork CADET on GitHub: <https://github.com/modsim/CADET>\n";
+		    std::cout << "CADET homepage: <https://cadet.github.io>\n";
+		    std::cout << "Fork CADET on GitHub: <https://github.com/cadet/CADET-Core>\n";
 		    std::cout << "Report bugs to the issue tracker on GitHub or <cadet@fz-juelich.de>\n";
 			std::cout << "See the accompanying LICENSE.txt, AUTHORS, and CONTRIBUTORS files" << std::endl;
 		}
@@ -60,8 +60,8 @@ namespace TCLAP
 		virtual void version(CmdLineInterface& c)
 		{
 			std::cout << "This is " << _progName << "\n";
-		    std::cout << "CADET homepage: <http://www.cadet-web.de>\n";
-		    std::cout << "Fork CADET on GitHub: <https://github.com/modsim/CADET>\n";
+		    std::cout << "CADET homepage: <https://cadet.github.io>\n";
+		    std::cout << "Fork CADET on GitHub: <https://github.com/cadet/CADET-Core>\n";
 		    std::cout << "Report bugs to the issue tracker on GitHub or <cadet@fz-juelich.de>\n";
 			std::cout << "See the accompanying LICENSE.txt, AUTHORS, and CONTRIBUTORS files" << std::endl;
 		}

--- a/include/common/TclapUtils.hpp
+++ b/include/common/TclapUtils.hpp
@@ -37,9 +37,9 @@ namespace TCLAP
 			std::cout << "This is " << _progName << " version " << cadet::getLibraryVersion() << " (" << cadet::getLibraryBranchRefspec() << " branch)\n";
 			std::cout << "Built from commit " << cadet::getLibraryCommitHash() << "\n";
 			std::cout << "Build variant " << cadet::getLibraryBuildType() << "\n";
-		    std::cout << "CADET homepage: <https://cadet.github.io>\n";
-		    std::cout << "Fork CADET on GitHub: <https://github.com/cadet/CADET-Core>\n";
-		    std::cout << "Report bugs to the issue tracker on GitHub or <cadet@fz-juelich.de>\n";
+			std::cout << "CADET homepage: <https://cadet.github.io>\n";
+			std::cout << "Fork CADET on GitHub: <https://github.com/cadet/CADET-Core>\n";
+			std::cout << "Report bugs to the issue tracker on GitHub or <cadet@fz-juelich.de>\n";
 			std::cout << "See the accompanying LICENSE.txt, AUTHORS, and CONTRIBUTORS files" << std::endl;
 		}
 


### PR DESCRIPTION
- [x] Update links in --version output
- [x] Add build variant to --version output
- [ ] Add option to return full version output in parseable form (json e.g.)