### PR TITLE
Remove years from copyright notice in files

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -45,7 +45,7 @@ By submitting your Contribution via the [Repository](https://github.com/modsim/C
 
 # Liability
 
-Except in cases of willful misconduct or physical damage directly caused to natural persons, the Parties will not be liable for any direct or indirect, material or moral, damages of any kind, arising out of the Licence or of the use of the Material, including, without limitation, damages for loss of goodwill, work stoppage, computer failure or malfunction, loss of data or any commercial damage.
+Except in cases of willful misconduct or physical damage directly caused to natural persons, the Parties will not be liable for any direct or indirect, material or moral, damages of any kind, arising out of the License or of the use of the Material, including, without limitation, damages for loss of goodwill, work stoppage, computer failure or malfunction, loss of data or any commercial damage.
 However, the Licensor will be liable under statutory product liability laws as far such laws apply to the Material.
 
 # Warranty

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,8 @@
 # =============================================================================
 #  CADET
 #  
-#  Copyright © 2008-2022: The CADET Authors
-#            Please see the AUTHORS and CONTRIBUTORS file.
+#  Copyright © The CADET Authors
+#            Please see the CONTRIBUTORS.md file.
 #  
 #  All rights reserved. This program and the accompanying materials
 #  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,3 +1,23 @@
+COPYRIGHT AND LICENSE NOTICE
+
+Copyright © 2008-2024: The CADET Authors, please see the CONTRIBUTORS.md file.
+
+This program is free software: you can redistribute it and/or modify it under the terms of the
+GNU General Public License as published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with this program, see below.
+If not, see <https://www.gnu.org/licenses/>.
+
+Except as contained in this notice, the name of a copyright holder shall not be used in advertising
+or otherwise to promote the sale, use, or other dealings in this Software without prior written
+authorization of the copyright holder.
+
+---
 
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007

--- a/cmake/Modules/FindCADET.cmake
+++ b/cmake/Modules/FindCADET.cmake
@@ -1,8 +1,8 @@
 # =============================================================================
 #  CADET
 #  
-#  Copyright © 2008-2024: The CADET Authors
-#            Please see the AUTHORS and CONTRIBUTORS file.
+#  Copyright © The CADET Authors
+#            Please see the CONTRIBUTORS.md file.
 #  
 #  All rights reserved. This program and the accompanying materials
 #  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/cmake/Modules/FindSUNDIALS.cmake
+++ b/cmake/Modules/FindSUNDIALS.cmake
@@ -1,8 +1,8 @@
 # =============================================================================
 #  CADET
 #  
-#  Copyright © 2008-2024: The CADET Authors
-#            Please see the AUTHORS and CONTRIBUTORS file.
+#  Copyright © The CADET Authors
+#            Please see the CONTRIBUTORS.md file.
 #  
 #  All rights reserved. This program and the accompanying materials
 #  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/cmake/Modules/FindSuperLU.cmake
+++ b/cmake/Modules/FindSuperLU.cmake
@@ -1,8 +1,8 @@
 # =============================================================================
 #  CADET
 #  
-#  Copyright © 2008-2024: The CADET Authors
-#            Please see the AUTHORS and CONTRIBUTORS file.
+#  Copyright © The CADET Authors
+#            Please see the CONTRIBUTORS.md file.
 #  
 #  All rights reserved. This program and the accompanying materials
 #  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/cmake/Modules/FindUMFPACK.cmake
+++ b/cmake/Modules/FindUMFPACK.cmake
@@ -1,8 +1,8 @@
 # =============================================================================
 #  CADET
 #  
-#  Copyright © 2008-2024: The CADET Authors
-#            Please see the AUTHORS and CONTRIBUTORS file.
+#  Copyright © The CADET Authors
+#            Please see the CONTRIBUTORS.md file.
 #  
 #  All rights reserved. This program and the accompanying materials
 #  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/cmake/Modules/MatlabTBBversion.cpp
+++ b/cmake/Modules/MatlabTBBversion.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/doc/developer_guide/TemplateBinding.cpp
+++ b/doc/developer_guide/TemplateBinding.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/include/ad/setfad.hpp
+++ b/include/ad/setfad.hpp
@@ -2,7 +2,7 @@
 //  SETFAD - Simple Expression Template Forward Automatic Differentiation
 //  (Part of SFAD library)
 //  
-//  Copyright © 2015-2024: Samuel Leweke¹
+//  Copyright © Samuel Leweke¹
 //	                                 
 //    ¹ Forschungszentrum Juelich GmbH, IBG-1, Juelich, Germany.
 //  

--- a/include/ad/sfad-common.hpp
+++ b/include/ad/sfad-common.hpp
@@ -1,7 +1,7 @@
 // =============================================================================
 //  SFAD - Simple Forward Automatic Differentiation
 //  
-//  Copyright © 2015-2024: Samuel Leweke¹
+//  Copyright © Samuel Leweke¹
 //                                      
 //    ¹ Forschungszentrum Juelich GmbH, IBG-1, Juelich, Germany.
 //  

--- a/include/ad/sfad.hpp
+++ b/include/ad/sfad.hpp
@@ -1,7 +1,7 @@
 // =============================================================================
 //  SFAD - Simple Forward Automatic Differentiation
 //  
-//  Copyright © 2015-2024: Samuel Leweke¹
+//  Copyright © Samuel Leweke¹
 //                                      
 //    ¹ Forschungszentrum Juelich GmbH, IBG-1, Juelich, Germany.
 //  

--- a/include/cadet/Exceptions.hpp
+++ b/include/cadet/Exceptions.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/include/cadet/ExternalFunction.hpp
+++ b/include/cadet/ExternalFunction.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/include/cadet/FactoryFuncs.hpp
+++ b/include/cadet/FactoryFuncs.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/include/cadet/HashUtil.hpp
+++ b/include/cadet/HashUtil.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/include/cadet/InletProfile.hpp
+++ b/include/cadet/InletProfile.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/include/cadet/LibExportImport.hpp
+++ b/include/cadet/LibExportImport.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/include/cadet/LibVersionInfo.hpp
+++ b/include/cadet/LibVersionInfo.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/include/cadet/Logging.hpp
+++ b/include/cadet/Logging.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/include/cadet/Model.hpp
+++ b/include/cadet/Model.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/include/cadet/ModelBuilder.hpp
+++ b/include/cadet/ModelBuilder.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/include/cadet/ModelSystem.hpp
+++ b/include/cadet/ModelSystem.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/include/cadet/Notification.hpp
+++ b/include/cadet/Notification.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/include/cadet/ParameterId.hpp
+++ b/include/cadet/ParameterId.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/include/cadet/ParameterProvider.hpp
+++ b/include/cadet/ParameterProvider.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/include/cadet/Simulator.hpp
+++ b/include/cadet/Simulator.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/include/cadet/SolutionExporter.hpp
+++ b/include/cadet/SolutionExporter.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/include/cadet/SolutionRecorder.hpp
+++ b/include/cadet/SolutionRecorder.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/include/cadet/StringUtil.hpp
+++ b/include/cadet/StringUtil.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/include/cadet/StrongTypes.hpp
+++ b/include/cadet/StrongTypes.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/include/cadet/cadet.h
+++ b/include/cadet/cadet.h
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET - The Chromatography Analysis and Design Toolkit
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/include/cadet/cadet.hpp
+++ b/include/cadet/cadet.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/include/common/CompilerSpecific.hpp
+++ b/include/common/CompilerSpecific.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/include/common/Driver.hpp
+++ b/include/common/Driver.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/include/common/JsonParameterProvider.hpp
+++ b/include/common/JsonParameterProvider.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/include/common/Logger.hpp
+++ b/include/common/Logger.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/include/common/LoggerBase.hpp
+++ b/include/common/LoggerBase.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/include/common/OrderingConverter.hpp
+++ b/include/common/OrderingConverter.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/include/common/ParameterProviderImpl.hpp
+++ b/include/common/ParameterProviderImpl.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/include/common/SolutionRecorderImpl.hpp
+++ b/include/common/SolutionRecorderImpl.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/include/common/TclapUtils.hpp
+++ b/include/common/TclapUtils.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at
@@ -40,7 +40,7 @@ namespace TCLAP
 			std::cout << "CADET homepage: <https://cadet.github.io>\n";
 			std::cout << "Fork CADET on GitHub: <https://github.com/cadet/CADET-Core>\n";
 			std::cout << "Report bugs to the issue tracker on GitHub or <cadet@fz-juelich.de>\n";
-			std::cout << "See the accompanying LICENSE.txt, AUTHORS, and CONTRIBUTORS files" << std::endl;
+			std::cout << "See the accompanying LICENSE.txt, CONTRIBUTORS.md files" << std::endl;
 		}
 
 	protected:
@@ -64,7 +64,7 @@ namespace TCLAP
 		    std::cout << "CADET homepage: <https://cadet.github.io>\n";
 		    std::cout << "Fork CADET on GitHub: <https://github.com/cadet/CADET-Core>\n";
 		    std::cout << "Report bugs to the issue tracker on GitHub or <cadet@fz-juelich.de>\n";
-			std::cout << "See the accompanying LICENSE.txt, AUTHORS, and CONTRIBUTORS files" << std::endl;
+			std::cout << "See the accompanying LICENSE.txt, CONTRIBUTORS.md files" << std::endl;
 		}
 
 	protected:

--- a/include/common/Timer.hpp
+++ b/include/common/Timer.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/include/io/FileIO.hpp
+++ b/include/io/FileIO.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/include/io/IOException.hpp
+++ b/include/io/IOException.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/include/io/hdf5/HDF5Base.hpp
+++ b/include/io/hdf5/HDF5Base.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/include/io/hdf5/HDF5Reader.hpp
+++ b/include/io/hdf5/HDF5Reader.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/include/io/hdf5/HDF5Writer.hpp
+++ b/include/io/hdf5/HDF5Writer.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/include/io/xml/XMLBase.hpp
+++ b/include/io/xml/XMLBase.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/include/io/xml/XMLReader.hpp
+++ b/include/io/xml/XMLReader.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/include/io/xml/XMLWriter.hpp
+++ b/include/io/xml/XMLWriter.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/build-tools/CMakeLists.txt
+++ b/src/build-tools/CMakeLists.txt
@@ -1,8 +1,8 @@
 # =============================================================================
 #  CADET
 #  
-#  Copyright © 2008-2024: The CADET Authors
-#            Please see the AUTHORS and CONTRIBUTORS file.
+#  Copyright © The CADET Authors
+#            Please see the CONTRIBUTORS.md file.
 #  
 #  All rights reserved. This program and the accompanying materials
 #  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/build-tools/templateCodeGen.cpp
+++ b/src/build-tools/templateCodeGen.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/cadet-cli/CMakeLists.txt
+++ b/src/cadet-cli/CMakeLists.txt
@@ -1,8 +1,8 @@
 # =============================================================================
 #  CADET
 #  
-#  Copyright © 2008-2024: The CADET Authors
-#            Please see the AUTHORS and CONTRIBUTORS file.
+#  Copyright © The CADET Authors
+#            Please see the CONTRIBUTORS.md file.
 #  
 #  All rights reserved. This program and the accompanying materials
 #  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/cadet-cli/Logging.hpp
+++ b/src/cadet-cli/Logging.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/cadet-cli/ProgressBar.cpp
+++ b/src/cadet-cli/ProgressBar.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/cadet-cli/ProgressBar.hpp
+++ b/src/cadet-cli/ProgressBar.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/cadet-cli/SignalHandler.cpp
+++ b/src/cadet-cli/SignalHandler.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/cadet-cli/SignalHandler.hpp
+++ b/src/cadet-cli/SignalHandler.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/cadet-cli/cadet-cli.cpp
+++ b/src/cadet-cli/cadet-cli.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/io/FileIO.cpp
+++ b/src/io/FileIO.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/io/JsonParameterProvider.cpp
+++ b/src/io/JsonParameterProvider.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/AdUtils.cpp
+++ b/src/libcadet/AdUtils.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/AdUtils.hpp
+++ b/src/libcadet/AdUtils.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/AutoDiff.cpp
+++ b/src/libcadet/AutoDiff.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/AutoDiff.hpp
+++ b/src/libcadet/AutoDiff.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/Benchmark.hpp
+++ b/src/libcadet/Benchmark.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/BindingModelFactory.cpp
+++ b/src/libcadet/BindingModelFactory.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/BindingModelFactory.hpp
+++ b/src/libcadet/BindingModelFactory.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/CMakeLists.txt
+++ b/src/libcadet/CMakeLists.txt
@@ -1,8 +1,8 @@
 # =============================================================================
 #  CADET
 #  
-#  Copyright © 2008-2022: The CADET Authors
-#            Please see the AUTHORS and CONTRIBUTORS file.
+#  Copyright © The CADET Authors
+#            Please see the CONTRIBUTORS.md file.
 #  
 #  All rights reserved. This program and the accompanying materials
 #  are made available under the terms of the GNU Public License v3.0 (or, at
@@ -28,8 +28,8 @@ write_compiler_detection_header(
 // =============================================================================\n\
 //  CADET\n\
 //  \n\
-//  Copyright © 2008-2022: The CADET Authors\n\
-//            Please see the AUTHORS and CONTRIBUTORS file.\n\
+//  Copyright © The CADET Authors\n\
+//            Please see the CONTRIBUTORS.md file.\n\
 //  \n\
 //  All rights reserved. This program and the accompanying materials\n\
 //  are made available under the terms of the GNU Public License v3.0 (or, at\n\

--- a/src/libcadet/CompileTimeConfig.hpp.in
+++ b/src/libcadet/CompileTimeConfig.hpp.in
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/ConfigurationHelper.hpp
+++ b/src/libcadet/ConfigurationHelper.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/FactoryFuncs.cpp
+++ b/src/libcadet/FactoryFuncs.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/LapackInterface.hpp
+++ b/src/libcadet/LapackInterface.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/LocalVector.hpp
+++ b/src/libcadet/LocalVector.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/Logging.cpp
+++ b/src/libcadet/Logging.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/Logging.hpp
+++ b/src/libcadet/Logging.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/LoggingUtils.hpp
+++ b/src/libcadet/LoggingUtils.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/MathUtil.hpp
+++ b/src/libcadet/MathUtil.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/Memory.hpp
+++ b/src/libcadet/Memory.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/ModelBuilderImpl.cpp
+++ b/src/libcadet/ModelBuilderImpl.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/ModelBuilderImpl.hpp
+++ b/src/libcadet/ModelBuilderImpl.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/ParallelSupport.hpp
+++ b/src/libcadet/ParallelSupport.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/ParamIdUtil.hpp
+++ b/src/libcadet/ParamIdUtil.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/ParamReaderHelper.hpp
+++ b/src/libcadet/ParamReaderHelper.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/ParamReaderScopes.hpp
+++ b/src/libcadet/ParamReaderScopes.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/ParameterDependenceFactory.cpp
+++ b/src/libcadet/ParameterDependenceFactory.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/ParameterDependenceFactory.hpp
+++ b/src/libcadet/ParameterDependenceFactory.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/ReactionModelFactory.cpp
+++ b/src/libcadet/ReactionModelFactory.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/ReactionModelFactory.hpp
+++ b/src/libcadet/ReactionModelFactory.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/SensParamUtil.hpp
+++ b/src/libcadet/SensParamUtil.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/SimulatableModel.hpp
+++ b/src/libcadet/SimulatableModel.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/SimulationTypes.hpp
+++ b/src/libcadet/SimulationTypes.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/SimulatorImpl.cpp
+++ b/src/libcadet/SimulatorImpl.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/SimulatorImpl.hpp
+++ b/src/libcadet/SimulatorImpl.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/SlicedVector.hpp
+++ b/src/libcadet/SlicedVector.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/Stencil.hpp
+++ b/src/libcadet/Stencil.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/SundialsVector.hpp
+++ b/src/libcadet/SundialsVector.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/VersionInfo.cpp.in
+++ b/src/libcadet/VersionInfo.cpp.in
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/Weno.cpp
+++ b/src/libcadet/Weno.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/Weno.hpp
+++ b/src/libcadet/Weno.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/api/CAPIv1.cpp
+++ b/src/libcadet/api/CAPIv1.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET - The Chromatography Analysis and Design Toolkit
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/graph/GraphAlgos.cpp
+++ b/src/libcadet/graph/GraphAlgos.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/graph/GraphAlgos.hpp
+++ b/src/libcadet/graph/GraphAlgos.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/linalg/ActiveDenseMatrix.hpp
+++ b/src/libcadet/linalg/ActiveDenseMatrix.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/linalg/BandMatrix.cpp
+++ b/src/libcadet/linalg/BandMatrix.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/linalg/BandMatrix.hpp
+++ b/src/libcadet/linalg/BandMatrix.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/linalg/CompressedSparseMatrix.cpp
+++ b/src/libcadet/linalg/CompressedSparseMatrix.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/linalg/CompressedSparseMatrix.hpp
+++ b/src/libcadet/linalg/CompressedSparseMatrix.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/linalg/DenseMatrix.cpp
+++ b/src/libcadet/linalg/DenseMatrix.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/linalg/DenseMatrix.hpp
+++ b/src/libcadet/linalg/DenseMatrix.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/linalg/EigenSolverWrapper.cpp
+++ b/src/libcadet/linalg/EigenSolverWrapper.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/linalg/EigenSolverWrapper.hpp
+++ b/src/libcadet/linalg/EigenSolverWrapper.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/linalg/Gmres.cpp
+++ b/src/libcadet/linalg/Gmres.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/linalg/Gmres.hpp
+++ b/src/libcadet/linalg/Gmres.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/linalg/Norms.hpp
+++ b/src/libcadet/linalg/Norms.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/linalg/SparseMatrix.cpp
+++ b/src/libcadet/linalg/SparseMatrix.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/linalg/SparseMatrix.hpp
+++ b/src/libcadet/linalg/SparseMatrix.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/linalg/SparseSolverInterface.hpp.in
+++ b/src/libcadet/linalg/SparseSolverInterface.hpp.in
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/linalg/Subset.hpp
+++ b/src/libcadet/linalg/Subset.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/linalg/SuperLUSparseMatrix.cpp
+++ b/src/libcadet/linalg/SuperLUSparseMatrix.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/linalg/SuperLUSparseMatrix.hpp
+++ b/src/libcadet/linalg/SuperLUSparseMatrix.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/linalg/UMFPackSparseMatrix.cpp
+++ b/src/libcadet/linalg/UMFPackSparseMatrix.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/linalg/UMFPackSparseMatrix.hpp
+++ b/src/libcadet/linalg/UMFPackSparseMatrix.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/BindingModel.hpp
+++ b/src/libcadet/model/BindingModel.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/ExternalFunctionSupport.hpp
+++ b/src/libcadet/model/ExternalFunctionSupport.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/GeneralRateModel-InitialConditions.cpp
+++ b/src/libcadet/model/GeneralRateModel-InitialConditions.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/GeneralRateModel-LinearSolver.cpp
+++ b/src/libcadet/model/GeneralRateModel-LinearSolver.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/GeneralRateModel.cpp
+++ b/src/libcadet/model/GeneralRateModel.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/GeneralRateModel.hpp
+++ b/src/libcadet/model/GeneralRateModel.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/GeneralRateModel2D-InitialConditions.cpp
+++ b/src/libcadet/model/GeneralRateModel2D-InitialConditions.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/GeneralRateModel2D-LinearSolver.cpp
+++ b/src/libcadet/model/GeneralRateModel2D-LinearSolver.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/GeneralRateModel2D.cpp
+++ b/src/libcadet/model/GeneralRateModel2D.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/GeneralRateModel2D.hpp
+++ b/src/libcadet/model/GeneralRateModel2D.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/GeneralRateModelDG-InitialConditions.cpp
+++ b/src/libcadet/model/GeneralRateModelDG-InitialConditions.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/GeneralRateModelDG-LinearSolver.cpp
+++ b/src/libcadet/model/GeneralRateModelDG-LinearSolver.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/GeneralRateModelDG.cpp
+++ b/src/libcadet/model/GeneralRateModelDG.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //
-//  Copyright © 2008-2021: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/GeneralRateModelDG.hpp
+++ b/src/libcadet/model/GeneralRateModelDG.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2021: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/InletModel.cpp
+++ b/src/libcadet/model/InletModel.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/InletModel.hpp
+++ b/src/libcadet/model/InletModel.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/LumpedRateModelWithPores-InitialConditions.cpp
+++ b/src/libcadet/model/LumpedRateModelWithPores-InitialConditions.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/LumpedRateModelWithPores-LinearSolver.cpp
+++ b/src/libcadet/model/LumpedRateModelWithPores-LinearSolver.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/LumpedRateModelWithPores.cpp
+++ b/src/libcadet/model/LumpedRateModelWithPores.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/LumpedRateModelWithPores.hpp
+++ b/src/libcadet/model/LumpedRateModelWithPores.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/LumpedRateModelWithPoresDG-InitialConditions.cpp
+++ b/src/libcadet/model/LumpedRateModelWithPoresDG-InitialConditions.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/LumpedRateModelWithPoresDG-LinearSolver.cpp
+++ b/src/libcadet/model/LumpedRateModelWithPoresDG-LinearSolver.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/LumpedRateModelWithPoresDG.cpp
+++ b/src/libcadet/model/LumpedRateModelWithPoresDG.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //
-//  Copyright © 2008-2021: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/LumpedRateModelWithPoresDG.hpp
+++ b/src/libcadet/model/LumpedRateModelWithPoresDG.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright � 2008-2021: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/LumpedRateModelWithoutPores.cpp
+++ b/src/libcadet/model/LumpedRateModelWithoutPores.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/LumpedRateModelWithoutPores.hpp
+++ b/src/libcadet/model/LumpedRateModelWithoutPores.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/LumpedRateModelWithoutPoresDG.cpp
+++ b/src/libcadet/model/LumpedRateModelWithoutPoresDG.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //
-//  Copyright © 2008-2021: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/LumpedRateModelWithoutPoresDG.hpp
+++ b/src/libcadet/model/LumpedRateModelWithoutPoresDG.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2021: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/ModelSystemImpl-Helper.hpp
+++ b/src/libcadet/model/ModelSystemImpl-Helper.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/ModelSystemImpl-InitialConditions.cpp
+++ b/src/libcadet/model/ModelSystemImpl-InitialConditions.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/ModelSystemImpl-LinearSolver.cpp
+++ b/src/libcadet/model/ModelSystemImpl-LinearSolver.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/ModelSystemImpl-Residual.cpp
+++ b/src/libcadet/model/ModelSystemImpl-Residual.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/ModelSystemImpl.cpp
+++ b/src/libcadet/model/ModelSystemImpl.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/ModelSystemImpl.hpp
+++ b/src/libcadet/model/ModelSystemImpl.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/ModelUtils.hpp
+++ b/src/libcadet/model/ModelUtils.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/MultiChannelTransportModel-InitialConditions.cpp
+++ b/src/libcadet/model/MultiChannelTransportModel-InitialConditions.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //
-//  Copyright © 2008-2021: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/MultiChannelTransportModel-LinearSolver.cpp
+++ b/src/libcadet/model/MultiChannelTransportModel-LinearSolver.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //
-//  Copyright © 2008-2021: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/MultiChannelTransportModel.cpp
+++ b/src/libcadet/model/MultiChannelTransportModel.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //
-//  Copyright © 2008-2021: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/MultiChannelTransportModel.hpp
+++ b/src/libcadet/model/MultiChannelTransportModel.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //
-//  Copyright © 2008-2021: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/OutletModel.cpp
+++ b/src/libcadet/model/OutletModel.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/OutletModel.hpp
+++ b/src/libcadet/model/OutletModel.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/ParameterDependence.hpp
+++ b/src/libcadet/model/ParameterDependence.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/ParameterMultiplexing.cpp
+++ b/src/libcadet/model/ParameterMultiplexing.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/ParameterMultiplexing.hpp
+++ b/src/libcadet/model/ParameterMultiplexing.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/Parameters.hpp
+++ b/src/libcadet/model/Parameters.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/ReactionModel.hpp
+++ b/src/libcadet/model/ReactionModel.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/StirredTankModel.cpp
+++ b/src/libcadet/model/StirredTankModel.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/StirredTankModel.hpp
+++ b/src/libcadet/model/StirredTankModel.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/UnitOperation.hpp
+++ b/src/libcadet/model/UnitOperation.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/UnitOperationBase.cpp
+++ b/src/libcadet/model/UnitOperationBase.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/UnitOperationBase.hpp
+++ b/src/libcadet/model/UnitOperationBase.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/binding/AntiLangmuirBinding.cpp
+++ b/src/libcadet/model/binding/AntiLangmuirBinding.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/binding/BiLangmuirBinding.cpp
+++ b/src/libcadet/model/binding/BiLangmuirBinding.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/binding/BiLangmuirLDFBinding.cpp
+++ b/src/libcadet/model/binding/BiLangmuirLDFBinding.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/binding/BiStericMassActionBinding.cpp
+++ b/src/libcadet/model/binding/BiStericMassActionBinding.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/binding/BindingModelBase.cpp
+++ b/src/libcadet/model/binding/BindingModelBase.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/binding/BindingModelBase.hpp
+++ b/src/libcadet/model/binding/BindingModelBase.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/binding/BindingModelMacros.hpp
+++ b/src/libcadet/model/binding/BindingModelMacros.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/binding/ColloidalBinding.cpp
+++ b/src/libcadet/model/binding/ColloidalBinding.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/binding/DummyBinding.cpp
+++ b/src/libcadet/model/binding/DummyBinding.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/binding/ExtendedMobilePhaseModulatorLangmuirBinding.cpp
+++ b/src/libcadet/model/binding/ExtendedMobilePhaseModulatorLangmuirBinding.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/binding/ExternalFunctionTemplate.cpp
+++ b/src/libcadet/model/binding/ExternalFunctionTemplate.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/binding/FreundlichLDFBinding.cpp
+++ b/src/libcadet/model/binding/FreundlichLDFBinding.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/binding/GeneralizedIonExchangeBinding.cpp
+++ b/src/libcadet/model/binding/GeneralizedIonExchangeBinding.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/binding/HICConstantWaterActivityBinding.cpp
+++ b/src/libcadet/model/binding/HICConstantWaterActivityBinding.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/binding/HICWaterOnHydrophobicSurfacesBinding.cpp
+++ b/src/libcadet/model/binding/HICWaterOnHydrophobicSurfacesBinding.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/binding/KumarLangmuirBinding.cpp
+++ b/src/libcadet/model/binding/KumarLangmuirBinding.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/binding/LangmuirBinding.cpp
+++ b/src/libcadet/model/binding/LangmuirBinding.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/binding/LangmuirLDFBinding.cpp
+++ b/src/libcadet/model/binding/LangmuirLDFBinding.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/binding/LangmuirLDFCBinding.cpp
+++ b/src/libcadet/model/binding/LangmuirLDFCBinding.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/binding/LinearBinding.cpp
+++ b/src/libcadet/model/binding/LinearBinding.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/binding/MobilePhaseModulatorLangmuirBinding.cpp
+++ b/src/libcadet/model/binding/MobilePhaseModulatorLangmuirBinding.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/binding/MultiComponentSpreadingBinding.cpp
+++ b/src/libcadet/model/binding/MultiComponentSpreadingBinding.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/binding/MultiStateStericMassActionBinding.cpp
+++ b/src/libcadet/model/binding/MultiStateStericMassActionBinding.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/binding/RefConcentrationSupport.hpp
+++ b/src/libcadet/model/binding/RefConcentrationSupport.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/binding/SaskaBinding.cpp
+++ b/src/libcadet/model/binding/SaskaBinding.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/binding/SelfAssociationBinding.cpp
+++ b/src/libcadet/model/binding/SelfAssociationBinding.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/binding/SimplifiedMultiStateStericMassActionBinding.cpp
+++ b/src/libcadet/model/binding/SimplifiedMultiStateStericMassActionBinding.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/binding/SimplifiedMultiStateStericMassActionBinding.hpp
+++ b/src/libcadet/model/binding/SimplifiedMultiStateStericMassActionBinding.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/binding/StericMassActionBinding.cpp
+++ b/src/libcadet/model/binding/StericMassActionBinding.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/extfun/LinearInterpolationExternalFunction.cpp
+++ b/src/libcadet/model/extfun/LinearInterpolationExternalFunction.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/extfun/PiecewiseCubicPolyExternalFunction.cpp
+++ b/src/libcadet/model/extfun/PiecewiseCubicPolyExternalFunction.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/inlet/PiecewiseCubicPoly.cpp
+++ b/src/libcadet/model/inlet/PiecewiseCubicPoly.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/paramdep/DummyParameterDependence.cpp
+++ b/src/libcadet/model/paramdep/DummyParameterDependence.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/paramdep/IdentityParameterDependence.cpp
+++ b/src/libcadet/model/paramdep/IdentityParameterDependence.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright ┬® 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright ® The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/paramdep/LiquidSaltSolidParameterDependence.cpp
+++ b/src/libcadet/model/paramdep/LiquidSaltSolidParameterDependence.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/paramdep/ParameterDependenceBase.cpp
+++ b/src/libcadet/model/paramdep/ParameterDependenceBase.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/paramdep/ParameterDependenceBase.hpp
+++ b/src/libcadet/model/paramdep/ParameterDependenceBase.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/paramdep/PowerLawParameterDependence.cpp
+++ b/src/libcadet/model/paramdep/PowerLawParameterDependence.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/parts/AxialConvectionDispersionKernel.cpp
+++ b/src/libcadet/model/parts/AxialConvectionDispersionKernel.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/parts/AxialConvectionDispersionKernel.hpp
+++ b/src/libcadet/model/parts/AxialConvectionDispersionKernel.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/parts/BindingCellKernel.hpp
+++ b/src/libcadet/model/parts/BindingCellKernel.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/parts/ConvectionDispersionOperator.cpp
+++ b/src/libcadet/model/parts/ConvectionDispersionOperator.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/parts/ConvectionDispersionOperator.hpp
+++ b/src/libcadet/model/parts/ConvectionDispersionOperator.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/parts/ConvectionDispersionOperatorDG.cpp
+++ b/src/libcadet/model/parts/ConvectionDispersionOperatorDG.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/parts/ConvectionDispersionOperatorDG.hpp
+++ b/src/libcadet/model/parts/ConvectionDispersionOperatorDG.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/parts/DGToolbox.cpp
+++ b/src/libcadet/model/parts/DGToolbox.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/parts/DGToolbox.hpp
+++ b/src/libcadet/model/parts/DGToolbox.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/parts/MultiChannelConvectionDispersionOperator.cpp
+++ b/src/libcadet/model/parts/MultiChannelConvectionDispersionOperator.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //
-//  Copyright © 2008-2021: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/parts/MultiChannelConvectionDispersionOperator.hpp
+++ b/src/libcadet/model/parts/MultiChannelConvectionDispersionOperator.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //
-//  Copyright © 2008-2021: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/parts/RadialConvectionDispersionKernel.cpp
+++ b/src/libcadet/model/parts/RadialConvectionDispersionKernel.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/parts/RadialConvectionDispersionKernel.hpp
+++ b/src/libcadet/model/parts/RadialConvectionDispersionKernel.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/parts/TwoDimensionalConvectionDispersionOperator.cpp
+++ b/src/libcadet/model/parts/TwoDimensionalConvectionDispersionOperator.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/parts/TwoDimensionalConvectionDispersionOperator.hpp
+++ b/src/libcadet/model/parts/TwoDimensionalConvectionDispersionOperator.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/reaction/DummyReaction.cpp
+++ b/src/libcadet/model/reaction/DummyReaction.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/reaction/ExternalFunctionTemplate.cpp
+++ b/src/libcadet/model/reaction/ExternalFunctionTemplate.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/reaction/MassActionLawReaction.cpp
+++ b/src/libcadet/model/reaction/MassActionLawReaction.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/reaction/MichaelisMentenReaction.cpp
+++ b/src/libcadet/model/reaction/MichaelisMentenReaction.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET - The Chromatography Analysis and Design Toolkit
 //
-//  Copyright © 2008-2020: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/reaction/ReactionModelBase.cpp
+++ b/src/libcadet/model/reaction/ReactionModelBase.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/model/reaction/ReactionModelBase.hpp
+++ b/src/libcadet/model/reaction/ReactionModelBase.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/nonlin/AdaptiveTrustRegionNewton.cpp
+++ b/src/libcadet/nonlin/AdaptiveTrustRegionNewton.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/nonlin/AdaptiveTrustRegionNewton.hpp
+++ b/src/libcadet/nonlin/AdaptiveTrustRegionNewton.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/nonlin/CompositeSolver.cpp
+++ b/src/libcadet/nonlin/CompositeSolver.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/nonlin/CompositeSolver.hpp
+++ b/src/libcadet/nonlin/CompositeSolver.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/nonlin/LevenbergMarquardt.cpp
+++ b/src/libcadet/nonlin/LevenbergMarquardt.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/nonlin/LevenbergMarquardt.hpp
+++ b/src/libcadet/nonlin/LevenbergMarquardt.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/nonlin/Solver.cpp
+++ b/src/libcadet/nonlin/Solver.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/libcadet/nonlin/Solver.hpp
+++ b/src/libcadet/nonlin/Solver.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -1,8 +1,8 @@
 # =============================================================================
 #  CADET
 #  
-#  Copyright © 2008-2022: The CADET Authors
-#            Please see the AUTHORS and CONTRIBUTORS file.
+#  Copyright © The CADET Authors
+#            Please see the CONTRIBUTORS.md file.
 #  
 #  All rights reserved. This program and the accompanying materials
 #  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/tools/FormatConverter.cpp
+++ b/src/tools/FormatConverter.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/tools/FormatConverter.hpp
+++ b/src/tools/FormatConverter.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/tools/ToolsHelper.hpp
+++ b/src/tools/ToolsHelper.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/tools/convertFile.cpp
+++ b/src/tools/convertFile.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/tools/createConvBenchmark.cpp
+++ b/src/tools/createConvBenchmark.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/tools/createLWE.cpp
+++ b/src/tools/createLWE.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/tools/createMCLin.cpp
+++ b/src/tools/createMCLin.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/tools/createSCLang.cpp
+++ b/src/tools/createSCLang.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/tools/createSCLin.cpp
+++ b/src/tools/createSCLin.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/src/tools/createSCLinStep.cpp
+++ b/src/tools/createSCLinStep.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/test/AD.cpp
+++ b/test/AD.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/test/Approx.hpp
+++ b/test/Approx.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/test/BandMatrix.cpp
+++ b/test/BandMatrix.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/test/BindingModelAutoJacobian.cpp
+++ b/test/BindingModelAutoJacobian.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/test/BindingModelTests.cpp
+++ b/test/BindingModelTests.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/test/BindingModelTests.hpp
+++ b/test/BindingModelTests.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/test/BindingModels.cpp
+++ b/test/BindingModels.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/test/BindingModels.hpp
+++ b/test/BindingModels.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,8 +1,8 @@
 # =============================================================================
 #  CADET
 #  
-#  Copyright © 2008-2022: The CADET Authors
-#            Please see the AUTHORS and CONTRIBUTORS file.
+#  Copyright © The CADET Authors
+#            Please see the CONTRIBUTORS.md file.
 #  
 #  All rights reserved. This program and the accompanying materials
 #  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/test/CSTR-Residual.cpp
+++ b/test/CSTR-Residual.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/test/CSTR-Simulation.cpp
+++ b/test/CSTR-Simulation.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/test/CellKernelTests.cpp
+++ b/test/CellKernelTests.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/test/ColumnTests.cpp
+++ b/test/ColumnTests.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/test/ColumnTests.hpp
+++ b/test/ColumnTests.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/test/ConvectionDispersionOperator.cpp
+++ b/test/ConvectionDispersionOperator.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/test/DenseMatrix.cpp
+++ b/test/DenseMatrix.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/test/Dummies.hpp
+++ b/test/Dummies.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/test/GeneralRateModel.cpp
+++ b/test/GeneralRateModel.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/test/GeneralRateModel2D.cpp
+++ b/test/GeneralRateModel2D.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/test/GeneralRateModelDG.cpp
+++ b/test/GeneralRateModelDG.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2023: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/test/Graph.cpp
+++ b/test/Graph.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/test/Histogram.cpp
+++ b/test/Histogram.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/test/JacobianHelper.hpp
+++ b/test/JacobianHelper.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/test/JsonTestModels.cpp
+++ b/test/JsonTestModels.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/test/JsonTestModels.hpp
+++ b/test/JsonTestModels.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/test/LogUtils.cpp
+++ b/test/LogUtils.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/test/LumpedRateModelWithPores.cpp
+++ b/test/LumpedRateModelWithPores.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/test/LumpedRateModelWithPoresDG.cpp
+++ b/test/LumpedRateModelWithPoresDG.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2023: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/test/LumpedRateModelWithoutPores.cpp
+++ b/test/LumpedRateModelWithoutPores.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/test/LumpedRateModelWithoutPoresDG.cpp
+++ b/test/LumpedRateModelWithoutPoresDG.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2023: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/test/MatrixHelper.hpp
+++ b/test/MatrixHelper.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/test/ModelSystem.cpp
+++ b/test/ModelSystem.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/test/MultiChannelTransportModel.cpp
+++ b/test/MultiChannelTransportModel.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/test/ParamDepTests.cpp
+++ b/test/ParamDepTests.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/test/ParamDepTests.hpp
+++ b/test/ParamDepTests.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/test/ParameterDependencies.cpp
+++ b/test/ParameterDependencies.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/test/ParameterDependencies.hpp
+++ b/test/ParameterDependencies.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/test/ParticleHelper.cpp
+++ b/test/ParticleHelper.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/test/ParticleHelper.hpp
+++ b/test/ParticleHelper.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/test/Paths.cpp.in
+++ b/test/Paths.cpp.in
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/test/RadialGeneralRateModel.cpp
+++ b/test/RadialGeneralRateModel.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/test/RadialLumpedRateModelWithPores.cpp
+++ b/test/RadialLumpedRateModelWithPores.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/test/RadialLumpedRateModelWithoutPores.cpp
+++ b/test/RadialLumpedRateModelWithoutPores.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/test/ReactionModelTests.cpp
+++ b/test/ReactionModelTests.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/test/ReactionModelTests.hpp
+++ b/test/ReactionModelTests.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/test/ReactionModels.cpp
+++ b/test/ReactionModels.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/test/SimHelper.cpp
+++ b/test/SimHelper.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/test/SimHelper.hpp
+++ b/test/SimHelper.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/test/SparseFactorizableMatrix.cpp
+++ b/test/SparseFactorizableMatrix.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/test/SparseMatrix.cpp
+++ b/test/SparseMatrix.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/test/StringHashing.cpp
+++ b/test/StringHashing.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/test/Subset.cpp
+++ b/test/Subset.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/test/TimeIntegrator.cpp
+++ b/test/TimeIntegrator.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/test/TimeIntegrator.hpp
+++ b/test/TimeIntegrator.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/test/TwoDimConvectionDispersionOperator.cpp
+++ b/test/TwoDimConvectionDispersionOperator.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/test/UnitOperationTests.cpp
+++ b/test/UnitOperationTests.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/test/UnitOperationTests.hpp
+++ b/test/UnitOperationTests.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/test/Utils.hpp
+++ b/test/Utils.hpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/test/testAdaptiveTRNewton.cpp
+++ b/test/testAdaptiveTRNewton.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/test/testLogging.cpp
+++ b/test/testLogging.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/test/testRadialKernel.cpp
+++ b/test/testRadialKernel.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //
-//  Copyright © 2008-2022: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/test/testRunner.cpp
+++ b/test/testRunner.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at

--- a/test/testSMANonlinearSolve.cpp
+++ b/test/testSMANonlinearSolve.cpp
@@ -1,8 +1,8 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-2024: The CADET Authors
-//            Please see the AUTHORS and CONTRIBUTORS file.
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials
 //  are made available under the terms of the GNU Public License v3.0 (or, at


### PR DESCRIPTION
Fixes #170


## To-do
- [x] Add years to license (similar to how it's done in [curl](https://daniel.haxx.se/blog/2023/01/08/copyright-without-years/))?