### PR TITLE
Add maximum number of AD directions check to AD Jacobian tests

### DIFF
--- a/test/ColumnTests.cpp
+++ b/test/ColumnTests.cpp
@@ -842,6 +842,8 @@ namespace column
 		cadet::ad::setDirections(cadet::ad::getMaxDirections());
 		unitAD->useAnalyticJacobian(false);
 
+		REQUIRE(unitAD->requiredADdirs() < cadet::ad::getMaxDirections());
+
 		cadet::active* adRes = new cadet::active[unitAD->numDofs()];
 		cadet::active* adY = new cadet::active[unitAD->numDofs()];
 


### PR DESCRIPTION
Ive wasted some time on debugging a Jacobian which turned out to be correct, but the number of allowed AD directions was exceeded. This somehow did not result in an exception for going out of bounds but wrote nonsense values at different positions into the Jacobian.
The number of allowed AD directions is already checked for actual Simulations but not in the AD Jacobian test. This PR adds such a check to that test function.