### PR TITLE
Adapt Freundlich parameter units based on feedback by Benedikt Aumeier.

### DIFF
--- a/doc/interface/binding/freundlich_ldf.rst
+++ b/doc/interface/binding/freundlich_ldf.rst
@@ -32,7 +32,7 @@ For information on model equations, refer to :ref:`freundlich_ldf_model`.
 ``FLDF_KF``
    Freundlich coefficient for each component
 
-**Unit:** :math:`m_{MP}^3~mol^{-1}`
+**Unit:** :math:`m_{MP}^{3/n}~m_{SP}^{-3}~mol^{1-1/n}`
 
 ===================  =========================  ==================================
 **Type:** double     **Range:** :math:`\ge 0`    **Length:** 1/NTOTALBND
@@ -41,7 +41,7 @@ For information on model equations, refer to :ref:`freundlich_ldf_model`.
 ``FLDF_N``
    Freundlich exponent for each component
 
-**Unit:** :[-]
+**Unit:** [-]
 
 ===================  =========================  ==================================
 **Type:** double     **Range:** :math:`> 0`      **Length:** 1/NTOTALBND


### PR DESCRIPTION
## Description of the PR

Based on feedback by Benedikt Aumeier, I think the unit for kF in the Freundlich model should be `m_{MP}^{3/n}~m_{SP}^{-3}~mol^{1-1/n}`

## Type of Change

Please mark the type of change that applies:

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Documentation update (updates or changes to documentation)

## Checklist

Please ensure you've completed the following tasks. Mark them with an `x` inside the brackets:

- [x] I have checked the CADET [Developer Guide](https://cadet.github.io/master/developer_guide)  
- [x] My code follows the project's code style and [RSE guidelines](https://rse-guidelines.readthedocs.io/en/latest/intro.html).
- [x] I have run relevant tests and verified that my changes do not break existing functionality.
- [x] I have updated documentation as needed.
- [x] I have reviewed my code for security considerations and potential vulnerabilities.
- [x] I have added necessary comments or descriptions for maintainers and reviewers.
