### PR TITLE
Add MCT exchange matrix sensitivity to documentation

### DIFF
--- a/doc/interface/unit_operations/multi_channel_transport_model.rst
+++ b/doc/interface/unit_operations/multi_channel_transport_model.rst
@@ -131,6 +131,11 @@ For information on model equations, refer to :ref:`multi_channel_transport_model
     e^k_{N1} & \dots & e^k_{N(N-1)} & 0 
     \end{bmatrix}    
 
+   For addressing the exchange rates as a parameter senstivity, the mapping is as follows:
+
+  - :math:`\texttt{SENS_BOUNDPHASE}` *Channel from* 
+  - :math:`\texttt{SENS_PARTYPE}` *Channel to* 
+
    ================  ========================  ===============================================
    **Type:** double  **Range:** :math:`[0,1]`  **Length:** :math:`\texttt{NCHANNEL}*\texttt{NCHANNEL}*\texttt{NCOMP}`
    ================  ========================  ===============================================

--- a/include/cadet/ParameterId.hpp
+++ b/include/cadet/ParameterId.hpp
@@ -211,6 +211,7 @@ inline ParameterId makeParamId(const std::string& name, const UnitOpIdx unitOper
  * @param [in] name Hash of the parameter name
  * @param [in] unitOperation Index of the unit operation this parameter belongs to
  * @param [in] component Index of the component this parameter belongs to
+ * @param [in] parType Index of the particle type this parameter belongs to
  * @param [in] boundState Index of the bound state this parameter belongs to
  * @param [in] reaction Index of the reaction this parameter belongs to
  * @param [in] section Index of the section this parameter belongs to


### PR DESCRIPTION
Fixes #288 

In CADET-Core for the MCT the parameters sensitivity entries of the exchange matrix can be accessed via mapping.

`srcChannel `=> `bound_phase`
`destChannel ` => `sens_partype`

This mapping should be added to the documentation of the `EXCHANGE_MATRIX `in the interface (https://cadet.github.io/master/interface/unit_operations/multi_channel_transport_model.html) similar to how it was done for the `CONNECTIONS` matrix (https://cadet.github.io/master/interface/system.html#group-input-model-connections).