### PR TITLE
Fix CSTR interface documentation and ensure backwards compatibility

### DIFF
--- a/doc/interface/unit_operations/cstr.rst
+++ b/doc/interface/unit_operations/cstr.rst
@@ -83,7 +83,7 @@ For information on model equations, refer to :ref:`cstr_model`.
    **Type:** double  **Range:** :math:`\geq 0`  **Length:** :math:`\texttt{NCOMP}`
    ================  =========================  ==================================
    
-``INIT_VOLUME``
+``INIT_LIQUID_VOLUME``
 
    Initial liquid volume
 

--- a/src/libcadet/model/StirredTankModel.cpp
+++ b/src/libcadet/model/StirredTankModel.cpp
@@ -270,7 +270,7 @@ bool CSTRModel::configure(IParameterProvider& paramProvider)
 	_constSolidVolume = 0.0;
 	if (paramProvider.exists("CONST_SOLID_VOLUME"))
 		_constSolidVolume = paramProvider.getDouble("CONST_SOLID_VOLUME");
-	else if (paramProvider.exists("POROSITY"))
+	else if (paramProvider.exists("POROSITY")) // todo delete for breaking change with new interface version
 	{
 		LOG(Warning) << "Field POROSITY is only supported for backwards compatibility, but the implementation of the CSTR has changed, please refer to the documentation. The POROSITY will be used to compute the constant solid volume from the liquid volume.";
 		_constSolidVolume = *(_initConditions.data() + _nComp + _totalBound) * (1.0 - paramProvider.getDouble("POROSITY"));
@@ -517,6 +517,8 @@ void CSTRModel::readInitialCondition(IParameterProvider& paramProvider)
 
 	if (paramProvider.exists("INIT_LIQUID_VOLUME"))
 		_initConditions[_nComp + _totalBound].setValue(paramProvider.getDouble("INIT_LIQUID_VOLUME"));
+	else if (paramProvider.exists("INIT_VOLUME")) // todo delete for breaking change with new interface version
+		_initConditions[_nComp + _totalBound].setValue(paramProvider.getDouble("INIT_VOLUME"));
 	else
 		_initConditions[_nComp + _totalBound].setValue(0.0);
 }


### PR DESCRIPTION
In #235  we changed the field "INIT_VOLUME" to "INIT_LIQUID_VOLUME" but forgot to update the documentation.
Also, Ive added backwards compatibility even though volume in the new CSTR refers to liquid volume only, since this unit operation is often used with constant volume and without a solid phase.
We can delete the backwards compatibility for the new interface version, i.e. for cadet-core v.6.0.0