### PR TITLE
Add release guide to documentation

### DIFF
--- a/doc/developer_guide/index.rst
+++ b/doc/developer_guide/index.rst
@@ -22,3 +22,4 @@ Since some developers may be new to collaborative software development using Git
    model_expansion
    debugging
    testing
+   release_new_version

--- a/doc/developer_guide/release_new_version.rst
+++ b/doc/developer_guide/release_new_version.rst
@@ -12,8 +12,12 @@ Release checklist
 
   - the release tests contain extensive testing that is not included in our CI, such as EOC tests. Running these tests might take a while and this should be done on the server
   - some tests are implemented in CADET-Core, and can be run with the [ReleaseCI] flag
-  - more tests are implemented in python, the code can be found on the `Core_tests branch of CADET-Reference <https://jugit.fz-juelich.de/IBG-1/ModSim/cadet/cadet-reference/-/tree/CADET-Core_tests>`_.
+  - more tests are implemented in python, the code can be found on the `Core_tests branch of CADET-Reference <https://jugit.fz-juelich.de/IBG-1/ModSim/cadet/cadet-reference/-/tree/CADET-Core_tests>`_
   Compare the results with the previous run. The release process can only be continued if the results are reasonable
+
+- Run performance benchmarks
+
+  - if numerical algorithms were refactored or if performance-critical infrastructure was changed, you should run performance benchmarks to compare the latest release with the planned new one. To this end, you can refer to the performance benchmark templates in CADET-Reference, e.g. the `benchmark for the modified Newton method <https://jugit.fz-juelich.de/IBG-1/ModSim/cadet/cadet-reference/-/tree/benchmark_modified_newton?ref_type=heads>`_
 
 - Create a version bump commit, which will be the target commit for the release.
   The bump commit contains:
@@ -31,7 +35,7 @@ Release checklist
     - Added: New features, enhancements, or functionalities introduced in this release
     - Fixed: Bug fixes and corrections made to resolve issues from previous versions
     - Changed: Modifications to existing features and breaking changes for major releases including changes in the interface
-    - Updated: Improvements to documentation, minor tweaks, or other updates that don’t fit into the other categories
+    - Updated: Improvements to documentation, minor tweaks, or other updates that donâ€™t fit into the other categories
 
   - attach the (zipped) source code
 

--- a/doc/developer_guide/release_new_version.rst
+++ b/doc/developer_guide/release_new_version.rst
@@ -1,0 +1,43 @@
+.. _release_new_version:
+
+CADET-Core version release
+==========================
+
+CADET-Core releases follow the semantic versioning system, which is documented `here <https://semver.org/>`_.
+
+Release checklist
+-----------------
+
+- Run the release tests
+
+  - the release tests contain extensive testing that is not included in our CI, such as EOC tests. Running these tests might take a while and this should be done on the server
+  - some tests are implemented in CADET-Core, and can be run with the [ReleaseCI] flag
+  - more tests are implemented in python, the code can be found on the `Core_tests branch of CADET-Reference <https://jugit.fz-juelich.de/IBG-1/ModSim/cadet/cadet-reference/-/tree/CADET-Core_tests>`_.
+  Compare the results with the previous run. The release process can only be continued if the results are reasonable
+
+- Create a version bump commit, which will be the target commit for the release.
+  The bump commit contains:
+  
+  - update of the version number in the `version.txt`
+  - update of the contributors list
+  - update of the copyright (years)
+  - update of the file format if needed
+
+- Create the release on github `here <https://github.com/cadet/CADET-Core/releases/new>`_
+
+  - add the version number according to the semantic versioning system as the tag and set the master branch as target
+  - add release notes with categories
+
+    - Added: New features, enhancements, or functionalities introduced in this release
+    - Fixed: Bug fixes and corrections made to resolve issues from previous versions
+    - Changed: Modifications to existing features and breaking changes for major releases including changes in the interface
+    - Updated: Improvements to documentation, minor tweaks, or other updates that don’t fit into the other categories
+
+  - attach the (zipped) source code
+
+- Check success of zenodo archiving
+
+  - upon release, Zenodo automatically archives the release, generating a version-specific DOI (Digital Object Identifier) for it and storing a copy of the source code, along with any associated files. The `concept DOI <https://doi.org/10.5281/zenodo.8179015>`_, which is also given in the repository README, does not change but represents the repository as a whole and always points to the latest version.
+
+Release of binaries on conda-forge
+----------------------------------

--- a/doc/developer_guide/release_new_version.rst
+++ b/doc/developer_guide/release_new_version.rst
@@ -8,40 +8,44 @@ CADET-Core releases follow the semantic versioning system, which is documented `
 Release checklist
 -----------------
 
-- Run the release tests
+- Run the release tests:
 
-  - the release tests contain extensive testing that is not included in our CI, such as EOC tests. Running these tests might take a while and this should be done on the server
-  - some tests are implemented in CADET-Core, and can be run with the [ReleaseCI] flag
-  - more tests are implemented in python, the code can be found on the `Core_tests branch of CADET-Reference <https://jugit.fz-juelich.de/IBG-1/ModSim/cadet/cadet-reference/-/tree/CADET-Core_tests>`_
-  Compare the results with the previous run. The release process can only be continued if the results are reasonable
+  - The release tests contain extensive testing that is not included in our CI, such as EOC tests.
+    Running these tests might take a while and this should be done on the server.
+  - Some tests are implemented in CADET-Core, and can be run with the [ReleaseCI] flag.
+  - More tests are implemented in Python, the code can be found on the `Core_tests branch of CADET-Reference <https://jugit.fz-juelich.de/IBG-1/ModSim/cadet/cadet-reference/-/tree/CADET-Core_tests>`_
+  Compare the results with the previous run.
+  The release process can only be continued if the results are reasonable.
 
-- Run performance benchmarks
+- Run performance benchmarks:
 
-  - if numerical algorithms were refactored or if performance-critical infrastructure was changed, you should run performance benchmarks to compare the latest release with the planned new one. To this end, you can refer to the performance benchmark templates in CADET-Reference, e.g. the `benchmark for the modified Newton method <https://jugit.fz-juelich.de/IBG-1/ModSim/cadet/cadet-reference/-/tree/benchmark_modified_newton?ref_type=heads>`_
+  - If numerical algorithms were refactored or if performance-critical infrastructure was changed, you should run performance benchmarks to compare the latest release with the planned new one.
+    To this end, you can refer to the performance benchmark templates in CADET-Reference, e.g. the `benchmark for the modified Newton method <https://jugit.fz-juelich.de/IBG-1/ModSim/cadet/cadet-reference/-/tree/benchmark_modified_newton?ref_type=heads>`_
 
 - Create a version bump commit, which will be the target commit for the release.
   The bump commit contains:
   
-  - update of the version number in the `version.txt`
-  - update of the contributors list
-  - update of the copyright (years)
-  - update of the file format if needed
+  - Update of the version number in the `version.txt`
+  - Update of the contributors list
+  - Update of the copyright (years)
+  - Update of the file format if needed
 
-- Create the release on github `here <https://github.com/cadet/CADET-Core/releases/new>`_
+- Create the release on github `here <https://github.com/cadet/CADET-Core/releases/new>`_.
 
-  - add the version number according to the semantic versioning system as the tag and set the master branch as target
-  - add release notes with categories
+  - Add the version number according to the semantic versioning system as the tag and set the master branch as target.
+  - Add release notes with these categories:
 
-    - Added: New features, enhancements, or functionalities introduced in this release
-    - Fixed: Bug fixes and corrections made to resolve issues from previous versions
-    - Changed: Modifications to existing features and breaking changes for major releases including changes in the interface
-    - Updated: Improvements to documentation, minor tweaks, or other updates that don’t fit into the other categories
+    - Added: New features, enhancements, or functionalities introduced in this release.
+    - Fixed: Bug fixes and corrections made to resolve issues from previous versions.
+    - Changed: Modifications to existing features and breaking changes for major releases including changes in the interface.
+    - Updated: Improvements to documentation, minor tweaks, or other updates that don’t fit into the other categories.
 
-  - attach the (zipped) source code
+  - Attach the (zipped) source code.
 
-- Check success of zenodo archiving
+- Check success of zenodo archiving:
 
-  - upon release, Zenodo automatically archives the release, generating a version-specific DOI (Digital Object Identifier) for it and storing a copy of the source code, along with any associated files. The `concept DOI <https://doi.org/10.5281/zenodo.8179015>`_, which is also given in the repository README, does not change but represents the repository as a whole and always points to the latest version.
+  - Upon release, Zenodo automatically archives the release, generating a version-specific DOI (Digital Object Identifier) for it and storing a copy of the source code, along with any associated files.
+    The `concept DOI <https://doi.org/10.5281/zenodo.8179015>`_, which is also given in the repository README, does not change but represents the repository as a whole and always points to the latest version.
 
 Release of binaries on conda-forge
 ----------------------------------

--- a/doc/developer_guide/release_new_version.rst
+++ b/doc/developer_guide/release_new_version.rst
@@ -49,3 +49,6 @@ Release checklist
 
 Release of binaries on conda-forge
 ----------------------------------
+
+To ensure CADET-Core is accessible to a broad community, it is available as a Python package on conda-forge.
+Other software, such as our Python interface, `CADET-Python`, and the frontend, `CADET-Process`, import this package.


### PR DESCRIPTION
We should take the opportunity of the upcoming release to document a checklist for making CADET releases.

ToDos:
 - [x] Section on general workflow
 - [x] Section on Conda forge Placeholder, continuation in new issue #306 