### PR TITLE
Fix invalid CMake install option in MacOS CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,7 +187,7 @@ jobs:
       - name: Install Dependencies
         run: |
           brew update > /dev/null || true
-          brew install cmake --without-docs
+          brew install cmake
           brew install hdf5
           brew install tbb
           brew install eigen


### PR DESCRIPTION
All our CI runs had an error for [MacOS](https://github.com/cadet/CADET-Core/actions/runs/10556683607/job/29243632339#step:3:198):
invalid option: --without-docs

Fixed, see [here](https://github.com/cadet/CADET-Core/actions/runs/10557120570/job/29244023307?pr=281)