### PR TITLE
Improve parallel compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,10 @@ set(CMAKE_VISIBILITY_INLINES_HIDDEN ON)
 # Enable folders for IDEs
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
+# Enable LTO (link time optimization) for the project
+set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -flto=auto")
+
 # ---------------------------------------------------
 #   Other configuration options
 # ---------------------------------------------------


### PR DESCRIPTION
We observed many warnings about serial compilations of e.g. LTRANS jobs, making the compilation with sanitizers enabled very slow

Todo:
- [ ] measure difference in compilation tim with and without these changes