### PR TITLE
Add rapid equilibrium reactions for CSTR

### DIFF
--- a/src/libcadet/Memory.hpp
+++ b/src/libcadet/Memory.hpp
@@ -353,6 +353,14 @@ namespace cadet
 
 		explicit operator T*() const { return _ptr; }
 
+		// method to copy elements from std::vector
+		void copyFromVector(const std::vector<T>& vec) {
+			if (vec.size() > _numElements) {
+				throw std::out_of_range("Vector size exceeds BufferedArray size");
+			}
+			std::copy(vec.begin(), vec.end(), _ptr);
+		}
+
 	private:
 		BufferedArray(T* ptr, unsigned int numElements) : _ptr(ptr), _numElements(numElements) { }
 

--- a/src/libcadet/model/LumpedRateModelWithPores-InitialConditions.cpp
+++ b/src/libcadet/model/LumpedRateModelWithPores-InitialConditions.cpp
@@ -593,7 +593,6 @@ void LumpedRateModelWithPores<ConvDispOperator>::consistentInitialState(const Si
 	}
 
 	// Step 1b: Compute fluxes j_f
-
 	// Reset j_f to 0.0
 	double* const jf = vecStateY + idxr.offsetJf();
 	std::fill(jf, jf + _disc.nComp * _disc.nCol * _disc.nParType, 0.0);

--- a/src/libcadet/model/LumpedRateModelWithPores-LinearSolver.cpp
+++ b/src/libcadet/model/LumpedRateModelWithPores-LinearSolver.cpp
@@ -133,6 +133,7 @@ int LumpedRateModelWithPores<ConvDispOperator>::linearSolve(double t, double alp
 		{
 			// Assemble and factorize discretized bulk Jacobian
 			const bool result = _convDispOp.assembleAndFactorizeDiscretizedJacobian(alpha);
+			
 			if (cadet_unlikely(!result))
 			{
 				LOG(Error) << "Factorize() failed for bulk block";

--- a/src/libcadet/model/LumpedRateModelWithPores.cpp
+++ b/src/libcadet/model/LumpedRateModelWithPores.cpp
@@ -355,6 +355,7 @@ bool LumpedRateModelWithPores<ConvDispOperator>::configureModelDiscretization(IP
 
 		if (_dynReactionBulk->usesParamProviderInDiscretizationConfig())
 			paramProvider.popScope();
+		
 	}
 
 	clearDynamicReactionModels();
@@ -563,6 +564,7 @@ bool LumpedRateModelWithPores<ConvDispOperator>::configure(IParameterProvider& p
 	{
 		paramProvider.pushScope("reaction_bulk");
 		dynReactionConfSuccess = _dynReactionBulk->configure(paramProvider, _unitOpIdx, ParTypeIndep);
+		_convDispOp.setDynamicReactionBulk(_dynReactionBulk);
 		paramProvider.popScope();
 	}
 

--- a/src/libcadet/model/ReactionModel.hpp
+++ b/src/libcadet/model/ReactionModel.hpp
@@ -265,8 +265,8 @@ public:
 	* @param [in,out] QsCompBulk Vector to be filled with the components involved in qs reactions
 	*/
 	virtual void fillConservedMoietiesBulk(Eigen::MatrixXd& M, std::vector<int>& QsCompBulk) {}
-	virtual void fillConservedMoietiesBulk2(Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>& M, std::vector<int>& QsCompBulk) {}
-	virtual void fillConservedMoietiesBulk2(Eigen::Matrix<active, Eigen::Dynamic, Eigen::Dynamic>& M, std::vector<int>& QsCompBulk) {}
+	virtual void fillConservedMoietiesBulk2(Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>& M, int& QsCompBulk) {}
+	virtual void fillConservedMoietiesBulk2(Eigen::Matrix<active, Eigen::Dynamic, Eigen::Dynamic>& M, int& QsCompBulk) {}
 
 
 	/**

--- a/src/libcadet/model/ReactionModel.hpp
+++ b/src/libcadet/model/ReactionModel.hpp
@@ -11,7 +11,7 @@
 // =============================================================================
 
 /**
- * @file 
+ * @file
  * Defines reaction model interfaces.
  */
 
@@ -26,7 +26,7 @@
 #include "linalg/DenseMatrix.hpp"
 #include "linalg/BandMatrix.hpp"
 #ifdef ENABLE_DG
-	#include "linalg/BandedEigenSparseRowIterator.hpp"
+#include "linalg/BandedEigenSparseRowIterator.hpp"
 #endif
 #include "linalg/CompressedSparseMatrix.hpp"
 #include "AutoDiff.hpp"
@@ -35,336 +35,347 @@
 namespace cadet
 {
 
-class IParameterProvider;
-class IExternalFunction;
+	class IParameterProvider;
+	class IExternalFunction;
 
-struct ColumnPosition;
+	struct ColumnPosition;
 
-namespace model
-{
+	namespace model
+	{
 
-/**
- * @brief Defines an internal DynamicReactionModel interface
- * @details Represents dynamic reactions between components in a finite volume cell.
- *          Both simple and extended cells are supported. A simple cell contains only
- *          liquid phase components. An extended cell contains liquid and solid phase
- *          components.
- */
-class IDynamicReactionModel
-{
-public:
+		/**
+		 * @brief Defines an internal DynamicReactionModel interface
+		 * @details Represents dynamic reactions between components in a finite volume cell.
+		 *          Both simple and extended cells are supported. A simple cell contains only
+		 *          liquid phase components. An extended cell contains liquid and solid phase
+		 *          components.
+		 */
+		class IDynamicReactionModel
+		{
+		public:
 
-	virtual ~IDynamicReactionModel() CADET_NOEXCEPT { }
+			virtual ~IDynamicReactionModel() CADET_NOEXCEPT { }
 
-	/**
-	 * @brief Returns the name of the dynamic reaction model
-	 * @details This name is also used to identify and create the dynamic reaction model in the factory.
-	 * @return Name of the dynamic reaction model
-	 */
-	virtual const char* name() const CADET_NOEXCEPT = 0;
+			/**
+			 * @brief Returns the name of the dynamic reaction model
+			 * @details This name is also used to identify and create the dynamic reaction model in the factory.
+			 * @return Name of the dynamic reaction model
+			 */
+			virtual const char* name() const CADET_NOEXCEPT = 0;
 
-	/**
-	 * @brief Returns whether the dynamic reaction model requires additional parameters supplied by configure()
-	 * @details After construction of an IDynamicReactionModel object, configureModelDiscretization() is called.
-	 *          The dynamic reaction model may require to read additional parameters from the reaction group
-	 *          of the parameter provider. This opportunity is given by a call to configure(). However, a
-	 *          dynamic reaction model may not require this. This function communicates to the outside
-	 *          whether a call to configure() is necessary.
-	 * @return @c true if configure() has to be called, otherwise @c false
-	 */
-	virtual bool requiresConfiguration() const CADET_NOEXCEPT = 0;
+			/**
+			 * @brief Returns whether the dynamic reaction model requires additional parameters supplied by configure()
+			 * @details After construction of an IDynamicReactionModel object, configureModelDiscretization() is called.
+			 *          The dynamic reaction model may require to read additional parameters from the reaction group
+			 *          of the parameter provider. This opportunity is given by a call to configure(). However, a
+			 *          dynamic reaction model may not require this. This function communicates to the outside
+			 *          whether a call to configure() is necessary.
+			 * @return @c true if configure() has to be called, otherwise @c false
+			 */
+			virtual bool requiresConfiguration() const CADET_NOEXCEPT = 0;
 
-	/**
-	 * @brief Returns whether the dynamic reaction model uses the IParameterProvider in configureModelDiscretization()
-	 * @details If the IParameterProvider is used in configureModelDiscretization(), it has to be in the correct scope.
-	 * @return @c true if the IParameterProvider is used in configureModelDiscretization(), otherwise @c false
-	 */
-	virtual bool usesParamProviderInDiscretizationConfig() const CADET_NOEXCEPT = 0;
+			/**
+			 * @brief Returns whether the dynamic reaction model uses the IParameterProvider in configureModelDiscretization()
+			 * @details If the IParameterProvider is used in configureModelDiscretization(), it has to be in the correct scope.
+			 * @return @c true if the IParameterProvider is used in configureModelDiscretization(), otherwise @c false
+			 */
+			virtual bool usesParamProviderInDiscretizationConfig() const CADET_NOEXCEPT = 0;
 
-	/**
-	 * @brief Sets the number of components in the model
-	 * @details This function is called prior to configure() by the underlying model.
-	 *          It can only be called once. Model parameters are configured by configure().
-	 * 
-	 * @param [in] paramProvider Parameter provider
-	 * @param [in] nComp Number of components
-	 * @param [in] nBound Array of size @p nComp which contains the number of bound states for each component
-	 * @param [in] boundOffset Array of size @p nComp with offsets to the first bound state of each component beginning from the solid phase
-	 */
-	virtual bool configureModelDiscretization(IParameterProvider& paramProvider, unsigned int nComp, unsigned int const* nBound, unsigned int const* boundOffset) = 0;
+			/**
+			 * @brief Sets the number of components in the model
+			 * @details This function is called prior to configure() by the underlying model.
+			 *          It can only be called once. Model parameters are configured by configure().
+			 *
+			 * @param [in] paramProvider Parameter provider
+			 * @param [in] nComp Number of components
+			 * @param [in] nBound Array of size @p nComp which contains the number of bound states for each component
+			 * @param [in] boundOffset Array of size @p nComp with offsets to the first bound state of each component beginning from the solid phase
+			 */
+			virtual bool configureModelDiscretization(IParameterProvider& paramProvider, unsigned int nComp, unsigned int const* nBound, unsigned int const* boundOffset) = 0;
 
-	/**
-	 * @brief Configures the model by extracting all non-structural parameters (e.g., model parameters) from the given @p paramProvider
-	 * @details The scope of the cadet::IParameterProvider is left unchanged on return.
-	 * 
-	 *          The structure of the model is left unchanged, that is, the number of degrees of
-	 *          freedom stays the same (e.g., number of bound states is left unchanged). Only
-	 *          true (non-structural) model parameters are read and changed.
-	 *          
-	 *          This function may only be called if configureModelDiscretization() has been called
-	 *          in the past. Contrary to configureModelDiscretization(), it can be called multiple
-	 *          times.
-	 * 
-	 * @param [in] paramProvider Parameter provider
-	 * @param [in] unitOpIdx Index of the unit operation this dynamic reaction model belongs to
-	 * @param [in] parTypeIdx Index of the particle type this dynamic reaction model belongs to
-	 * @return @c true if the configuration was successful, otherwise @c false
-	 */
-	virtual bool configure(IParameterProvider& paramProvider, UnitOpIdx unitOpIdx, ParticleTypeIdx parTypeIdx) = 0;
+			/**
+			 * @brief Configures the model by extracting all non-structural parameters (e.g., model parameters) from the given @p paramProvider
+			 * @details The scope of the cadet::IParameterProvider is left unchanged on return.
+			 *
+			 *          The structure of the model is left unchanged, that is, the number of degrees of
+			 *          freedom stays the same (e.g., number of bound states is left unchanged). Only
+			 *          true (non-structural) model parameters are read and changed.
+			 *
+			 *          This function may only be called if configureModelDiscretization() has been called
+			 *          in the past. Contrary to configureModelDiscretization(), it can be called multiple
+			 *          times.
+			 *
+			 * @param [in] paramProvider Parameter provider
+			 * @param [in] unitOpIdx Index of the unit operation this dynamic reaction model belongs to
+			 * @param [in] parTypeIdx Index of the particle type this dynamic reaction model belongs to
+			 * @return @c true if the configuration was successful, otherwise @c false
+			 */
+			virtual bool configure(IParameterProvider& paramProvider, UnitOpIdx unitOpIdx, ParticleTypeIdx parTypeIdx) = 0;
 
-	/**
-	 * @brief Sets external functions for this dynamic reaction model
-	 * @details The external functions are not owned by this IDynamicReactionModel.
-	 * 
-	 * @param [in] extFuns Pointer to array of IExternalFunction objects of size @p size
-	 * @param [in] size Number of elements in the IExternalFunction array @p extFuns
-	 */
-	virtual void setExternalFunctions(IExternalFunction** extFuns, unsigned int size) = 0;
+			/**
+			 * @brief Sets external functions for this dynamic reaction model
+			 * @details The external functions are not owned by this IDynamicReactionModel.
+			 *
+			 * @param [in] extFuns Pointer to array of IExternalFunction objects of size @p size
+			 * @param [in] size Number of elements in the IExternalFunction array @p extFuns
+			 */
+			virtual void setExternalFunctions(IExternalFunction** extFuns, unsigned int size) = 0;
 
-	/**
-	 * @brief Checks whether a given parameter exists
-	 * @param [in] pId ParameterId that identifies the parameter uniquely
-	 * @return @c true if the parameter exists, otherwise @c false
-	 */
-	virtual bool hasParameter(const ParameterId& pId) const = 0;
+			/**
+			 * @brief Checks whether a given parameter exists
+			 * @param [in] pId ParameterId that identifies the parameter uniquely
+			 * @return @c true if the parameter exists, otherwise @c false
+			 */
+			virtual bool hasParameter(const ParameterId& pId) const = 0;
 
-	/**
-	 * @brief Returns all parameters with their current values that can be made sensitive
-	 * @return Map with all parameters that can be made sensitive along with their current value
-	 */
-	virtual std::unordered_map<ParameterId, double> getAllParameterValues() const = 0;
+			/**
+			 * @brief Returns all parameters with their current values that can be made sensitive
+			 * @return Map with all parameters that can be made sensitive along with their current value
+			 */
+			virtual std::unordered_map<ParameterId, double> getAllParameterValues() const = 0;
 
-	/**
-	 * @brief Sets a parameter value
-	 * @details The parameter identified by its unique parameter is set to the given value.
-	 * 
-	 * @param [in] pId ParameterId that identifies the parameter uniquely
-	 * @param [in] value Value of the parameter
-	 * @return @c true if the parameter has been successfully set to the given value,
-	 *         otherwise @c false (e.g., if the parameter is not available in this model)
-	 */
-	virtual bool setParameter(const ParameterId& pId, int value) = 0;
-	virtual bool setParameter(const ParameterId& pId, double value) = 0;
-	virtual bool setParameter(const ParameterId& pId, bool value) = 0;
+			/**
+			 * @brief Sets a parameter value
+			 * @details The parameter identified by its unique parameter is set to the given value.
+			 *
+			 * @param [in] pId ParameterId that identifies the parameter uniquely
+			 * @param [in] value Value of the parameter
+			 * @return @c true if the parameter has been successfully set to the given value,
+			 *         otherwise @c false (e.g., if the parameter is not available in this model)
+			 */
+			virtual bool setParameter(const ParameterId& pId, int value) = 0;
+			virtual bool setParameter(const ParameterId& pId, double value) = 0;
+			virtual bool setParameter(const ParameterId& pId, bool value) = 0;
 
-	/**
-	 * @brief Returns a pointer to the parameter identified by the given id
-	 * @param [in] pId Parameter Id of the sensitive parameter
-	 * @return a pointer to the parameter if the dynamic reaction model contains the parameter, otherwise @c nullptr
-	 */
-	virtual active* getParameter(const ParameterId& pId) = 0;
+			/**
+			 * @brief Returns a pointer to the parameter identified by the given id
+			 * @param [in] pId Parameter Id of the sensitive parameter
+			 * @return a pointer to the parameter if the dynamic reaction model contains the parameter, otherwise @c nullptr
+			 */
+			virtual active* getParameter(const ParameterId& pId) = 0;
 
-	/**
-	 * @brief Returns whether this dynamic reaction model depends on time
-	 * @details Dynamic reaction models may depend on time if external functions are used.
-	 * @return @c true if the model is time-dependent, otherwise @c false
-	 */
-	virtual bool dependsOnTime() const CADET_NOEXCEPT = 0;
+			/**
+			 * @brief Returns whether this dynamic reaction model depends on time
+			 * @details Dynamic reaction models may depend on time if external functions are used.
+			 * @return @c true if the model is time-dependent, otherwise @c false
+			 */
+			virtual bool dependsOnTime() const CADET_NOEXCEPT = 0;
 
-	/**
-	 * @brief Returns whether this dynamic reaction model requires workspace
-	 * @details The workspace may be required for evaluation of residual and
-	 *          Jacobian. A workspace is a memory buffer whose size is given by
-	 *          workspaceSize().
-	 * @return @c true if the model requires a workspace, otherwise @c false
-	 */
-	virtual bool requiresWorkspace() const CADET_NOEXCEPT = 0;
+			/**
+			 * @brief Returns whether this dynamic reaction model requires workspace
+			 * @details The workspace may be required for evaluation of residual and
+			 *          Jacobian. A workspace is a memory buffer whose size is given by
+			 *          workspaceSize().
+			 * @return @c true if the model requires a workspace, otherwise @c false
+			 */
+			virtual bool requiresWorkspace() const CADET_NOEXCEPT = 0;
 
-	/**
-	 * @brief Returns the size of the required workspace in bytes
-	 * @details The memory is required for externally dependent dynamic reaction models.
-	 * @param [in] nComp Number of components
-	 * @param [in] totalNumBoundStates Total number of bound states
-	 * @param [in] nBoundStates Array with bound states for each component
-	 * @return Size of the workspace in bytes
-	 */
-	virtual unsigned int workspaceSize(unsigned int nComp, unsigned int totalNumBoundStates, unsigned int const* nBoundStates) const CADET_NOEXCEPT = 0;
+			/**
+			 * @brief Returns the size of the required workspace in bytes
+			 * @details The memory is required for externally dependent dynamic reaction models.
+			 * @param [in] nComp Number of components
+			 * @param [in] totalNumBoundStates Total number of bound states
+			 * @param [in] nBoundStates Array with bound states for each component
+			 * @return Size of the workspace in bytes
+			 */
+			virtual unsigned int workspaceSize(unsigned int nComp, unsigned int totalNumBoundStates, unsigned int const* nBoundStates) const CADET_NOEXCEPT = 0;
 
-	/**
-	 * @brief Evaluates the residual for one liquid phase cell
-	 * @details Adds the dynamic reaction terms to the residual vector for the given
-	 *          liquid phase cell. The reaction terms are premultiplied with a given
-	 *          factor. That is, this function realizes
-	 *          \f[ \begin{align} 
-	 *              \text{res} = \text{res} + \gamma R
-	 *          \end{align} \f]
-	 *          where @f$ R @f$ are the reaction terms.
-	 *          
-	 *          This function is called simultaneously from multiple threads.
-	 * 
-	 * @param [in] t Current time point
-	 * @param [in] secIdx Index of the current section
-	 * @param [in] colPos Position in normalized coordinates (column inlet = 0, column outlet = 1; outer shell = 1, inner center = 0)
-	 * @param [in] y Pointer to first component in the current cell
-	 * @param [out] res Pointer to residual of the first component in the current particle shell's liquid phase
-	 * @param [in] factor Factor @f$ \gamma @f$
-	 * @param [in,out] workSpace Memory work space
-	 * @return @c 0 on success, @c -1 on non-recoverable error, and @c +1 on recoverable error
-	 */
-	virtual int residualLiquidAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, active const* y,
-		active* res, const active& factor, LinearBufferAllocator workSpace) const = 0;
+			/**
+			 * @brief Evaluates the residual for one liquid phase cell
+			 * @details Adds the dynamic reaction terms to the residual vector for the given
+			 *          liquid phase cell. The reaction terms are premultiplied with a given
+			 *          factor. That is, this function realizes
+			 *          \f[ \begin{align}
+			 *              \text{res} = \text{res} + \gamma R
+			 *          \end{align} \f]
+			 *          where @f$ R @f$ are the reaction terms.
+			 *
+			 *          This function is called simultaneously from multiple threads.
+			 *
+			 * @param [in] t Current time point
+			 * @param [in] secIdx Index of the current section
+			 * @param [in] colPos Position in normalized coordinates (column inlet = 0, column outlet = 1; outer shell = 1, inner center = 0)
+			 * @param [in] y Pointer to first component in the current cell
+			 * @param [out] res Pointer to residual of the first component in the current particle shell's liquid phase
+			 * @param [in] factor Factor @f$ \gamma @f$
+			 * @param [in,out] workSpace Memory work space
+			 * @return @c 0 on success, @c -1 on non-recoverable error, and @c +1 on recoverable error
+			 */
+			virtual int residualLiquidAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, active const* y,
+				active* res, const active& factor, LinearBufferAllocator workSpace) const = 0;
 
-	virtual int residualLiquidAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, active const* y,
-		active* res, double factor, LinearBufferAllocator workSpace) const = 0;
+			virtual int residualLiquidAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, active const* y,
+				active* res, double factor, LinearBufferAllocator workSpace) const = 0;
 
-	virtual int residualLiquidAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,
-		active* res, double factor, LinearBufferAllocator workSpace) const = 0;
+			virtual int residualLiquidAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,
+				active* res, double factor, LinearBufferAllocator workSpace) const = 0;
 
-	virtual int residualLiquidAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,
-		double* res, double factor, LinearBufferAllocator workSpace) const = 0;
-	
-
-	virtual int computeQuasiStationaryReactionFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,
-		Eigen::Map<Eigen::Vector<active, Eigen::Dynamic>> fluxes,  LinearBufferAllocator workSpace) = 0;
-
-	virtual int computeQuasiStationaryReactionFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, active const* y,
-		Eigen::Map<Eigen::Vector<double, Eigen::Dynamic>> fluxes, LinearBufferAllocator workSpace) = 0;
-
-	virtual int computeQuasiStationaryReactionFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,
-		Eigen::Map<Eigen::Vector<double, Eigen::Dynamic>> fluxes,  LinearBufferAllocator workSpace) = 0;
-
-	virtual int computeQuasiStationaryReactionFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, active const* y,
-		Eigen::Map<Eigen::Vector<active, Eigen::Dynamic>> fluxes, LinearBufferAllocator workSpace) = 0;
-
-	/**
-	 * @brief Adds the analytical Jacobian of the reaction terms for one liquid phase cell
-	 * @details Adds the Jacobian of the dynamic reaction terms for the given liquid phase
-	 *          cell to the full Jacobian. The reaction terms are premultiplied with a given
-	 *          factor. That is, this function realizes
-	 *          \f[ \begin{align} 
-	 *              J = J + \gamma J_R
-	 *          \end{align} \f]
-	 *          where @f$ J_R @f$ is the Jacobian of the reaction terms.
-	 * 
-	 *          This function is called simultaneously from multiple threads.
-	 *          It can be left out (empty implementation) if AD is used to evaluate the Jacobian.
-	 *
-	 * @param [in] t Current time point
-	 * @param [in] secIdx Index of the current section
-	 * @param [in] colPos Position in normalized coordinates (column inlet = 0, column outlet = 1; outer shell = 1, inner center = 0)
-	 * @param [in] y Pointer to first component in the current cell
-	 * @param [in] factor Factor @f$ \gamma @f$
-	 * @param [in,out] jac Row iterator pointing to the first component row of the underlying matrix in which the Jacobian is stored
-	 * @param [in,out] workSpace Memory work space
-	 */
-	virtual void analyticJacobianLiquidAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double factor, linalg::BandMatrix::RowIterator jac, LinearBufferAllocator workSpace) const = 0;
-	virtual void analyticJacobianLiquidAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double factor, linalg::DenseBandedRowIterator jac, LinearBufferAllocator workSpace) const = 0;
-	virtual void analyticJacobianLiquidAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double factor, linalg::BandedSparseRowIterator jac, LinearBufferAllocator workSpace) const = 0;
-	
-	virtual void analyticJacobianQuasiStationaryReaction(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction, linalg::BandMatrix::RowIterator jac, LinearBufferAllocator workSpace) const = 0;
-	virtual void analyticJacobianQuasiStationaryReaction(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction, linalg::DenseBandedRowIterator jac, LinearBufferAllocator workSpace) const = 0;
-	virtual void analyticJacobianQuasiStationaryReaction(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction, linalg::BandedSparseRowIterator jac, LinearBufferAllocator workSpace) const = 0;
-
-	/**
-	* @brief fills the conserved moieties matrix and the vector of components involved in qs reactions
-	* @param [in,out] M Matrix to be filled with the conserved moieties
-	* @param [in,out] QsCompBulk Vector to be filled with the components involved in qs reactions
-	*/
-	virtual void fillConservedMoietiesBulk(Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>& M, int& nConservedQuants, std::vector<int>& QsCompBulk) {}
-	virtual void fillConservedMoietiesBulk(Eigen::Matrix<active, Eigen::Dynamic, Eigen::Dynamic>& M, int& nConservedQuants, std::vector<int>& QsCompBulk) {}
+			virtual int residualLiquidAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,
+				double* res, double factor, LinearBufferAllocator workSpace) const = 0;
 
 
-	/**
-	 * @brief Returns whether this dynamic reaction model has quasi-stationary reactions
-	 * @details Quasi-stationary reactions are reactions that are in equilibrium and can be solved
-	 *          algebraically. This function is used to determine whether the model can be solved
-	 *          in quasi-stationary mode.
-	 * @return @c true if the model has quasi-stationary reactions, otherwise @c false
-	 */
-	virtual bool hasQuasiStationaryReactionsBulk() const CADET_NOEXCEPT { return false; }
+			virtual int computeQuasiStationaryReactionFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,
+				Eigen::Map<Eigen::Vector<active, Eigen::Dynamic>> fluxes, LinearBufferAllocator workSpace) = 0;
 
-	virtual void timeDerivativeQuasiStationaryReaction(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double* dReacDt, LinearBufferAllocator workSpace) = 0;
+			virtual int computeQuasiStationaryReactionFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, active const* y,
+				Eigen::Map<Eigen::Vector<double, Eigen::Dynamic>> fluxes, LinearBufferAllocator workSpace) = 0;
 
-	virtual int const* reactionQuasiStationarity() const = 0;
+			virtual int computeQuasiStationaryReactionFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,
+				Eigen::Map<Eigen::Vector<double, Eigen::Dynamic>> fluxes, LinearBufferAllocator workSpace) = 0;
+
+			virtual int computeQuasiStationaryReactionFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, active const* y,
+				Eigen::Map<Eigen::Vector<active, Eigen::Dynamic>> fluxes, LinearBufferAllocator workSpace) = 0;
+
+			/**
+			 * @brief Adds the analytical Jacobian of the reaction terms for one liquid phase cell
+			 * @details Adds the Jacobian of the dynamic reaction terms for the given liquid phase
+			 *          cell to the full Jacobian. The reaction terms are premultiplied with a given
+			 *          factor. That is, this function realizes
+			 *          \f[ \begin{align}
+			 *              J = J + \gamma J_R
+			 *          \end{align} \f]
+			 *          where @f$ J_R @f$ is the Jacobian of the reaction terms.
+			 *
+			 *          This function is called simultaneously from multiple threads.
+			 *          It can be left out (empty implementation) if AD is used to evaluate the Jacobian.
+			 *
+			 * @param [in] t Current time point
+			 * @param [in] secIdx Index of the current section
+			 * @param [in] colPos Position in normalized coordinates (column inlet = 0, column outlet = 1; outer shell = 1, inner center = 0)
+			 * @param [in] y Pointer to first component in the current cell
+			 * @param [in] factor Factor @f$ \gamma @f$
+			 * @param [in,out] jac Row iterator pointing to the first component row of the underlying matrix in which the Jacobian is stored
+			 * @param [in,out] workSpace Memory work space
+			 */
+			virtual void analyticJacobianLiquidAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double factor, linalg::BandMatrix::RowIterator jac, LinearBufferAllocator workSpace) const = 0;
+			virtual void analyticJacobianLiquidAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double factor, linalg::DenseBandedRowIterator jac, LinearBufferAllocator workSpace) const = 0;
+			virtual void analyticJacobianLiquidAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double factor, linalg::BandedSparseRowIterator jac, LinearBufferAllocator workSpace) const = 0;
+
+			virtual void analyticJacobianQuasiStationaryReaction(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction, linalg::BandMatrix::RowIterator jac, LinearBufferAllocator workSpace) const = 0;
+			virtual void analyticJacobianQuasiStationaryReaction(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction, linalg::DenseBandedRowIterator jac, LinearBufferAllocator workSpace) const = 0;
+			virtual void analyticJacobianQuasiStationaryReaction(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction, linalg::BandedSparseRowIterator jac, LinearBufferAllocator workSpace) const = 0;
+
+			/**
+			* @brief fills the conserved moieties matrix and the vector of components involved in qs reactions
+			* @param [in,out] M Matrix to be filled with the conserved moieties
+			* @param [in,out] QsCompBulk Vector to be filled with the components involved in qs reactions
+			*/
+			virtual void fillConservedMoietiesBulk(Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>& M, int& nConservedQuants, std::vector<int>& QsCompBulk) {}
+			virtual void fillConservedMoietiesBulk(Eigen::Matrix<active, Eigen::Dynamic, Eigen::Dynamic>& M, int& nConservedQuants, std::vector<int>& QsCompBulk) {}
+
+
+			/**
+			 * @brief Returns whether this dynamic reaction model has quasi-stationary reactions
+			 * @details Quasi-stationary reactions are reactions that are in equilibrium and can be solved
+			 *          algebraically. This function is used to determine whether the model can be solved
+			 *          in quasi-stationary mode.
+			 * @return @c true if the model has quasi-stationary reactions, otherwise @c false
+			 */
+			virtual bool hasQuasiStationaryReactionsBulk() const CADET_NOEXCEPT { return false; }
+
+			virtual void timeDerivativeQuasiStationaryReaction(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double* dReacDt, LinearBufferAllocator workSpace) = 0;
+
+			virtual int const* reactionQuasiStationarity() const = 0;
+
+			virtual auto numConservedMoities() const -> unsigned int { return 0; }
+			virtual auto configureConservedMoity() -> bool { return false; }
+			virtual unsigned int numReactionQuasiStationary() const { return 0; }
+			virtual auto quasiStationaryComponentMap() const-> std::vector<int>
+			{
+				std::vector<int> v = { 0 };
+				return v;
+			};
+			virtual auto matrixMoietiesBulk() -> Eigen::Matrix<active, Eigen::Dynamic, Eigen::Dynamic>
+			{
+				Eigen::Matrix<active, Eigen::Dynamic, Eigen::Dynamic> M;
+				return M;
+			}
+
+
 #ifdef ENABLE_DG
-	virtual void analyticJacobianLiquidAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double factor, linalg::BandedEigenSparseRowIterator jac, LinearBufferAllocator workSpace) const = 0;
+			virtual void analyticJacobianLiquidAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double factor, linalg::BandedEigenSparseRowIterator jac, LinearBufferAllocator workSpace) const = 0;
 
 #endif
 
-	/**
-	 * @brief Evaluates the residual for one combined phase cell
-	 * @details Adds the dynamic reaction terms to the residual vector for the given
-	 *          combined phase cell. The reaction terms are premultiplied with a given
-	 *          factor. That is, this function realizes
-	 *          \f[ \begin{align} 
-	 *              \text{res} = \text{res} + \gamma R
-	 *          \end{align} \f]
-	 *          where @f$ R @f$ are the reaction terms.
-	 *          
-	 *          This function is called simultaneously from multiple threads.
-	 * 
-	 * @param [in] t Current time point
-	 * @param [in] secIdx Index of the current section
-	 * @param [in] colPos Position in normalized coordinates (column inlet = 0, column outlet = 1; outer shell = 1, inner center = 0)
-	 * @param [in] yLiquid Pointer to first component in the current cell's liquid phase
-	 * @param [in] ySolid Pointer to first component in the current cell's solid phase
-	 * @param [out] resLiquid Pointer to residual of the first component in the current particle shell's liquid phase
-	 * @param [out] resSolid Pointer to residual of the first bound state of the first component in the current particle shell
-	 * @param [in] factor Factor @f$ \gamma @f$
-	 * @param [in,out] workSpace Memory work space
-	 * @return @c 0 on success, @c -1 on non-recoverable error, and @c +1 on recoverable error
-	 */
-	virtual int residualCombinedAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, active const* yLiquid,
-		active const* ySolid, active* resLiquid, active* resSolid, double factor, LinearBufferAllocator workSpace) const = 0;
+			/**
+			 * @brief Evaluates the residual for one combined phase cell
+			 * @details Adds the dynamic reaction terms to the residual vector for the given
+			 *          combined phase cell. The reaction terms are premultiplied with a given
+			 *          factor. That is, this function realizes
+			 *          \f[ \begin{align}
+			 *              \text{res} = \text{res} + \gamma R
+			 *          \end{align} \f]
+			 *          where @f$ R @f$ are the reaction terms.
+			 *
+			 *          This function is called simultaneously from multiple threads.
+			 *
+			 * @param [in] t Current time point
+			 * @param [in] secIdx Index of the current section
+			 * @param [in] colPos Position in normalized coordinates (column inlet = 0, column outlet = 1; outer shell = 1, inner center = 0)
+			 * @param [in] yLiquid Pointer to first component in the current cell's liquid phase
+			 * @param [in] ySolid Pointer to first component in the current cell's solid phase
+			 * @param [out] resLiquid Pointer to residual of the first component in the current particle shell's liquid phase
+			 * @param [out] resSolid Pointer to residual of the first bound state of the first component in the current particle shell
+			 * @param [in] factor Factor @f$ \gamma @f$
+			 * @param [in,out] workSpace Memory work space
+			 * @return @c 0 on success, @c -1 on non-recoverable error, and @c +1 on recoverable error
+			 */
+			virtual int residualCombinedAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, active const* yLiquid,
+				active const* ySolid, active* resLiquid, active* resSolid, double factor, LinearBufferAllocator workSpace) const = 0;
 
-	virtual int residualCombinedAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* yLiquid,
-		double const* ySolid, active* resLiquid, active* resSolid, double factor, LinearBufferAllocator workSpace) const = 0;
+			virtual int residualCombinedAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* yLiquid,
+				double const* ySolid, active* resLiquid, active* resSolid, double factor, LinearBufferAllocator workSpace) const = 0;
 
-	virtual int residualCombinedAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* yLiquid,
-		double const* ySolid, double* resLiquid, double* resSolid, double factor, LinearBufferAllocator workSpace) const = 0;
+			virtual int residualCombinedAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* yLiquid,
+				double const* ySolid, double* resLiquid, double* resSolid, double factor, LinearBufferAllocator workSpace) const = 0;
 
-	/**
-	 * @brief Adds the analytical Jacobian of the reaction terms for one combined phase cell
-	 * @details Adds the Jacobian of the dynamic reaction terms for the given combined phase
-	 *          cell to the full Jacobian. The reaction terms are premultiplied with a given
-	 *          factor. That is, this function realizes
-	 *          \f[ \begin{align} 
-	 *              J = J + \gamma J_R
-	 *          \end{align} \f]
-	 *          where @f$ J_R @f$ is the Jacobian of the reaction terms.
-	 * 
-	 *          This function is called simultaneously from multiple threads.
-	 *          It can be left out (empty implementation) if AD is used to evaluate the Jacobian.
-	 *
-	 * @param [in] t Current time point
-	 * @param [in] secIdx Index of the current section
-	 * @param [in] colPos Position in normalized coordinates (column inlet = 0, column outlet = 1; outer shell = 1, inner center = 0)
-	 * @param [in] yLiquid Pointer to first component in the current cell's liquid phase
-	 * @param [in] ySolid Pointer to first component in the current cell's solid phase
-	 * @param [in] factor Factor @f$ \gamma @f$
-	 * @param [in,out] jacLiquid Row iterator pointing to the first component row of the underlying matrix in which the Jacobian is stored
-	 * @param [in,out] jacSolid Row iterator pointing to the first bound state row of the underlying matrix in which the Jacobian is stored
-	 * @param [in,out] workSpace Memory work space
-	 */
-	virtual void analyticJacobianCombinedAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* yLiquid, double const* ySolid, double factor, linalg::BandMatrix::RowIterator jacLiquid, linalg::BandMatrix::RowIterator jacSolid, LinearBufferAllocator workSpace) const = 0;
-	virtual void analyticJacobianCombinedAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* yLiquid, double const* ySolid, double factor, linalg::DenseBandedRowIterator jacLiquid, linalg::DenseBandedRowIterator jacSolid, LinearBufferAllocator workSpace) const = 0;
-	virtual void analyticJacobianCombinedAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* yLiquid, double const* ySolid, double factor, linalg::BandMatrix::RowIterator jacLiquid, linalg::DenseBandedRowIterator jacSolid, LinearBufferAllocator workSpace) const = 0;
-	#ifdef ENABLE_DG
-	virtual void analyticJacobianCombinedAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* yLiquid, double const* ySolid, double factor, linalg::BandedEigenSparseRowIterator jacLiquid, linalg::DenseBandedRowIterator jacSolid, LinearBufferAllocator workSpace) const = 0;
-	#endif
+			/**
+			 * @brief Adds the analytical Jacobian of the reaction terms for one combined phase cell
+			 * @details Adds the Jacobian of the dynamic reaction terms for the given combined phase
+			 *          cell to the full Jacobian. The reaction terms are premultiplied with a given
+			 *          factor. That is, this function realizes
+			 *          \f[ \begin{align}
+			 *              J = J + \gamma J_R
+			 *          \end{align} \f]
+			 *          where @f$ J_R @f$ is the Jacobian of the reaction terms.
+			 *
+			 *          This function is called simultaneously from multiple threads.
+			 *          It can be left out (empty implementation) if AD is used to evaluate the Jacobian.
+			 *
+			 * @param [in] t Current time point
+			 * @param [in] secIdx Index of the current section
+			 * @param [in] colPos Position in normalized coordinates (column inlet = 0, column outlet = 1; outer shell = 1, inner center = 0)
+			 * @param [in] yLiquid Pointer to first component in the current cell's liquid phase
+			 * @param [in] ySolid Pointer to first component in the current cell's solid phase
+			 * @param [in] factor Factor @f$ \gamma @f$
+			 * @param [in,out] jacLiquid Row iterator pointing to the first component row of the underlying matrix in which the Jacobian is stored
+			 * @param [in,out] jacSolid Row iterator pointing to the first bound state row of the underlying matrix in which the Jacobian is stored
+			 * @param [in,out] workSpace Memory work space
+			 */
+			virtual void analyticJacobianCombinedAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* yLiquid, double const* ySolid, double factor, linalg::BandMatrix::RowIterator jacLiquid, linalg::BandMatrix::RowIterator jacSolid, LinearBufferAllocator workSpace) const = 0;
+			virtual void analyticJacobianCombinedAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* yLiquid, double const* ySolid, double factor, linalg::DenseBandedRowIterator jacLiquid, linalg::DenseBandedRowIterator jacSolid, LinearBufferAllocator workSpace) const = 0;
+			virtual void analyticJacobianCombinedAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* yLiquid, double const* ySolid, double factor, linalg::BandMatrix::RowIterator jacLiquid, linalg::DenseBandedRowIterator jacSolid, LinearBufferAllocator workSpace) const = 0;
+#ifdef ENABLE_DG
+			virtual void analyticJacobianCombinedAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* yLiquid, double const* ySolid, double factor, linalg::BandedEigenSparseRowIterator jacLiquid, linalg::DenseBandedRowIterator jacSolid, LinearBufferAllocator workSpace) const = 0;
+#endif
 
-	/**
-	 * @brief Returns the number of reactions for a liquid phase cell
-	 * @return Number of reactions
-	 */
-	virtual unsigned int numReactionsLiquid() const CADET_NOEXCEPT = 0;
+			/**
+			 * @brief Returns the number of reactions for a liquid phase cell
+			 * @return Number of reactions
+			 */
+			virtual unsigned int numReactionsLiquid() const CADET_NOEXCEPT = 0;
 
-	/**
-	 * @brief Returns the number of reactions for a combined phase cell
-	 * @return Number of reactions
-	 */
-	virtual unsigned int numReactionsCombined() const CADET_NOEXCEPT = 0;
-	
-	/**
-	 * @brief Returns the number of reactions in quasi stationary state
-	 * @return Number of reactions
-	 */
-	virtual unsigned int numReactionQuasiStationary() const CADET_NOEXCEPT = 0;
+			/**
+			 * @brief Returns the number of reactions for a combined phase cell
+			 * @return Number of reactions
+			 */
+			virtual unsigned int numReactionsCombined() const CADET_NOEXCEPT = 0;
 
-protected:
-};
 
-} // namespace model
+		protected:
+		};
+
+	} // namespace model
 } // namespace cadet
 
 #endif  // LIBCADET_REACTIONMODELINTERFACE_HPP_

--- a/src/libcadet/model/ReactionModel.hpp
+++ b/src/libcadet/model/ReactionModel.hpp
@@ -214,12 +214,17 @@ public:
 		double* res, double factor, LinearBufferAllocator workSpace) const = 0;
 	
 
-	virtual int quasiStationaryFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, active const* y,
-		Eigen::Map<Eigen::VectorXd> fluxes, int const* mapQSReac, LinearBufferAllocator workSpace) = 0;
+	virtual int computeQuasiStationaryReactionFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,
+		Eigen::Map<Eigen::Vector<active, Eigen::Dynamic>> fluxes, int const* mapQSReac, LinearBufferAllocator workSpace) = 0;
 
-	virtual int quasiStationaryFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,
-		Eigen::Map<Eigen::VectorXd> fluxes, int const* mapQSReac, LinearBufferAllocator workSpace) = 0;
+	virtual int computeQuasiStationaryReactionFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, active const* y,
+		Eigen::Map<Eigen::Vector<double, Eigen::Dynamic>> fluxes, int const* mapQSReac, LinearBufferAllocator workSpace) = 0;
 
+	virtual int computeQuasiStationaryReactionFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,
+		Eigen::Map<Eigen::Vector<double, Eigen::Dynamic>> fluxes, int const* mapQSReac, LinearBufferAllocator workSpace) = 0;
+
+	virtual int computeQuasiStationaryReactionFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, active const* y,
+		Eigen::Map<Eigen::Vector<active, Eigen::Dynamic>> fluxes, int const* mapQSReac, LinearBufferAllocator workSpace) = 0;
 
 	/**
 	 * @brief Adds the analytical Jacobian of the reaction terms for one liquid phase cell
@@ -246,15 +251,29 @@ public:
 	virtual void analyticJacobianLiquidAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double factor, linalg::DenseBandedRowIterator jac, LinearBufferAllocator workSpace) const = 0;
 	virtual void analyticJacobianLiquidAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double factor, linalg::BandedSparseRowIterator jac, LinearBufferAllocator workSpace) const = 0;
 	
-	virtual void analyticQuasiSteadyJacobianLiquid(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction, linalg::BandMatrix::RowIterator jac, LinearBufferAllocator workSpace) const = 0;
-	virtual void analyticQuasiSteadyJacobianLiquid(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction, linalg::DenseBandedRowIterator jac, LinearBufferAllocator workSpace) const = 0;
-	virtual void analyticQuasiSteadyJacobianLiquid(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction, linalg::BandedSparseRowIterator jac, LinearBufferAllocator workSpace) const = 0;
+	virtual void analyticJacobianQuasiStationaryReaction(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction, linalg::BandMatrix::RowIterator jac, LinearBufferAllocator workSpace) const = 0;
+	virtual void analyticJacobianQuasiStationaryReaction(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction, linalg::DenseBandedRowIterator jac, LinearBufferAllocator workSpace) const = 0;
+	virtual void analyticJacobianQuasiStationaryReaction(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction, linalg::BandedSparseRowIterator jac, LinearBufferAllocator workSpace) const = 0;
 
 	virtual void analyticJacobianLiquidSingleFluxAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction, linalg::BandMatrix::RowIterator jac, LinearBufferAllocator workSpace) const = 0;
 	virtual void analyticJacobianLiquidSingleFluxAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction, linalg::DenseBandedRowIterator jac, LinearBufferAllocator workSpace) const = 0;
 	virtual void analyticJacobianLiquidSingleFluxAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction, linalg::BandedSparseRowIterator jac, LinearBufferAllocator workSpace) const = 0;
 	
-	virtual void fillConservedMoietiesBulk(Eigen::MatrixXd& M, unsigned int & QSReaction, std::vector<int>& _QsCompBulk) = 0;
+	/**
+	* @brief fills the conserved moieties matrix and the vector of components involved in qs reactions
+	* @param [in,out] M Matrix to be filled with the conserved moieties
+	* @param [in,out] QsCompBulk Vector to be filled with the components involved in qs reactions
+	*/
+	virtual void fillConservedMoietiesBulk(Eigen::MatrixXd& M, std::vector<int>& QsCompBulk) {}
+
+	/**
+	 * @brief Returns whether this dynamic reaction model has quasi-stationary reactions
+	 * @details Quasi-stationary reactions are reactions that are in equilibrium and can be solved
+	 *          algebraically. This function is used to determine whether the model can be solved
+	 *          in quasi-stationary mode.
+	 * @return @c true if the model has quasi-stationary reactions, otherwise @c false
+	 */
+	virtual bool hasQuasiStationaryReactionsBulk() const CADET_NOEXCEPT { return false; }
 
 	virtual void timeDerivativeQuasiStationaryReaction(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double* dReacDt, LinearBufferAllocator workSpace) = 0;
 

--- a/src/libcadet/model/ReactionModel.hpp
+++ b/src/libcadet/model/ReactionModel.hpp
@@ -249,6 +249,10 @@ public:
 	virtual void analyticQuasiSteadyJacobianLiquid(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction, linalg::BandMatrix::RowIterator jac, LinearBufferAllocator workSpace) const = 0;
 	virtual void analyticQuasiSteadyJacobianLiquid(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction, linalg::DenseBandedRowIterator jac, LinearBufferAllocator workSpace) const = 0;
 	virtual void analyticQuasiSteadyJacobianLiquid(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction, linalg::BandedSparseRowIterator jac, LinearBufferAllocator workSpace) const = 0;
+
+	virtual void analyticJacobianLiquidSingleFluxAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction, linalg::BandMatrix::RowIterator jac, LinearBufferAllocator workSpace) const = 0;
+	virtual void analyticJacobianLiquidSingleFluxAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction, linalg::DenseBandedRowIterator jac, LinearBufferAllocator workSpace) const = 0;
+	virtual void analyticJacobianLiquidSingleFluxAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction, linalg::BandedSparseRowIterator jac, LinearBufferAllocator workSpace) const = 0;
 	
 	virtual void fillConservedMoietiesBulk(Eigen::MatrixXd& M, std::vector<int>& QSReaction, std::vector<int>& _QsCompBulk) = 0;
 

--- a/src/libcadet/model/ReactionModel.hpp
+++ b/src/libcadet/model/ReactionModel.hpp
@@ -290,6 +290,17 @@ namespace cadet
 				Eigen::Matrix<active, Eigen::Dynamic, Eigen::Dynamic> M;
 				return M;
 			}
+			virtual auto algIdx() -> std::vector<int>
+			{
+				std::vector<int> v{ 0 };
+				return v;
+			}
+
+			virtual auto consMoityIdx() -> std::vector<int> 
+			{
+				std::vector<int> v{ 0 };
+				return v;
+			}
 
 
 #ifdef ENABLE_DG

--- a/src/libcadet/model/ReactionModel.hpp
+++ b/src/libcadet/model/ReactionModel.hpp
@@ -265,6 +265,9 @@ public:
 	* @param [in,out] QsCompBulk Vector to be filled with the components involved in qs reactions
 	*/
 	virtual void fillConservedMoietiesBulk(Eigen::MatrixXd& M, std::vector<int>& QsCompBulk) {}
+	virtual void fillConservedMoietiesBulk2(Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>& M, std::vector<int>& QsCompBulk) {}
+	virtual void fillConservedMoietiesBulk2(Eigen::Matrix<active, Eigen::Dynamic, Eigen::Dynamic>& M, std::vector<int>& QsCompBulk) {}
+
 
 	/**
 	 * @brief Returns whether this dynamic reaction model has quasi-stationary reactions
@@ -358,9 +361,10 @@ public:
 	virtual unsigned int numReactionsCombined() const CADET_NOEXCEPT = 0;
 	
 	/**
-	 * @brief Returns wheather liquid reactions are in quasi-stationary state
-	 * @return boolean
+	 * @brief Returns the number of reactions in quasi stationary state
+	 * @return Number of reactions
 	 */
+	virtual unsigned int numReactionQuasiStationary() const CADET_NOEXCEPT = 0;
 
 protected:
 };

--- a/src/libcadet/model/ReactionModel.hpp
+++ b/src/libcadet/model/ReactionModel.hpp
@@ -273,8 +273,6 @@ namespace cadet
 			 */
 			virtual bool hasQuasiStationaryReactionsBulk() const CADET_NOEXCEPT { return false; }
 
-			virtual void timeDerivativeQuasiStationaryReaction(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double* dReacDt, LinearBufferAllocator workSpace) = 0;
-
 			virtual int const* reactionQuasiStationarity() const = 0;
 
 			virtual auto numConservedMoities() const -> unsigned int { return 0; }
@@ -290,7 +288,7 @@ namespace cadet
 				Eigen::Matrix<active, Eigen::Dynamic, Eigen::Dynamic> M;
 				return M;
 			}
-			virtual auto algIdx() -> std::vector<int>
+			virtual auto algIdx() const -> std::vector<int>
 			{
 				std::vector<int> v{ 0 };
 				return v;

--- a/src/libcadet/model/ReactionModel.hpp
+++ b/src/libcadet/model/ReactionModel.hpp
@@ -215,16 +215,16 @@ public:
 	
 
 	virtual int computeQuasiStationaryReactionFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,
-		Eigen::Map<Eigen::Vector<active, Eigen::Dynamic>> fluxes, int const* mapQSReac, LinearBufferAllocator workSpace) = 0;
+		Eigen::Map<Eigen::Vector<active, Eigen::Dynamic>> fluxes,  LinearBufferAllocator workSpace) = 0;
 
 	virtual int computeQuasiStationaryReactionFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, active const* y,
-		Eigen::Map<Eigen::Vector<double, Eigen::Dynamic>> fluxes, int const* mapQSReac, LinearBufferAllocator workSpace) = 0;
+		Eigen::Map<Eigen::Vector<double, Eigen::Dynamic>> fluxes, LinearBufferAllocator workSpace) = 0;
 
 	virtual int computeQuasiStationaryReactionFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,
-		Eigen::Map<Eigen::Vector<double, Eigen::Dynamic>> fluxes, int const* mapQSReac, LinearBufferAllocator workSpace) = 0;
+		Eigen::Map<Eigen::Vector<double, Eigen::Dynamic>> fluxes,  LinearBufferAllocator workSpace) = 0;
 
 	virtual int computeQuasiStationaryReactionFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, active const* y,
-		Eigen::Map<Eigen::Vector<active, Eigen::Dynamic>> fluxes, int const* mapQSReac, LinearBufferAllocator workSpace) = 0;
+		Eigen::Map<Eigen::Vector<active, Eigen::Dynamic>> fluxes, LinearBufferAllocator workSpace) = 0;
 
 	/**
 	 * @brief Adds the analytical Jacobian of the reaction terms for one liquid phase cell
@@ -255,18 +255,13 @@ public:
 	virtual void analyticJacobianQuasiStationaryReaction(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction, linalg::DenseBandedRowIterator jac, LinearBufferAllocator workSpace) const = 0;
 	virtual void analyticJacobianQuasiStationaryReaction(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction, linalg::BandedSparseRowIterator jac, LinearBufferAllocator workSpace) const = 0;
 
-	virtual void analyticJacobianLiquidSingleFluxAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction, linalg::BandMatrix::RowIterator jac, LinearBufferAllocator workSpace) const = 0;
-	virtual void analyticJacobianLiquidSingleFluxAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction, linalg::DenseBandedRowIterator jac, LinearBufferAllocator workSpace) const = 0;
-	virtual void analyticJacobianLiquidSingleFluxAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction, linalg::BandedSparseRowIterator jac, LinearBufferAllocator workSpace) const = 0;
-	
 	/**
 	* @brief fills the conserved moieties matrix and the vector of components involved in qs reactions
 	* @param [in,out] M Matrix to be filled with the conserved moieties
 	* @param [in,out] QsCompBulk Vector to be filled with the components involved in qs reactions
 	*/
-	virtual void fillConservedMoietiesBulk(Eigen::MatrixXd& M, std::vector<int>& QsCompBulk) {}
-	virtual void fillConservedMoietiesBulk2(Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>& M, int& nConservedQuants, std::vector<int>& QsCompBulk) {}
-	virtual void fillConservedMoietiesBulk2(Eigen::Matrix<active, Eigen::Dynamic, Eigen::Dynamic>& M, int& nConservedQuants, std::vector<int>& QsCompBulk) {}
+	virtual void fillConservedMoietiesBulk(Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>& M, int& nConservedQuants, std::vector<int>& QsCompBulk) {}
+	virtual void fillConservedMoietiesBulk(Eigen::Matrix<active, Eigen::Dynamic, Eigen::Dynamic>& M, int& nConservedQuants, std::vector<int>& QsCompBulk) {}
 
 
 	/**

--- a/src/libcadet/model/ReactionModel.hpp
+++ b/src/libcadet/model/ReactionModel.hpp
@@ -265,8 +265,8 @@ public:
 	* @param [in,out] QsCompBulk Vector to be filled with the components involved in qs reactions
 	*/
 	virtual void fillConservedMoietiesBulk(Eigen::MatrixXd& M, std::vector<int>& QsCompBulk) {}
-	virtual void fillConservedMoietiesBulk2(Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>& M, int& QsCompBulk) {}
-	virtual void fillConservedMoietiesBulk2(Eigen::Matrix<active, Eigen::Dynamic, Eigen::Dynamic>& M, int& QsCompBulk) {}
+	virtual void fillConservedMoietiesBulk2(Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>& M, int& nConservedQuants, std::vector<int>& QsCompBulk) {}
+	virtual void fillConservedMoietiesBulk2(Eigen::Matrix<active, Eigen::Dynamic, Eigen::Dynamic>& M, int& nConservedQuants, std::vector<int>& QsCompBulk) {}
 
 
 	/**

--- a/src/libcadet/model/ReactionModel.hpp
+++ b/src/libcadet/model/ReactionModel.hpp
@@ -246,12 +246,13 @@ public:
 	virtual void analyticJacobianLiquidAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double factor, linalg::DenseBandedRowIterator jac, LinearBufferAllocator workSpace) const = 0;
 	virtual void analyticJacobianLiquidAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double factor, linalg::BandedSparseRowIterator jac, LinearBufferAllocator workSpace) const = 0;
 	
-	virtual void analyticQuasiSteadyJacobianLiquid(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double factor, linalg::BandMatrix::RowIterator jac, LinearBufferAllocator workSpace) const = 0;
-	virtual void analyticQuasiSteadyJacobianLiquid(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double factor, linalg::DenseBandedRowIterator jac, LinearBufferAllocator workSpace) const = 0;
-	virtual void analyticQuasiSteadyJacobianLiquid(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double factor, linalg::BandedSparseRowIterator jac, LinearBufferAllocator workSpace) const = 0;
+	virtual void analyticQuasiSteadyJacobianLiquid(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction, linalg::BandMatrix::RowIterator jac, LinearBufferAllocator workSpace) const = 0;
+	virtual void analyticQuasiSteadyJacobianLiquid(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction, linalg::DenseBandedRowIterator jac, LinearBufferAllocator workSpace) const = 0;
+	virtual void analyticQuasiSteadyJacobianLiquid(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction, linalg::BandedSparseRowIterator jac, LinearBufferAllocator workSpace) const = 0;
 	
 	virtual void fillConservedMoietiesBulk(Eigen::MatrixXd& M, std::vector<int>& QSReaction, std::vector<int>& _QsCompBulk) = 0;
 
+	virtual void timeDerivativeQuasiStationaryReaction(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double* dReacDt, LinearBufferAllocator workSpace) = 0;
 
 #ifdef ENABLE_DG
 	virtual void analyticJacobianLiquidAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double factor, linalg::BandedEigenSparseRowIterator jac, LinearBufferAllocator workSpace) const = 0;

--- a/src/libcadet/model/ReactionModel.hpp
+++ b/src/libcadet/model/ReactionModel.hpp
@@ -11,7 +11,7 @@
 // =============================================================================
 
 /**
- * @file
+ * @file 
  * Defines reaction model interfaces.
  */
 
@@ -26,7 +26,7 @@
 #include "linalg/DenseMatrix.hpp"
 #include "linalg/BandMatrix.hpp"
 #ifdef ENABLE_DG
-#include "linalg/BandedEigenSparseRowIterator.hpp"
+	#include "linalg/BandedEigenSparseRowIterator.hpp"
 #endif
 #include "linalg/CompressedSparseMatrix.hpp"
 #include "AutoDiff.hpp"
@@ -35,356 +35,310 @@
 namespace cadet
 {
 
-	class IParameterProvider;
-	class IExternalFunction;
+class IParameterProvider;
+class IExternalFunction;
 
-	struct ColumnPosition;
+struct ColumnPosition;
 
-	namespace model
-	{
+namespace model
+{
 
-		/**
-		 * @brief Defines an internal DynamicReactionModel interface
-		 * @details Represents dynamic reactions between components in a finite volume cell.
-		 *          Both simple and extended cells are supported. A simple cell contains only
-		 *          liquid phase components. An extended cell contains liquid and solid phase
-		 *          components.
-		 */
-		class IDynamicReactionModel
-		{
-		public:
+/**
+ * @brief Defines an internal DynamicReactionModel interface
+ * @details Represents dynamic reactions between components in a finite volume cell.
+ *          Both simple and extended cells are supported. A simple cell contains only
+ *          liquid phase components. An extended cell contains liquid and solid phase
+ *          components.
+ */
+class IDynamicReactionModel
+{
+public:
 
-			virtual ~IDynamicReactionModel() CADET_NOEXCEPT { }
+	virtual ~IDynamicReactionModel() CADET_NOEXCEPT { }
 
-			/**
-			 * @brief Returns the name of the dynamic reaction model
-			 * @details This name is also used to identify and create the dynamic reaction model in the factory.
-			 * @return Name of the dynamic reaction model
-			 */
-			virtual const char* name() const CADET_NOEXCEPT = 0;
+	/**
+	 * @brief Returns the name of the dynamic reaction model
+	 * @details This name is also used to identify and create the dynamic reaction model in the factory.
+	 * @return Name of the dynamic reaction model
+	 */
+	virtual const char* name() const CADET_NOEXCEPT = 0;
 
-			/**
-			 * @brief Returns whether the dynamic reaction model requires additional parameters supplied by configure()
-			 * @details After construction of an IDynamicReactionModel object, configureModelDiscretization() is called.
-			 *          The dynamic reaction model may require to read additional parameters from the reaction group
-			 *          of the parameter provider. This opportunity is given by a call to configure(). However, a
-			 *          dynamic reaction model may not require this. This function communicates to the outside
-			 *          whether a call to configure() is necessary.
-			 * @return @c true if configure() has to be called, otherwise @c false
-			 */
-			virtual bool requiresConfiguration() const CADET_NOEXCEPT = 0;
+	/**
+	 * @brief Returns whether the dynamic reaction model requires additional parameters supplied by configure()
+	 * @details After construction of an IDynamicReactionModel object, configureModelDiscretization() is called.
+	 *          The dynamic reaction model may require to read additional parameters from the reaction group
+	 *          of the parameter provider. This opportunity is given by a call to configure(). However, a
+	 *          dynamic reaction model may not require this. This function communicates to the outside
+	 *          whether a call to configure() is necessary.
+	 * @return @c true if configure() has to be called, otherwise @c false
+	 */
+	virtual bool requiresConfiguration() const CADET_NOEXCEPT = 0;
 
-			/**
-			 * @brief Returns whether the dynamic reaction model uses the IParameterProvider in configureModelDiscretization()
-			 * @details If the IParameterProvider is used in configureModelDiscretization(), it has to be in the correct scope.
-			 * @return @c true if the IParameterProvider is used in configureModelDiscretization(), otherwise @c false
-			 */
-			virtual bool usesParamProviderInDiscretizationConfig() const CADET_NOEXCEPT = 0;
+	/**
+	 * @brief Returns whether the dynamic reaction model uses the IParameterProvider in configureModelDiscretization()
+	 * @details If the IParameterProvider is used in configureModelDiscretization(), it has to be in the correct scope.
+	 * @return @c true if the IParameterProvider is used in configureModelDiscretization(), otherwise @c false
+	 */
+	virtual bool usesParamProviderInDiscretizationConfig() const CADET_NOEXCEPT = 0;
 
-			/**
-			 * @brief Sets the number of components in the model
-			 * @details This function is called prior to configure() by the underlying model.
-			 *          It can only be called once. Model parameters are configured by configure().
-			 *
-			 * @param [in] paramProvider Parameter provider
-			 * @param [in] nComp Number of components
-			 * @param [in] nBound Array of size @p nComp which contains the number of bound states for each component
-			 * @param [in] boundOffset Array of size @p nComp with offsets to the first bound state of each component beginning from the solid phase
-			 */
-			virtual bool configureModelDiscretization(IParameterProvider& paramProvider, unsigned int nComp, unsigned int const* nBound, unsigned int const* boundOffset) = 0;
+	/**
+	 * @brief Sets the number of components in the model
+	 * @details This function is called prior to configure() by the underlying model.
+	 *          It can only be called once. Model parameters are configured by configure().
+	 * 
+	 * @param [in] paramProvider Parameter provider
+	 * @param [in] nComp Number of components
+	 * @param [in] nBound Array of size @p nComp which contains the number of bound states for each component
+	 * @param [in] boundOffset Array of size @p nComp with offsets to the first bound state of each component beginning from the solid phase
+	 */
+	virtual bool configureModelDiscretization(IParameterProvider& paramProvider, unsigned int nComp, unsigned int const* nBound, unsigned int const* boundOffset) = 0;
 
-			/**
-			 * @brief Configures the model by extracting all non-structural parameters (e.g., model parameters) from the given @p paramProvider
-			 * @details The scope of the cadet::IParameterProvider is left unchanged on return.
-			 *
-			 *          The structure of the model is left unchanged, that is, the number of degrees of
-			 *          freedom stays the same (e.g., number of bound states is left unchanged). Only
-			 *          true (non-structural) model parameters are read and changed.
-			 *
-			 *          This function may only be called if configureModelDiscretization() has been called
-			 *          in the past. Contrary to configureModelDiscretization(), it can be called multiple
-			 *          times.
-			 *
-			 * @param [in] paramProvider Parameter provider
-			 * @param [in] unitOpIdx Index of the unit operation this dynamic reaction model belongs to
-			 * @param [in] parTypeIdx Index of the particle type this dynamic reaction model belongs to
-			 * @return @c true if the configuration was successful, otherwise @c false
-			 */
-			virtual bool configure(IParameterProvider& paramProvider, UnitOpIdx unitOpIdx, ParticleTypeIdx parTypeIdx) = 0;
+	/**
+	 * @brief Configures the model by extracting all non-structural parameters (e.g., model parameters) from the given @p paramProvider
+	 * @details The scope of the cadet::IParameterProvider is left unchanged on return.
+	 * 
+	 *          The structure of the model is left unchanged, that is, the number of degrees of
+	 *          freedom stays the same (e.g., number of bound states is left unchanged). Only
+	 *          true (non-structural) model parameters are read and changed.
+	 *          
+	 *          This function may only be called if configureModelDiscretization() has been called
+	 *          in the past. Contrary to configureModelDiscretization(), it can be called multiple
+	 *          times.
+	 * 
+	 * @param [in] paramProvider Parameter provider
+	 * @param [in] unitOpIdx Index of the unit operation this dynamic reaction model belongs to
+	 * @param [in] parTypeIdx Index of the particle type this dynamic reaction model belongs to
+	 * @return @c true if the configuration was successful, otherwise @c false
+	 */
+	virtual bool configure(IParameterProvider& paramProvider, UnitOpIdx unitOpIdx, ParticleTypeIdx parTypeIdx) = 0;
 
-			/**
-			 * @brief Sets external functions for this dynamic reaction model
-			 * @details The external functions are not owned by this IDynamicReactionModel.
-			 *
-			 * @param [in] extFuns Pointer to array of IExternalFunction objects of size @p size
-			 * @param [in] size Number of elements in the IExternalFunction array @p extFuns
-			 */
-			virtual void setExternalFunctions(IExternalFunction** extFuns, unsigned int size) = 0;
+	/**
+	 * @brief Sets external functions for this dynamic reaction model
+	 * @details The external functions are not owned by this IDynamicReactionModel.
+	 * 
+	 * @param [in] extFuns Pointer to array of IExternalFunction objects of size @p size
+	 * @param [in] size Number of elements in the IExternalFunction array @p extFuns
+	 */
+	virtual void setExternalFunctions(IExternalFunction** extFuns, unsigned int size) = 0;
 
-			/**
-			 * @brief Checks whether a given parameter exists
-			 * @param [in] pId ParameterId that identifies the parameter uniquely
-			 * @return @c true if the parameter exists, otherwise @c false
-			 */
-			virtual bool hasParameter(const ParameterId& pId) const = 0;
+	/**
+	 * @brief Checks whether a given parameter exists
+	 * @param [in] pId ParameterId that identifies the parameter uniquely
+	 * @return @c true if the parameter exists, otherwise @c false
+	 */
+	virtual bool hasParameter(const ParameterId& pId) const = 0;
 
-			/**
-			 * @brief Returns all parameters with their current values that can be made sensitive
-			 * @return Map with all parameters that can be made sensitive along with their current value
-			 */
-			virtual std::unordered_map<ParameterId, double> getAllParameterValues() const = 0;
+	/**
+	 * @brief Returns all parameters with their current values that can be made sensitive
+	 * @return Map with all parameters that can be made sensitive along with their current value
+	 */
+	virtual std::unordered_map<ParameterId, double> getAllParameterValues() const = 0;
 
-			/**
-			 * @brief Sets a parameter value
-			 * @details The parameter identified by its unique parameter is set to the given value.
-			 *
-			 * @param [in] pId ParameterId that identifies the parameter uniquely
-			 * @param [in] value Value of the parameter
-			 * @return @c true if the parameter has been successfully set to the given value,
-			 *         otherwise @c false (e.g., if the parameter is not available in this model)
-			 */
-			virtual bool setParameter(const ParameterId& pId, int value) = 0;
-			virtual bool setParameter(const ParameterId& pId, double value) = 0;
-			virtual bool setParameter(const ParameterId& pId, bool value) = 0;
+	/**
+	 * @brief Sets a parameter value
+	 * @details The parameter identified by its unique parameter is set to the given value.
+	 * 
+	 * @param [in] pId ParameterId that identifies the parameter uniquely
+	 * @param [in] value Value of the parameter
+	 * @return @c true if the parameter has been successfully set to the given value,
+	 *         otherwise @c false (e.g., if the parameter is not available in this model)
+	 */
+	virtual bool setParameter(const ParameterId& pId, int value) = 0;
+	virtual bool setParameter(const ParameterId& pId, double value) = 0;
+	virtual bool setParameter(const ParameterId& pId, bool value) = 0;
 
-			/**
-			 * @brief Returns a pointer to the parameter identified by the given id
-			 * @param [in] pId Parameter Id of the sensitive parameter
-			 * @return a pointer to the parameter if the dynamic reaction model contains the parameter, otherwise @c nullptr
-			 */
-			virtual active* getParameter(const ParameterId& pId) = 0;
+	/**
+	 * @brief Returns a pointer to the parameter identified by the given id
+	 * @param [in] pId Parameter Id of the sensitive parameter
+	 * @return a pointer to the parameter if the dynamic reaction model contains the parameter, otherwise @c nullptr
+	 */
+	virtual active* getParameter(const ParameterId& pId) = 0;
 
-			/**
-			 * @brief Returns whether this dynamic reaction model depends on time
-			 * @details Dynamic reaction models may depend on time if external functions are used.
-			 * @return @c true if the model is time-dependent, otherwise @c false
-			 */
-			virtual bool dependsOnTime() const CADET_NOEXCEPT = 0;
+	/**
+	 * @brief Returns whether this dynamic reaction model depends on time
+	 * @details Dynamic reaction models may depend on time if external functions are used.
+	 * @return @c true if the model is time-dependent, otherwise @c false
+	 */
+	virtual bool dependsOnTime() const CADET_NOEXCEPT = 0;
 
-			/**
-			 * @brief Returns whether this dynamic reaction model requires workspace
-			 * @details The workspace may be required for evaluation of residual and
-			 *          Jacobian. A workspace is a memory buffer whose size is given by
-			 *          workspaceSize().
-			 * @return @c true if the model requires a workspace, otherwise @c false
-			 */
-			virtual bool requiresWorkspace() const CADET_NOEXCEPT = 0;
+	/**
+	 * @brief Returns whether this dynamic reaction model requires workspace
+	 * @details The workspace may be required for evaluation of residual and
+	 *          Jacobian. A workspace is a memory buffer whose size is given by
+	 *          workspaceSize().
+	 * @return @c true if the model requires a workspace, otherwise @c false
+	 */
+	virtual bool requiresWorkspace() const CADET_NOEXCEPT = 0;
 
-			/**
-			 * @brief Returns the size of the required workspace in bytes
-			 * @details The memory is required for externally dependent dynamic reaction models.
-			 * @param [in] nComp Number of components
-			 * @param [in] totalNumBoundStates Total number of bound states
-			 * @param [in] nBoundStates Array with bound states for each component
-			 * @return Size of the workspace in bytes
-			 */
-			virtual unsigned int workspaceSize(unsigned int nComp, unsigned int totalNumBoundStates, unsigned int const* nBoundStates) const CADET_NOEXCEPT = 0;
+	/**
+	 * @brief Returns the size of the required workspace in bytes
+	 * @details The memory is required for externally dependent dynamic reaction models.
+	 * @param [in] nComp Number of components
+	 * @param [in] totalNumBoundStates Total number of bound states
+	 * @param [in] nBoundStates Array with bound states for each component
+	 * @return Size of the workspace in bytes
+	 */
+	virtual unsigned int workspaceSize(unsigned int nComp, unsigned int totalNumBoundStates, unsigned int const* nBoundStates) const CADET_NOEXCEPT = 0;
 
-			/**
-			 * @brief Evaluates the residual for one liquid phase cell
-			 * @details Adds the dynamic reaction terms to the residual vector for the given
-			 *          liquid phase cell. The reaction terms are premultiplied with a given
-			 *          factor. That is, this function realizes
-			 *          \f[ \begin{align}
-			 *              \text{res} = \text{res} + \gamma R
-			 *          \end{align} \f]
-			 *          where @f$ R @f$ are the reaction terms.
-			 *
-			 *          This function is called simultaneously from multiple threads.
-			 *
-			 * @param [in] t Current time point
-			 * @param [in] secIdx Index of the current section
-			 * @param [in] colPos Position in normalized coordinates (column inlet = 0, column outlet = 1; outer shell = 1, inner center = 0)
-			 * @param [in] y Pointer to first component in the current cell
-			 * @param [out] res Pointer to residual of the first component in the current particle shell's liquid phase
-			 * @param [in] factor Factor @f$ \gamma @f$
-			 * @param [in,out] workSpace Memory work space
-			 * @return @c 0 on success, @c -1 on non-recoverable error, and @c +1 on recoverable error
-			 */
-			virtual int residualLiquidAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, active const* y,
-				active* res, const active& factor, LinearBufferAllocator workSpace) const = 0;
+	/**
+	 * @brief Evaluates the residual for one liquid phase cell
+	 * @details Adds the dynamic reaction terms to the residual vector for the given
+	 *          liquid phase cell. The reaction terms are premultiplied with a given
+	 *          factor. That is, this function realizes
+	 *          \f[ \begin{align} 
+	 *              \text{res} = \text{res} + \gamma R
+	 *          \end{align} \f]
+	 *          where @f$ R @f$ are the reaction terms.
+	 *          
+	 *          This function is called simultaneously from multiple threads.
+	 * 
+	 * @param [in] t Current time point
+	 * @param [in] secIdx Index of the current section
+	 * @param [in] colPos Position in normalized coordinates (column inlet = 0, column outlet = 1; outer shell = 1, inner center = 0)
+	 * @param [in] y Pointer to first component in the current cell
+	 * @param [out] res Pointer to residual of the first component in the current particle shell's liquid phase
+	 * @param [in] factor Factor @f$ \gamma @f$
+	 * @param [in,out] workSpace Memory work space
+	 * @return @c 0 on success, @c -1 on non-recoverable error, and @c +1 on recoverable error
+	 */
+	virtual int residualLiquidAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, active const* y,
+		active* res, const active& factor, LinearBufferAllocator workSpace) const = 0;
 
-			virtual int residualLiquidAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, active const* y,
-				active* res, double factor, LinearBufferAllocator workSpace) const = 0;
+	virtual int residualLiquidAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, active const* y,
+		active* res, double factor, LinearBufferAllocator workSpace) const = 0;
 
-			virtual int residualLiquidAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,
-				active* res, double factor, LinearBufferAllocator workSpace) const = 0;
+	virtual int residualLiquidAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,
+		active* res, double factor, LinearBufferAllocator workSpace) const = 0;
 
-			virtual int residualLiquidAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,
-				double* res, double factor, LinearBufferAllocator workSpace) const = 0;
+	virtual int residualLiquidAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,
+		double* res, double factor, LinearBufferAllocator workSpace) const = 0;
 
+	/**
+	 * @brief Adds the analytical Jacobian of the reaction terms for one liquid phase cell
+	 * @details Adds the Jacobian of the dynamic reaction terms for the given liquid phase
+	 *          cell to the full Jacobian. The reaction terms are premultiplied with a given
+	 *          factor. That is, this function realizes
+	 *          \f[ \begin{align} 
+	 *              J = J + \gamma J_R
+	 *          \end{align} \f]
+	 *          where @f$ J_R @f$ is the Jacobian of the reaction terms.
+	 * 
+	 *          This function is called simultaneously from multiple threads.
+	 *          It can be left out (empty implementation) if AD is used to evaluate the Jacobian.
+	 *
+	 * @param [in] t Current time point
+	 * @param [in] secIdx Index of the current section
+	 * @param [in] colPos Position in normalized coordinates (column inlet = 0, column outlet = 1; outer shell = 1, inner center = 0)
+	 * @param [in] y Pointer to first component in the current cell
+	 * @param [in] factor Factor @f$ \gamma @f$
+	 * @param [in,out] jac Row iterator pointing to the first component row of the underlying matrix in which the Jacobian is stored
+	 * @param [in,out] workSpace Memory work space
+	 */
+	virtual void analyticJacobianLiquidAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double factor, linalg::BandMatrix::RowIterator jac, LinearBufferAllocator workSpace) const = 0;
+	virtual void analyticJacobianLiquidAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double factor, linalg::DenseBandedRowIterator jac, LinearBufferAllocator workSpace) const = 0;
+	virtual void analyticJacobianLiquidAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double factor, linalg::BandedSparseRowIterator jac, LinearBufferAllocator workSpace) const = 0;
+	#ifdef ENABLE_DG
+	virtual void analyticJacobianLiquidAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double factor, linalg::BandedEigenSparseRowIterator jac, LinearBufferAllocator workSpace) const = 0;
+	#endif
 
-			virtual int computeQuasiStationaryReactionFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,
-				Eigen::Map<Eigen::Vector<active, Eigen::Dynamic>> fluxes, LinearBufferAllocator workSpace) = 0;
+	/**
+	 * @brief Evaluates the residual for one combined phase cell
+	 * @details Adds the dynamic reaction terms to the residual vector for the given
+	 *          combined phase cell. The reaction terms are premultiplied with a given
+	 *          factor. That is, this function realizes
+	 *          \f[ \begin{align} 
+	 *              \text{res} = \text{res} + \gamma R
+	 *          \end{align} \f]
+	 *          where @f$ R @f$ are the reaction terms.
+	 *          
+	 *          This function is called simultaneously from multiple threads.
+	 * 
+	 * @param [in] t Current time point
+	 * @param [in] secIdx Index of the current section
+	 * @param [in] colPos Position in normalized coordinates (column inlet = 0, column outlet = 1; outer shell = 1, inner center = 0)
+	 * @param [in] yLiquid Pointer to first component in the current cell's liquid phase
+	 * @param [in] ySolid Pointer to first component in the current cell's solid phase
+	 * @param [out] resLiquid Pointer to residual of the first component in the current particle shell's liquid phase
+	 * @param [out] resSolid Pointer to residual of the first bound state of the first component in the current particle shell
+	 * @param [in] factor Factor @f$ \gamma @f$
+	 * @param [in,out] workSpace Memory work space
+	 * @return @c 0 on success, @c -1 on non-recoverable error, and @c +1 on recoverable error
+	 */
+	virtual int residualCombinedAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, active const* yLiquid,
+		active const* ySolid, active* resLiquid, active* resSolid, double factor, LinearBufferAllocator workSpace) const = 0;
 
-			virtual int computeQuasiStationaryReactionFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, active const* y,
-				Eigen::Map<Eigen::Vector<double, Eigen::Dynamic>> fluxes, LinearBufferAllocator workSpace) = 0;
+	virtual int residualCombinedAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* yLiquid,
+		double const* ySolid, active* resLiquid, active* resSolid, double factor, LinearBufferAllocator workSpace) const = 0;
 
-			virtual int computeQuasiStationaryReactionFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,
-				Eigen::Map<Eigen::Vector<double, Eigen::Dynamic>> fluxes, LinearBufferAllocator workSpace) = 0;
+	virtual int residualCombinedAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* yLiquid,
+		double const* ySolid, double* resLiquid, double* resSolid, double factor, LinearBufferAllocator workSpace) const = 0;
 
-			virtual int computeQuasiStationaryReactionFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, active const* y,
-				Eigen::Map<Eigen::Vector<active, Eigen::Dynamic>> fluxes, LinearBufferAllocator workSpace) = 0;
+	/**
+	 * @brief Adds the analytical Jacobian of the reaction terms for one combined phase cell
+	 * @details Adds the Jacobian of the dynamic reaction terms for the given combined phase
+	 *          cell to the full Jacobian. The reaction terms are premultiplied with a given
+	 *          factor. That is, this function realizes
+	 *          \f[ \begin{align} 
+	 *              J = J + \gamma J_R
+	 *          \end{align} \f]
+	 *          where @f$ J_R @f$ is the Jacobian of the reaction terms.
+	 * 
+	 *          This function is called simultaneously from multiple threads.
+	 *          It can be left out (empty implementation) if AD is used to evaluate the Jacobian.
+	 *
+	 * @param [in] t Current time point
+	 * @param [in] secIdx Index of the current section
+	 * @param [in] colPos Position in normalized coordinates (column inlet = 0, column outlet = 1; outer shell = 1, inner center = 0)
+	 * @param [in] yLiquid Pointer to first component in the current cell's liquid phase
+	 * @param [in] ySolid Pointer to first component in the current cell's solid phase
+	 * @param [in] factor Factor @f$ \gamma @f$
+	 * @param [in,out] jacLiquid Row iterator pointing to the first component row of the underlying matrix in which the Jacobian is stored
+	 * @param [in,out] jacSolid Row iterator pointing to the first bound state row of the underlying matrix in which the Jacobian is stored
+	 * @param [in,out] workSpace Memory work space
+	 */
+	virtual void analyticJacobianCombinedAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* yLiquid, double const* ySolid, double factor, linalg::BandMatrix::RowIterator jacLiquid, linalg::BandMatrix::RowIterator jacSolid, LinearBufferAllocator workSpace) const = 0;
+	virtual void analyticJacobianCombinedAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* yLiquid, double const* ySolid, double factor, linalg::DenseBandedRowIterator jacLiquid, linalg::DenseBandedRowIterator jacSolid, LinearBufferAllocator workSpace) const = 0;
+	virtual void analyticJacobianCombinedAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* yLiquid, double const* ySolid, double factor, linalg::BandMatrix::RowIterator jacLiquid, linalg::DenseBandedRowIterator jacSolid, LinearBufferAllocator workSpace) const = 0;
+	#ifdef ENABLE_DG
+	virtual void analyticJacobianCombinedAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* yLiquid, double const* ySolid, double factor, linalg::BandedEigenSparseRowIterator jacLiquid, linalg::DenseBandedRowIterator jacSolid, LinearBufferAllocator workSpace) const = 0;
+	#endif
 
-			/**
-			 * @brief Adds the analytical Jacobian of the reaction terms for one liquid phase cell
-			 * @details Adds the Jacobian of the dynamic reaction terms for the given liquid phase
-			 *          cell to the full Jacobian. The reaction terms are premultiplied with a given
-			 *          factor. That is, this function realizes
-			 *          \f[ \begin{align}
-			 *              J = J + \gamma J_R
-			 *          \end{align} \f]
-			 *          where @f$ J_R @f$ is the Jacobian of the reaction terms.
-			 *
-			 *          This function is called simultaneously from multiple threads.
-			 *          It can be left out (empty implementation) if AD is used to evaluate the Jacobian.
-			 *
-			 * @param [in] t Current time point
-			 * @param [in] secIdx Index of the current section
-			 * @param [in] colPos Position in normalized coordinates (column inlet = 0, column outlet = 1; outer shell = 1, inner center = 0)
-			 * @param [in] y Pointer to first component in the current cell
-			 * @param [in] factor Factor @f$ \gamma @f$
-			 * @param [in,out] jac Row iterator pointing to the first component row of the underlying matrix in which the Jacobian is stored
-			 * @param [in,out] workSpace Memory work space
-			 */
-			virtual void analyticJacobianLiquidAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double factor, linalg::BandMatrix::RowIterator jac, LinearBufferAllocator workSpace) const = 0;
-			virtual void analyticJacobianLiquidAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double factor, linalg::DenseBandedRowIterator jac, LinearBufferAllocator workSpace) const = 0;
-			virtual void analyticJacobianLiquidAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double factor, linalg::BandedSparseRowIterator jac, LinearBufferAllocator workSpace) const = 0;
+	/**
+	 * @brief Returns the number of reactions for a liquid phase cell
+	 * @return Number of reactions
+	 */
+	virtual unsigned int numReactionsLiquid() const CADET_NOEXCEPT = 0;
 
-			virtual void analyticJacobianQuasiStationaryReaction(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction, linalg::BandMatrix::RowIterator jac, LinearBufferAllocator workSpace) const = 0;
-			virtual void analyticJacobianQuasiStationaryReaction(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction, linalg::DenseBandedRowIterator jac, LinearBufferAllocator workSpace) const = 0;
-			virtual void analyticJacobianQuasiStationaryReaction(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction, linalg::BandedSparseRowIterator jac, LinearBufferAllocator workSpace) const = 0;
+	/**
+	 * @brief Returns the number of reactions for a combined phase cell
+	 * @return Number of reactions
+	 */
+	virtual unsigned int numReactionsCombined() const CADET_NOEXCEPT = 0;
 
-			/**
-			* @brief fills the conserved moieties matrix and the vector of components involved in qs reactions
-			* @param [in,out] M Matrix to be filled with the conserved moieties
-			* @param [in,out] QsCompBulk Vector to be filled with the components involved in qs reactions
-			*/
-			virtual void fillConservedMoietiesBulk(Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>& M, int& nConservedQuants, std::vector<int>& QsCompBulk) {}
-			virtual void fillConservedMoietiesBulk(Eigen::Matrix<active, Eigen::Dynamic, Eigen::Dynamic>& M, int& nConservedQuants, std::vector<int>& QsCompBulk) {}
+	// conserved moitie methods: 
+	virtual auto numConservedMoities() const CADET_NOEXCEPT -> unsigned int  { return 0; }
 
+	virtual auto configureConservedMoity() -> bool{ return false;}
+	
+	virtual auto matrixMoietiesBulk() -> Eigen::Matrix<active, Eigen::Dynamic, Eigen::Dynamic> { return Eigen::Matrix<active, Eigen::Dynamic, Eigen::Dynamic>(0, 0); }
 
-			/**
-			 * @brief Returns whether this dynamic reaction model has quasi-stationary reactions
-			 * @details Quasi-stationary reactions are reactions that are in equilibrium and can be solved
-			 *          algebraically. This function is used to determine whether the model can be solved
-			 *          in quasi-stationary mode.
-			 * @return @c true if the model has quasi-stationary reactions, otherwise @c false
-			 */
-			virtual bool hasQuasiStationaryReactionsBulk() const CADET_NOEXCEPT { return false; }
+	virtual auto quasiStationaryComponentMap() const -> std::vector<int> { return std::vector<int>{0}; }
 
-			virtual int const* reactionQuasiStationarity() const = 0;
+	virtual auto algIdx()const -> std::vector<int> { return std::vector<int>{0}; }
 
-			virtual auto numConservedMoities() const -> unsigned int { return 0; }
-			virtual auto configureConservedMoity() -> bool { return false; }
-			virtual unsigned int numReactionQuasiStationary() const { return 0; }
-			virtual auto quasiStationaryComponentMap() const-> std::vector<int>
-			{
-				std::vector<int> v = { 0 };
-				return v;
-			};
-			virtual auto matrixMoietiesBulk() -> Eigen::Matrix<active, Eigen::Dynamic, Eigen::Dynamic>
-			{
-				Eigen::Matrix<active, Eigen::Dynamic, Eigen::Dynamic> M;
-				return M;
-			}
-			virtual auto algIdx() const -> std::vector<int>
-			{
-				std::vector<int> v{ 0 };
-				return v;
-			}
+	virtual auto consMoityIdx() -> std::vector<int> { return std::vector<int>{0}; }
 
-			virtual auto consMoityIdx() -> std::vector<int> 
-			{
-				std::vector<int> v{ 0 };
-				return v;
-			}
+	virtual auto numReactionQuasiStationary() const -> unsigned int { return 0; }
 
+	virtual auto  hasQuasiStationaryReactionsBulk() const CADET_NOEXCEPT -> bool { return false; }
 
-#ifdef ENABLE_DG
-			virtual void analyticJacobianLiquidAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double factor, linalg::BandedEigenSparseRowIterator jac, LinearBufferAllocator workSpace) const = 0;
-
-#endif
-
-			/**
-			 * @brief Evaluates the residual for one combined phase cell
-			 * @details Adds the dynamic reaction terms to the residual vector for the given
-			 *          combined phase cell. The reaction terms are premultiplied with a given
-			 *          factor. That is, this function realizes
-			 *          \f[ \begin{align}
-			 *              \text{res} = \text{res} + \gamma R
-			 *          \end{align} \f]
-			 *          where @f$ R @f$ are the reaction terms.
-			 *
-			 *          This function is called simultaneously from multiple threads.
-			 *
-			 * @param [in] t Current time point
-			 * @param [in] secIdx Index of the current section
-			 * @param [in] colPos Position in normalized coordinates (column inlet = 0, column outlet = 1; outer shell = 1, inner center = 0)
-			 * @param [in] yLiquid Pointer to first component in the current cell's liquid phase
-			 * @param [in] ySolid Pointer to first component in the current cell's solid phase
-			 * @param [out] resLiquid Pointer to residual of the first component in the current particle shell's liquid phase
-			 * @param [out] resSolid Pointer to residual of the first bound state of the first component in the current particle shell
-			 * @param [in] factor Factor @f$ \gamma @f$
-			 * @param [in,out] workSpace Memory work space
-			 * @return @c 0 on success, @c -1 on non-recoverable error, and @c +1 on recoverable error
-			 */
-			virtual int residualCombinedAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, active const* yLiquid,
-				active const* ySolid, active* resLiquid, active* resSolid, double factor, LinearBufferAllocator workSpace) const = 0;
-
-			virtual int residualCombinedAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* yLiquid,
-				double const* ySolid, active* resLiquid, active* resSolid, double factor, LinearBufferAllocator workSpace) const = 0;
-
-			virtual int residualCombinedAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* yLiquid,
-				double const* ySolid, double* resLiquid, double* resSolid, double factor, LinearBufferAllocator workSpace) const = 0;
-
-			/**
-			 * @brief Adds the analytical Jacobian of the reaction terms for one combined phase cell
-			 * @details Adds the Jacobian of the dynamic reaction terms for the given combined phase
-			 *          cell to the full Jacobian. The reaction terms are premultiplied with a given
-			 *          factor. That is, this function realizes
-			 *          \f[ \begin{align}
-			 *              J = J + \gamma J_R
-			 *          \end{align} \f]
-			 *          where @f$ J_R @f$ is the Jacobian of the reaction terms.
-			 *
-			 *          This function is called simultaneously from multiple threads.
-			 *          It can be left out (empty implementation) if AD is used to evaluate the Jacobian.
-			 *
-			 * @param [in] t Current time point
-			 * @param [in] secIdx Index of the current section
-			 * @param [in] colPos Position in normalized coordinates (column inlet = 0, column outlet = 1; outer shell = 1, inner center = 0)
-			 * @param [in] yLiquid Pointer to first component in the current cell's liquid phase
-			 * @param [in] ySolid Pointer to first component in the current cell's solid phase
-			 * @param [in] factor Factor @f$ \gamma @f$
-			 * @param [in,out] jacLiquid Row iterator pointing to the first component row of the underlying matrix in which the Jacobian is stored
-			 * @param [in,out] jacSolid Row iterator pointing to the first bound state row of the underlying matrix in which the Jacobian is stored
-			 * @param [in,out] workSpace Memory work space
-			 */
-			virtual void analyticJacobianCombinedAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* yLiquid, double const* ySolid, double factor, linalg::BandMatrix::RowIterator jacLiquid, linalg::BandMatrix::RowIterator jacSolid, LinearBufferAllocator workSpace) const = 0;
-			virtual void analyticJacobianCombinedAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* yLiquid, double const* ySolid, double factor, linalg::DenseBandedRowIterator jacLiquid, linalg::DenseBandedRowIterator jacSolid, LinearBufferAllocator workSpace) const = 0;
-			virtual void analyticJacobianCombinedAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* yLiquid, double const* ySolid, double factor, linalg::BandMatrix::RowIterator jacLiquid, linalg::DenseBandedRowIterator jacSolid, LinearBufferAllocator workSpace) const = 0;
-#ifdef ENABLE_DG
-			virtual void analyticJacobianCombinedAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* yLiquid, double const* ySolid, double factor, linalg::BandedEigenSparseRowIterator jacLiquid, linalg::DenseBandedRowIterator jacSolid, LinearBufferAllocator workSpace) const = 0;
-#endif
-
-			/**
-			 * @brief Returns the number of reactions for a liquid phase cell
-			 * @return Number of reactions
-			 */
-			virtual unsigned int numReactionsLiquid() const CADET_NOEXCEPT = 0;
-
-			/**
-			 * @brief Returns the number of reactions for a combined phase cell
-			 * @return Number of reactions
-			 */
-			virtual unsigned int numReactionsCombined() const CADET_NOEXCEPT = 0;
+	virtual void timeDerivativeQuasiStationaryReaction(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double* dY, LinearBufferAllocator workSpace) const {}
 
 
-		protected:
-		};
+protected:
+};
 
-	} // namespace model
+} // namespace model
 } // namespace cadet
 
 #endif  // LIBCADET_REACTIONMODELINTERFACE_HPP_

--- a/src/libcadet/model/ReactionModel.hpp
+++ b/src/libcadet/model/ReactionModel.hpp
@@ -213,6 +213,10 @@ public:
 	virtual int residualLiquidAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,
 		double* res, double factor, LinearBufferAllocator workSpace) const = 0;
 
+	virtual int quasiStationaryFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,
+		active* fluxes, std::vector<int>& mapQSReac, LinearBufferAllocator workSpace)  const = 0;
+
+
 	/**
 	 * @brief Adds the analytical Jacobian of the reaction terms for one liquid phase cell
 	 * @details Adds the Jacobian of the dynamic reaction terms for the given liquid phase
@@ -237,9 +241,15 @@ public:
 	virtual void analyticJacobianLiquidAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double factor, linalg::BandMatrix::RowIterator jac, LinearBufferAllocator workSpace) const = 0;
 	virtual void analyticJacobianLiquidAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double factor, linalg::DenseBandedRowIterator jac, LinearBufferAllocator workSpace) const = 0;
 	virtual void analyticJacobianLiquidAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double factor, linalg::BandedSparseRowIterator jac, LinearBufferAllocator workSpace) const = 0;
-	#ifdef ENABLE_DG
+	
+	
+	virtual void fillConservedMoietiesBulk(Eigen::MatrixXd& M, std::vector<int>& QSReaction, std::vector<int>& _QsCompBulk) = 0;
+
+
+#ifdef ENABLE_DG
 	virtual void analyticJacobianLiquidAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double factor, linalg::BandedEigenSparseRowIterator jac, LinearBufferAllocator workSpace) const = 0;
-	#endif
+
+#endif
 
 	/**
 	 * @brief Evaluates the residual for one combined phase cell
@@ -314,6 +324,11 @@ public:
 	 * @return Number of reactions
 	 */
 	virtual unsigned int numReactionsCombined() const CADET_NOEXCEPT = 0;
+	
+	/**
+	 * @brief Returns wheather liquid reactions are in quasi-stationary state
+	 * @return boolean
+	 */
 
 protected:
 };

--- a/src/libcadet/model/ReactionModel.hpp
+++ b/src/libcadet/model/ReactionModel.hpp
@@ -215,10 +215,10 @@ public:
 	
 
 	virtual int quasiStationaryFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, active const* y,
-		Eigen::Map<Eigen::VectorXd> fluxes, std::vector<int> mapQSReac, LinearBufferAllocator workSpace) = 0;
+		Eigen::Map<Eigen::VectorXd> fluxes, int const* mapQSReac, LinearBufferAllocator workSpace) = 0;
 
 	virtual int quasiStationaryFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,
-		Eigen::Map<Eigen::VectorXd> fluxes, std::vector<int> mapQSReac, LinearBufferAllocator workSpace) = 0;
+		Eigen::Map<Eigen::VectorXd> fluxes, int const* mapQSReac, LinearBufferAllocator workSpace) = 0;
 
 
 	/**
@@ -254,10 +254,11 @@ public:
 	virtual void analyticJacobianLiquidSingleFluxAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction, linalg::DenseBandedRowIterator jac, LinearBufferAllocator workSpace) const = 0;
 	virtual void analyticJacobianLiquidSingleFluxAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction, linalg::BandedSparseRowIterator jac, LinearBufferAllocator workSpace) const = 0;
 	
-	virtual void fillConservedMoietiesBulk(Eigen::MatrixXd& M, std::vector<int>& QSReaction, std::vector<int>& _QsCompBulk) = 0;
+	virtual void fillConservedMoietiesBulk(Eigen::MatrixXd& M, unsigned int & QSReaction, std::vector<int>& _QsCompBulk) = 0;
 
 	virtual void timeDerivativeQuasiStationaryReaction(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double* dReacDt, LinearBufferAllocator workSpace) = 0;
 
+	virtual int const* reactionQuasiStationarity() const = 0;
 #ifdef ENABLE_DG
 	virtual void analyticJacobianLiquidAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double factor, linalg::BandedEigenSparseRowIterator jac, LinearBufferAllocator workSpace) const = 0;
 

--- a/src/libcadet/model/ReactionModel.hpp
+++ b/src/libcadet/model/ReactionModel.hpp
@@ -212,9 +212,13 @@ public:
 
 	virtual int residualLiquidAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,
 		double* res, double factor, LinearBufferAllocator workSpace) const = 0;
+	
+
+	virtual int quasiStationaryFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, active const* y,
+		Eigen::Map<Eigen::VectorXd> fluxes, std::vector<int> mapQSReac, LinearBufferAllocator workSpace) = 0;
 
 	virtual int quasiStationaryFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,
-		active* fluxes, std::vector<int>& mapQSReac, LinearBufferAllocator workSpace)  const = 0;
+		Eigen::Map<Eigen::VectorXd> fluxes, std::vector<int> mapQSReac, LinearBufferAllocator workSpace) = 0;
 
 
 	/**
@@ -242,6 +246,9 @@ public:
 	virtual void analyticJacobianLiquidAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double factor, linalg::DenseBandedRowIterator jac, LinearBufferAllocator workSpace) const = 0;
 	virtual void analyticJacobianLiquidAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double factor, linalg::BandedSparseRowIterator jac, LinearBufferAllocator workSpace) const = 0;
 	
+	virtual void analyticQuasiSteadyJacobianLiquid(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double factor, linalg::BandMatrix::RowIterator jac, LinearBufferAllocator workSpace) const = 0;
+	virtual void analyticQuasiSteadyJacobianLiquid(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double factor, linalg::DenseBandedRowIterator jac, LinearBufferAllocator workSpace) const = 0;
+	virtual void analyticQuasiSteadyJacobianLiquid(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double factor, linalg::BandedSparseRowIterator jac, LinearBufferAllocator workSpace) const = 0;
 	
 	virtual void fillConservedMoietiesBulk(Eigen::MatrixXd& M, std::vector<int>& QSReaction, std::vector<int>& _QsCompBulk) = 0;
 

--- a/src/libcadet/model/StirredTankModel.cpp
+++ b/src/libcadet/model/StirredTankModel.cpp
@@ -1552,7 +1552,7 @@ namespace cadet
 			std::unique_ptr<ResidualType[]> temp1 = std::make_unique<ResidualType[]>(_nComp);
 			Eigen::Map<Eigen::Vector<ResidualType, Eigen::Dynamic>> qsFlux(temp1.get(), _dynReactionBulk->numReactionsLiquid());
 			qsFlux.setZero();
-			_dynReactionBulk->computeQuasiStationaryReactionFlux(t, secIdx, colPos, c, qsFlux, subAlloc);
+			//_dynReactionBulk->computeQuasiStationaryReactionFlux(t, secIdx, colPos, c, qsFlux, subAlloc);
 
 			// buffer memory for transformed residual
 			std::unique_ptr<ResidualType[]> temp = std::make_unique<ResidualType[]>(_nComp);
@@ -1578,7 +1578,7 @@ namespace cadet
 				EigenMatrixTimesDenseMatrix(_dynReactionBulk->matrixMoietiesBulk(), _jac);
 				for (int state : _dynReactionBulk->algIdx())
 				{
-					_dynReactionBulk->analyticJacobianQuasiStationaryReaction(t, secIdx, colPos, reinterpret_cast<double const*>(c), state, rIdx, _jac.row(state), subAlloc);
+					//_dynReactionBulk->analyticJacobianQuasiStationaryReaction(t, secIdx, colPos, reinterpret_cast<double const*>(c), state, rIdx, _jac.row(state), subAlloc);
 					_jac.native(state, _nComp + _totalBound) = 0.0; // dF_{ci}/dvliquid = 0
 				}
 			}

--- a/src/libcadet/model/StirredTankModel.cpp
+++ b/src/libcadet/model/StirredTankModel.cpp
@@ -34,2563 +34,2410 @@
 #include <Eigen/Dense>
 #include <Eigen/Sparse>
 
-#include<iostream>
+#include<iostream>//todo delete
 
 namespace cadet
 {
 
-namespace model
-{
-
-namespace
-{
-	inline void bindingFlux(IBindingModel* binding, double t, unsigned int secIdx, const ColumnPosition& colPos, active const* yCp, active const* yQ, active* res, cadet::LinearBufferAllocator buffer, WithParamSensitivity)
+	namespace model
 	{
-		binding->flux(t, secIdx, colPos, yQ, yCp, res, buffer, WithParamSensitivity());
-	}
 
-	inline void bindingFlux(IBindingModel* binding, double t, unsigned int secIdx, const ColumnPosition& colPos, active const* yCp, active const* yQ, active* res, cadet::LinearBufferAllocator buffer, WithoutParamSensitivity)
-	{
-		binding->flux(t, secIdx, colPos, yQ, yCp, res, buffer, WithoutParamSensitivity());
-	}
-
-	inline void bindingFlux(IBindingModel* binding, double t, unsigned int secIdx, const ColumnPosition& colPos, double const* yCp, double const* yQ, active* res, cadet::LinearBufferAllocator buffer, WithParamSensitivity)
-	{
-		binding->flux(t, secIdx, colPos, yQ, yCp, res, buffer);
-	}
-
-	inline void bindingFlux(IBindingModel* binding, double t, unsigned int secIdx, const ColumnPosition& colPos, double const* yCp, double const* yQ, double* res, cadet::LinearBufferAllocator buffer, WithoutParamSensitivity)
-	{
-		binding->flux(t, secIdx, colPos, yQ, yCp, res, buffer);
-	}
-}
-
-
-CSTRModel::CSTRModel(UnitOpIdx unitOpIdx) : UnitOperationBase(unitOpIdx), _nComp(0), _nParType(0), _nBound(nullptr), _boundOffset(nullptr), _strideBound(nullptr), _offsetParType(nullptr),
-	_totalBound(0), _analyticJac(true), _jac(), _jacFact(), _factorizeJac(false), _initConditions(0), _initConditionsDot(0), _dynReactionBulk(nullptr)
-{
-	// Mutliplexed binding and reaction models make no sense in CSTR
-	_singleBinding = false;
-	_singleDynReaction = false;
-}
-
-CSTRModel::~CSTRModel() CADET_NOEXCEPT
-{
-	delete[] _boundOffset;
-	delete[] _nBound;
-	delete[] _strideBound;
-	delete[] _offsetParType;
-
-	delete[] _dynReactionBulk;
-	//delete[] _temp;
-	//delete[] _temp2;
-}
-
-unsigned int CSTRModel::numDofs() const CADET_NOEXCEPT
-{
-	return 2 * _nComp + _totalBound + 1; 
-}
-
-unsigned int CSTRModel::numPureDofs() const CADET_NOEXCEPT
-{
-	return _nComp + _totalBound + 1;
-}
-
-bool CSTRModel::usesAD() const CADET_NOEXCEPT
-{
-#ifdef CADET_CHECK_ANALYTIC_JACOBIAN
-	// We always need AD if we want to check the analytical Jacobian
-	return true;
-#else
-	// We only need AD if we are not computing the Jacobian analytically
-	return !_analyticJac;
-#endif
-}
-
-void CSTRModel::setFlowRates(active const* in, active const* out) CADET_NOEXCEPT
-{ 
-	_flowRateIn = in[0];
-	_flowRateOut = out[0];
-}
-
-bool CSTRModel::configureModelDiscretization(IParameterProvider& paramProvider, const IConfigHelper& helper)
-{
-	_nComp = paramProvider.getInt("NCOMP");
-
-	if (paramProvider.exists("NBOUND"))
-	{
-		const std::vector<int> nBound = paramProvider.getIntArray("NBOUND");
-		_nParType = nBound.size() / _nComp;
-		
-		_nBound = new unsigned int[_nComp * _nParType];
-		std::copy(nBound.begin(), nBound.begin() + _nComp * _nParType, _nBound);
-
-		// Precompute offsets and total number of bound states (DOFs in solid phase)
-		_boundOffset = new unsigned int[_nComp * _nParType];
-		_offsetParType = new unsigned int[_nParType];
-		_strideBound = new unsigned int[_nParType];
-		_totalBound = 0;
-		_offsetParType[0] = 0;
-		for (unsigned int j = 0; j < _nParType; ++j)
+		namespace
 		{
-			unsigned int* const bo = _boundOffset + j * _nComp;
-			unsigned int* const nb = _nBound + j * _nComp;
-
-			bo[0] = 0;
-			for (unsigned int i = 1; i < _nComp; ++i)
+			inline void bindingFlux(IBindingModel* binding, double t, unsigned int secIdx, const ColumnPosition& colPos, active const* yCp, active const* yQ, active* res, cadet::LinearBufferAllocator buffer, WithParamSensitivity)
 			{
-				bo[i] = bo[i - 1] + nb[i - 1];
+				binding->flux(t, secIdx, colPos, yQ, yCp, res, buffer, WithParamSensitivity());
 			}
-			_strideBound[j] = bo[_nComp-1] + nb[_nComp - 1];
-			_totalBound += _strideBound[j];
 
-			if (j < _nParType - 1)
-				_offsetParType[j + 1] = _totalBound;
+			inline void bindingFlux(IBindingModel* binding, double t, unsigned int secIdx, const ColumnPosition& colPos, active const* yCp, active const* yQ, active* res, cadet::LinearBufferAllocator buffer, WithoutParamSensitivity)
+			{
+				binding->flux(t, secIdx, colPos, yQ, yCp, res, buffer, WithoutParamSensitivity());
+			}
+
+			inline void bindingFlux(IBindingModel* binding, double t, unsigned int secIdx, const ColumnPosition& colPos, double const* yCp, double const* yQ, active* res, cadet::LinearBufferAllocator buffer, WithParamSensitivity)
+			{
+				binding->flux(t, secIdx, colPos, yQ, yCp, res, buffer);
+			}
+
+			inline void bindingFlux(IBindingModel* binding, double t, unsigned int secIdx, const ColumnPosition& colPos, double const* yCp, double const* yQ, double* res, cadet::LinearBufferAllocator buffer, WithoutParamSensitivity)
+			{
+				binding->flux(t, secIdx, colPos, yQ, yCp, res, buffer);
+			}
 		}
-	}
-	else
-	{
-		_nParType = 0;
-		_totalBound = 0;
-		_nBound = nullptr;
-		_boundOffset = nullptr;
-		_strideBound = nullptr;
-		_offsetParType = nullptr;
-	}
 
-	if ((_nParType > 1) && (_totalBound == 0))
-		throw InvalidParameterException("Multiple particle types but not a single bound state detected");
 
-	// Make sure each particle type has at least one bound state
-	for (unsigned int i = 0; i < _nParType; ++i)
-	{
-		if (_strideBound[i] == 0)
-			throw InvalidParameterException("Particle type " + std::to_string(i) + " does not have a bound state");
-	}
+		CSTRModel::CSTRModel(UnitOpIdx unitOpIdx) : UnitOperationBase(unitOpIdx), _nComp(0), _nParType(0), _nBound(nullptr), _boundOffset(nullptr), _strideBound(nullptr), _offsetParType(nullptr),
+			_totalBound(0), _analyticJac(true), _jac(), _jacFact(), _factorizeJac(false), _initConditions(0), _initConditionsDot(0), _dynReactionBulk(nullptr)
+		{
+			// Mutliplexed binding and reaction models make no sense in CSTR
+			_singleBinding = false;
+			_singleDynReaction = false;
+		}
 
-	// Allocate Jacobian
-	const unsigned int nVar = _nComp + _totalBound + 1;
-	_jac.resize(nVar, nVar);
-	_jacFact.resize(nVar, nVar);
+		CSTRModel::~CSTRModel() CADET_NOEXCEPT
+		{
+			delete[] _boundOffset;
+			delete[] _nBound;
+			delete[] _strideBound;
+			delete[] _offsetParType;
 
-	// Allocate space for initial conditions
-	_initConditions.resize(nVar);
-	_initConditionsDot.resize(nVar, 0.0);
+			delete[] _dynReactionBulk;
 
-	// Determine whether analytic Jacobian should be used
+		}
+
+		unsigned int CSTRModel::numDofs() const CADET_NOEXCEPT
+		{
+			return 2 * _nComp + _totalBound + 1;
+		}
+
+		unsigned int CSTRModel::numPureDofs() const CADET_NOEXCEPT
+		{
+			return _nComp + _totalBound + 1;
+		}
+
+		bool CSTRModel::usesAD() const CADET_NOEXCEPT
+		{
+#ifdef CADET_CHECK_ANALYTIC_JACOBIAN
+			// We always need AD if we want to check the analytical Jacobian
+			return true;
+#else
+			// We only need AD if we are not computing the Jacobian analytically
+			return !_analyticJac;
+#endif
+		}
+
+		void CSTRModel::setFlowRates(active const* in, active const* out) CADET_NOEXCEPT
+		{
+			_flowRateIn = in[0];
+			_flowRateOut = out[0];
+		}
+
+		bool CSTRModel::configureModelDiscretization(IParameterProvider& paramProvider, const IConfigHelper& helper)
+		{
+			_nComp = paramProvider.getInt("NCOMP");
+
+			if (paramProvider.exists("NBOUND"))
+			{
+				const std::vector<int> nBound = paramProvider.getIntArray("NBOUND");
+				_nParType = nBound.size() / _nComp;
+
+				_nBound = new unsigned int[_nComp * _nParType];
+				std::copy(nBound.begin(), nBound.begin() + _nComp * _nParType, _nBound);
+
+				// Precompute offsets and total number of bound states (DOFs in solid phase)
+				_boundOffset = new unsigned int[_nComp * _nParType];
+				_offsetParType = new unsigned int[_nParType];
+				_strideBound = new unsigned int[_nParType];
+				_totalBound = 0;
+				_offsetParType[0] = 0;
+				for (unsigned int j = 0; j < _nParType; ++j)
+				{
+					unsigned int* const bo = _boundOffset + j * _nComp;
+					unsigned int* const nb = _nBound + j * _nComp;
+
+					bo[0] = 0;
+					for (unsigned int i = 1; i < _nComp; ++i)
+					{
+						bo[i] = bo[i - 1] + nb[i - 1];
+					}
+					_strideBound[j] = bo[_nComp - 1] + nb[_nComp - 1];
+					_totalBound += _strideBound[j];
+
+					if (j < _nParType - 1)
+						_offsetParType[j + 1] = _totalBound;
+				}
+			}
+			else
+			{
+				_nParType = 0;
+				_totalBound = 0;
+				_nBound = nullptr;
+				_boundOffset = nullptr;
+				_strideBound = nullptr;
+				_offsetParType = nullptr;
+			}
+
+			if ((_nParType > 1) && (_totalBound == 0))
+				throw InvalidParameterException("Multiple particle types but not a single bound state detected");
+
+			// Make sure each particle type has at least one bound state
+			for (unsigned int i = 0; i < _nParType; ++i)
+			{
+				if (_strideBound[i] == 0)
+					throw InvalidParameterException("Particle type " + std::to_string(i) + " does not have a bound state");
+			}
+
+			// Allocate Jacobian
+			const unsigned int nVar = _nComp + _totalBound + 1;
+			_jac.resize(nVar, nVar);
+			_jacFact.resize(nVar, nVar);
+
+			// Allocate space for initial conditions
+			_initConditions.resize(nVar);
+			_initConditionsDot.resize(nVar, 0.0);
+
+			// Determine whether analytic Jacobian should be used
 #ifndef CADET_CHECK_ANALYTIC_JACOBIAN
-	bool analyticJac = true;
-	if (paramProvider.exists("USE_ANALYTIC_JACOBIAN"))
-		analyticJac = paramProvider.getBool("USE_ANALYTIC_JACOBIAN");
+			bool analyticJac = true;
+			if (paramProvider.exists("USE_ANALYTIC_JACOBIAN"))
+				analyticJac = paramProvider.getBool("USE_ANALYTIC_JACOBIAN");
 #else
 	// Default to AD Jacobian when analytic Jacobian is to be checked
-	const bool analyticJac = false;
+			const bool analyticJac = false;
 #endif
-	useAnalyticJacobian(analyticJac);
+			useAnalyticJacobian(analyticJac);
 
-	// Create nonlinear solver for consistent initialization
-	if (paramProvider.exists("discretization"))
-	{
-		paramProvider.pushScope("discretization");
-		configureNonlinearSolver(paramProvider);
-		paramProvider.popScope();
-	}
-	else
-		configureNonlinearSolver();
-
-	// ==== Construct and configure binding models
-	clearBindingModels();
-	_binding = std::vector<IBindingModel*>(_nParType, nullptr);
-
-	if ((_nParType > 0) && !paramProvider.exists("ADSORPTION_MODEL"))
-		throw InvalidParameterException("Binding model required when using at least one particle type");
-
-	bool bindingConfSuccess = true;
-	if (_nParType > 0)
-	{
-		const std::vector<std::string> bindModelNames = paramProvider.getStringArray("ADSORPTION_MODEL");
-		if (bindModelNames.size() < _nParType)
-			throw InvalidParameterException("Field ADSORPTION_MODEL contains too few elements (" + std::to_string(_nParType) + " required)");
-
-		for (unsigned int i = 0; i < _nParType; ++i)
-		{
-			_binding[i] = helper.createBindingModel(bindModelNames[i]);
-			if (!_binding[i])
-				throw InvalidParameterException("Unknown binding model " + bindModelNames[i]);
-
-			MultiplexedScopeSelector scopeGuard(paramProvider, "adsorption", _nParType == 1, i, _nParType == 1, _binding[i]->usesParamProviderInDiscretizationConfig());
-			bindingConfSuccess = _binding[i]->configureModelDiscretization(paramProvider, _nComp, _nBound + i * _nComp, _boundOffset + i * _nComp) && bindingConfSuccess;
-		}
-	}
-
-	// ==== Construct and configure dynamic reaction model
-	clearDynamicReactionModels();
-	bool reactionConfSuccess = true;
-
-	_dynReactionBulk = nullptr;
-	if (paramProvider.exists("REACTION_MODEL"))
-	{
-		const std::string dynReactName = paramProvider.getString("REACTION_MODEL");
-		_dynReactionBulk = helper.createDynamicReactionModel(dynReactName);
-		if (!_dynReactionBulk)
-			throw InvalidParameterException("Unknown dynamic reaction model " + dynReactName);
-
-		if (_dynReactionBulk->usesParamProviderInDiscretizationConfig())
-			paramProvider.pushScope("reaction_bulk");
-
-		reactionConfSuccess = _dynReactionBulk->configureModelDiscretization(paramProvider, _nComp, nullptr, nullptr);
-
-		if (_dynReactionBulk->usesParamProviderInDiscretizationConfig())
-			paramProvider.popScope();
-	}
-
-	_dynReaction = std::vector<IDynamicReactionModel*>(_nParType, nullptr);
-
-	if (paramProvider.exists("REACTION_MODEL_PARTICLES"))
-	{
-		const std::vector<std::string> dynReactModelNames = paramProvider.getStringArray("REACTION_MODEL_PARTICLES");
-		if (dynReactModelNames.size() < _nParType)
-			throw InvalidParameterException("Field REACTION_MODEL_PARTICLES contains too few elements (" + std::to_string(_nParType) + " required)");
-
-		for (unsigned int i = 0; i < _nParType; ++i)
-		{
-			_dynReaction[i] = helper.createDynamicReactionModel(dynReactModelNames[i]);
-			if (!_dynReaction[i])
-				throw InvalidParameterException("Unknown dynamic reaction model " + dynReactModelNames[i]);
-
-			MultiplexedScopeSelector scopeGuard(paramProvider, "reaction_particle", _nParType == 1, i, _nParType == 1, _dynReaction[i]->usesParamProviderInDiscretizationConfig());
-			reactionConfSuccess = _dynReaction[i]->configureModelDiscretization(paramProvider, _nComp, _nBound + i * _nComp, _boundOffset + i * _nComp) && reactionConfSuccess;
-		}
-	}
-
-	return bindingConfSuccess && reactionConfSuccess;
-}
-
-bool CSTRModel::configure(IParameterProvider& paramProvider)
-{
-	_curFlowRateFilter = 0.0;
-	_flowRateFilter.clear();
-	const bool hasFlowrateFilter = paramProvider.exists("FLOWRATE_FILTER");
-	if (hasFlowrateFilter)
-		readScalarParameterOrArray(_flowRateFilter, paramProvider, "FLOWRATE_FILTER", 1);
-
-	_constSolidVolume = 0.0;
-	if (paramProvider.exists("CONST_SOLID_VOLUME"))
-		_constSolidVolume = paramProvider.getDouble("CONST_SOLID_VOLUME");
-	else if (paramProvider.exists("POROSITY")) // todo delete for breaking change with new interface version
-	{
-		LOG(Warning) << "Field POROSITY is only supported for backwards compatibility, but the implementation of the CSTR has changed, please refer to the documentation. The POROSITY will be used to compute the constant solid volume from the liquid volume.";
-
-		double init_liquid_volume = 0.0;
-		if (paramProvider.exists("INIT_LIQUID_VOLUME"))
-			init_liquid_volume = paramProvider.getDouble("INIT_LIQUID_VOLUME");
-
-		else if (paramProvider.exists("INIT_VOLUME")) // todo delete for breaking change with new interface version
-			init_liquid_volume = paramProvider.getDouble("INIT_VOLUME");
-
-		else
-			throw InvalidParameterException("Field CONST_SOLID_VOLUME or INIT_LIQUID_VOLUME required");
-
-		const double epsilon = paramProvider.getDouble("POROSITY");
-
-		if (epsilon > 0.0) // else, constant solid volume is already set to zero
-			_constSolidVolume = init_liquid_volume * (1.0 - epsilon) / epsilon; // V_s = (V_l + V_s) * (1 - epsilon) -> V_s = V_l * (1 - \epsilon) / \epsilon
-	}
-	_parameters[makeParamId(hashString("CONST_SOLID_VOLUME"), _unitOpIdx, CompIndep, ParTypeIndep, BoundStateIndep, ReactionIndep, SectionIndep)] = &_constSolidVolume;
-
-	if (_totalBound > 0)
-	{
-		// Let PAR_TYPE_VOLFRAC default to 1.0 for backwards compatibility
-		if (paramProvider.exists("PAR_TYPE_VOLFRAC"))
-			readScalarParameterOrArray(_parTypeVolFrac, paramProvider, "PAR_TYPE_VOLFRAC", 1);
-		else
-			_parTypeVolFrac.resize(1, 1.0);
-
-		if (_nParType != _parTypeVolFrac.size())
-			throw InvalidParameterException("Number of elements in field PAR_TYPE_VOLFRAC does not match number of particle types");
-
-		// Check that particle volume fractions sum to 1.0
-		const double volFracSum = std::accumulate(_parTypeVolFrac.begin(), _parTypeVolFrac.end(), 0.0, 
-			[](double a, const active& b) -> double { return a + static_cast<double>(b); });
-		if (std::abs(1.0 - volFracSum) > 1e-10)
-			throw InvalidParameterException("Sum of field PAR_TYPE_VOLFRAC differs from 1.0 (is " + std::to_string(volFracSum) + ")");
-	}
-
-	_parameters.clear();
-	if (hasFlowrateFilter)
-		registerScalarSectionDependentParam(hashString("FLOWRATE_FILTER"), _parameters, _flowRateFilter, _unitOpIdx, ParTypeIndep);
-
-	if (_totalBound > 0)
-		registerParam1DArray(_parameters, _parTypeVolFrac, [=](bool multi, unsigned int type) { return makeParamId(hashString("PAR_TYPE_VOLFRAC"), _unitOpIdx, CompIndep, type, BoundStateIndep, ReactionIndep, SectionIndep); });
-
-	// Register initial conditions parameters
-	for (unsigned int i = 0; i < _nComp; ++i)
-		_parameters[makeParamId(hashString("INIT_C"), _unitOpIdx, i, ParTypeIndep, BoundStateIndep, ReactionIndep, SectionIndep)] = _initConditions.data() + i;
-
-	for (unsigned int type = 0; type < _nParType; ++type)
-	{
-		if (!_binding[type])
-			continue;
-
-		std::vector<ParameterId> initParams(_strideBound[type]);
-		_binding[type]->fillBoundPhaseInitialParameters(initParams.data(), _unitOpIdx, type);
-
-		active* const ic = _initConditions.data() + _nComp + _offsetParType[type];
-		for (unsigned int i = 0; i < _strideBound[type]; ++i)
-			_parameters[initParams[i]] = ic + i;
-	}
-
-	_parameters[makeParamId(hashString("INIT_LIQUID_VOLUME"), _unitOpIdx, CompIndep, ParTypeIndep, BoundStateIndep, ReactionIndep, SectionIndep)] = _initConditions.data() + _nComp + _totalBound;
-
-	// Reconfigure binding model
-	bool bindingConfSuccess = true;
-	if (!_binding.empty())
-	{
-		for (unsigned int type = 0; type < _nParType; ++type)
-		{
- 			if (!_binding[type] || !_binding[type]->requiresConfiguration())
- 				continue;
-
-			MultiplexedScopeSelector scopeGuard(paramProvider, "adsorption", type, _nParType == 1, true);
-			bindingConfSuccess = _binding[type]->configure(paramProvider, _unitOpIdx, type) && bindingConfSuccess;
-		}
-	}
-
-	// Reconfigure reaction model
-	bool dynReactionConfSuccess = true;
-	_hasQuasiStationaryReactionBulk = false;
-	if (_dynReactionBulk && _dynReactionBulk->requiresConfiguration())
-	{
-		paramProvider.pushScope("reaction_bulk");
-		dynReactionConfSuccess = _dynReactionBulk->configure(paramProvider, _unitOpIdx, ParTypeIndep);
-		paramProvider.popScope();
-
-		// Get quasi stationary reactions information vector
-		_qsReactionBulk = nullptr;
-		_qsReactionBulk = _dynReactionBulk->reactionQuasiStationarity();
-
-
-		if (_qsReactionBulk != nullptr)
-		{	
-			//_dynReactionBulk->fillConservedMoietiesBulk(_MconvMoityBulk, _QsCompBulk); // fill conserved moities matrix
-			_QsCompBulk.resize(_nComp);
-			_dynReactionBulk->fillConservedMoietiesBulk2(_MconvMoityBulk2, _nConservedQuants, _QsCompBulk);
-		
-
-			bool hasQSBinding = false;
-			for (int i = 0; i < _nParType; i++)
+			// Create nonlinear solver for consistent initialization
+			if (paramProvider.exists("discretization"))
 			{
-				if (_binding[i] && _binding[i]->hasQuasiStationaryReactions())
+				paramProvider.pushScope("discretization");
+				configureNonlinearSolver(paramProvider);
+				paramProvider.popScope();
+			}
+			else
+				configureNonlinearSolver();
+
+			// ==== Construct and configure binding models
+			clearBindingModels();
+			_binding = std::vector<IBindingModel*>(_nParType, nullptr);
+
+			if ((_nParType > 0) && !paramProvider.exists("ADSORPTION_MODEL"))
+				throw InvalidParameterException("Binding model required when using at least one particle type");
+
+			bool bindingConfSuccess = true;
+			if (_nParType > 0)
+			{
+				const std::vector<std::string> bindModelNames = paramProvider.getStringArray("ADSORPTION_MODEL");
+				if (bindModelNames.size() < _nParType)
+					throw InvalidParameterException("Field ADSORPTION_MODEL contains too few elements (" + std::to_string(_nParType) + " required)");
+
+				for (unsigned int i = 0; i < _nParType; ++i)
 				{
-					hasQSBinding = true;
-					break;
+					_binding[i] = helper.createBindingModel(bindModelNames[i]);
+					if (!_binding[i])
+						throw InvalidParameterException("Unknown binding model " + bindModelNames[i]);
+
+					MultiplexedScopeSelector scopeGuard(paramProvider, "adsorption", _nParType == 1, i, _nParType == 1, _binding[i]->usesParamProviderInDiscretizationConfig());
+					bindingConfSuccess = _binding[i]->configureModelDiscretization(paramProvider, _nComp, _nBound + i * _nComp, _boundOffset + i * _nComp) && bindingConfSuccess;
 				}
 			}
-			_hasQuasiStationaryReactionBulk = _dynReactionBulk->hasQuasiStationaryReactionsBulk();
-			if (hasQSBinding && _hasQuasiStationaryReactionBulk)
+
+			// ==== Construct and configure dynamic reaction model
+			clearDynamicReactionModels();
+			bool reactionConfSuccess = true;
+
+			_dynReactionBulk = nullptr;
+			if (paramProvider.exists("REACTION_MODEL"))
 			{
-				throw InvalidParameterException("Quasi stationary reactions in binding and bulk reaction model are not supported");
+				const std::string dynReactName = paramProvider.getString("REACTION_MODEL");
+				_dynReactionBulk = helper.createDynamicReactionModel(dynReactName);
+				if (!_dynReactionBulk)
+					throw InvalidParameterException("Unknown dynamic reaction model " + dynReactName);
+
+				if (_dynReactionBulk->usesParamProviderInDiscretizationConfig())
+					paramProvider.pushScope("reaction_bulk");
+
+				reactionConfSuccess = _dynReactionBulk->configureModelDiscretization(paramProvider, _nComp, nullptr, nullptr);
+
+				if (_dynReactionBulk->usesParamProviderInDiscretizationConfig())
+					paramProvider.popScope();
 			}
+
+			_dynReaction = std::vector<IDynamicReactionModel*>(_nParType, nullptr);
+
+			if (paramProvider.exists("REACTION_MODEL_PARTICLES"))
+			{
+				const std::vector<std::string> dynReactModelNames = paramProvider.getStringArray("REACTION_MODEL_PARTICLES");
+				if (dynReactModelNames.size() < _nParType)
+					throw InvalidParameterException("Field REACTION_MODEL_PARTICLES contains too few elements (" + std::to_string(_nParType) + " required)");
+
+				for (unsigned int i = 0; i < _nParType; ++i)
+				{
+					_dynReaction[i] = helper.createDynamicReactionModel(dynReactModelNames[i]);
+					if (!_dynReaction[i])
+						throw InvalidParameterException("Unknown dynamic reaction model " + dynReactModelNames[i]);
+
+					MultiplexedScopeSelector scopeGuard(paramProvider, "reaction_particle", _nParType == 1, i, _nParType == 1, _dynReaction[i]->usesParamProviderInDiscretizationConfig());
+					reactionConfSuccess = _dynReaction[i]->configureModelDiscretization(paramProvider, _nComp, _nBound + i * _nComp, _boundOffset + i * _nComp) && reactionConfSuccess;
+				}
+			}
+
+			return bindingConfSuccess && reactionConfSuccess;
 		}
-	}
-	else
-	{	
-		_MconvMoityBulk = Eigen::MatrixXd::Zero(0, 0); // matrix for conserved moities
-		_QsCompBulk.clear();
-	}
 
-	for (unsigned int type = 0; type < _nParType; ++type)
-	{
-		if (!_dynReaction[type] || !_dynReaction[type]->requiresConfiguration())
-			continue;
-
-		MultiplexedScopeSelector scopeGuard(paramProvider, "reaction_particle", type, _nParType == 1, true);
-		dynReactionConfSuccess = _dynReaction[type]->configure(paramProvider, _unitOpIdx, type) && dynReactionConfSuccess;
-	}
-
-	return bindingConfSuccess && dynReactionConfSuccess;
-}
-
-unsigned int CSTRModel::threadLocalMemorySize() const CADET_NOEXCEPT
-{
-	LinearMemorySizer lms;
-
-	// Memory for residualImpl()
-	for (unsigned int i = 0; i < _nParType; ++i)
-	{
-		if (_binding[i] && _binding[i]->requiresWorkspace())
-			lms.fitBlock(_binding[i]->workspaceSize(_nComp, _strideBound[i], _nBound + i * _nComp));
-		if (_dynReaction[i] && _dynReaction[i]->requiresWorkspace())
-			lms.fitBlock(_dynReaction[i]->workspaceSize(_nComp, _strideBound[i], _nBound + i * _nComp));
-	}
-
-	if (_dynReactionBulk && _dynReactionBulk->requiresWorkspace())
-		lms.fitBlock(_dynReactionBulk->workspaceSize(_nComp, 0, nullptr));
-
-	const unsigned int maxStrideBound = _strideBound ? *std::max_element(_strideBound, _strideBound + _nParType) : 0;
-	lms.add<active>(_nComp + maxStrideBound);
-	lms.add<double>((maxStrideBound + _nComp) * (maxStrideBound + _nComp));
-	
-	if (_hasQuasiStationaryReactionBulk)
-	{
-		lms.add<active>(_nComp); // buffer for recalculation residual if conserved moities are needed
-		lms.add<active>(_nComp); // mem for flux from reactions in bulk that are quasi stationary
-	}
-
-	lms.commit();
-	const std::size_t resImplSize = lms.bufferSize();
-
-	// Memory for consistentInitialTimeDerivative()
-	for (unsigned int i = 0; i < _nParType; ++i)
-	{
-		if (_binding[i] && _binding[i]->requiresWorkspace())
-			lms.fitBlock(_binding[i]->workspaceSize(_nComp, _strideBound[i], _nBound + i * _nComp));
-	}
-	lms.add<double>(_nComp + _totalBound + 1);
-	lms.commit();
-
-	// Memory for consistentInitialState()
-	lms.add<int>(_nComp + _totalBound);
-	lms.add<double>(_nComp + _totalBound);
-	lms.add<double>(_nComp);
-	lms.add<double>(_nComp + _totalBound);
-	lms.add<double>(numDofs());
-	lms.add<double>(_nonlinearSolver->workspaceSize(_nComp + _totalBound) * sizeof(double));
-	lms.addBlock(resImplSize);
-	lms.commit();
-
-	// Memory for consistentInitialSensitivity
-	lms.add<int>(_totalBound);
-	lms.add<double>(_nComp + _totalBound + 1);
-	lms.add<double>(_nComp + _totalBound);
-	lms.add<double>(_totalBound);
-	lms.commit();
-
-	if (_hasQuasiStationaryReactionBulk)
-	{
-		// Additonally Memory for consistentInitialState() 
-		lms.add<int>(_nComp); // map of kinetic components 
-		lms.add<double>(_nComp); // solution 
-		lms.add<double>(_nComp); // conserved quantities
-		lms.add<double>(numDofs()); // fullX 
-		lms.add<double>(numDofs()); // fullRes 
-		lms.add<double>(_nonlinearSolver->workspaceSize(_nComp + _totalBound) * sizeof(double)); //non linear solver workspace
-		lms.addBlock(resImplSize);
-		lms.commit();
-		
-		// Memory for ConsistentInitialTimeDerivative()
-		lms.add<double>(_nComp+1); // dReacDt
-		lms.add<double>(_nComp); //map
-		lms.add<double>(_nComp); //additional puffer
-		lms.commit();
-	}
-	return lms.bufferSize();
-}
-
-void CSTRModel::setSectionTimes(double const* secTimes, bool const* secContinuity, unsigned int nSections){}
-
-void CSTRModel::useAnalyticJacobian(const bool analyticJac)
-{
-#ifndef CADET_CHECK_ANALYTIC_JACOBIAN
-	_analyticJac = analyticJac;
-#else
-	// Use AD Jacobian if analytic Jacobian is to be checked
-	_analyticJac = false;
-#endif
-}
-
-void CSTRModel::notifyDiscontinuousSectionTransition(double t, unsigned int secIdx, const ConstSimulationState& simState, const AdJacobianParams& adJac)
-{
-	if (_flowRateFilter.size() > 1)
-	{
-		_curFlowRateFilter = _flowRateFilter[secIdx];
-	}
-	else if (_flowRateFilter.size() == 1)
-	{
-		_curFlowRateFilter = _flowRateFilter[0];
-	}
-
-	_curSecIdx = secIdx;
-}
-
-void CSTRModel::reportSolution(ISolutionRecorder& recorder, double const* const solution) const
-{
-	Exporter expr(_nComp, _nParType, _nBound, _strideBound, _boundOffset, _totalBound, solution);
-	recorder.beginUnitOperation(_unitOpIdx, *this, expr);
-	recorder.endUnitOperation();
-}
-
-void CSTRModel::reportSolutionStructure(ISolutionRecorder& recorder) const
-{
-	Exporter expr(_nComp, _nParType, _nBound, _strideBound, _boundOffset, _totalBound, nullptr);
-	recorder.unitOperationStructure(_unitOpIdx, *this, expr);
-}
-
-unsigned int CSTRModel::requiredADdirs() const CADET_NOEXCEPT
-{
-#ifndef CADET_CHECK_ANALYTIC_JACOBIAN
-	if (_analyticJac)
-		// Only use AD if binding models require it
-		return maxBindingAdDirs();
-#endif
-
-	// We always need AD if CADET_CHECK_ANALYTIC_JACOBIAN and if analytic Jacobian is disabled
-	return _nComp + _totalBound + 1;
-}
-
-void CSTRModel::prepareADvectors(const AdJacobianParams& adJac) const
-{
-	// Early out if AD is disabled
-	if (!adJac.adY)
-		return;
-
-	ad::prepareAdVectorSeedsForDenseMatrix(adJac.adY + _nComp, adJac.adDirOffset, _jac.columns());
-}
-
-void CSTRModel::applyInitialCondition(const SimulationState& simState) const
-{
-	// Inlet DOFs
-	std::fill(simState.vecStateY, simState.vecStateY + _nComp, 0.0);
-	std::fill(simState.vecStateYdot, simState.vecStateYdot + _nComp, 0.0);
-
-	const unsigned int nDof = numPureDofs();
-	ad::copyFromAd(_initConditions.data(), simState.vecStateY + _nComp, nDof);
-
-	std::copy(_initConditionsDot.data(), _initConditionsDot.data() + nDof, simState.vecStateYdot + _nComp);
-}
-
-void CSTRModel::readInitialCondition(IParameterProvider& paramProvider)
-{
-	// Clear time derivative
-	std::fill(_initConditionsDot.begin(), _initConditionsDot.end(), 0.0);
-
-	// Check if INIT_STATE is present
-	if (paramProvider.exists("INIT_STATE"))
-	{
-		const unsigned int nDof = numPureDofs();
-		const std::vector<double> initState = paramProvider.getDoubleArray("INIT_STATE");
-
-		ad::copyToAd(initState.data(), _initConditions.data(), nDof);
-
-		// Check if INIT_STATE contains the full state and its time derivative
-		if (initState.size() >= 2 * nDof)
-			std::copy(initState.data() + nDof, initState.data() + 2 * nDof, _initConditionsDot.data());
-
-		return;
-	}
-
-	const std::vector<double> initC = paramProvider.getDoubleArray("INIT_C");
-
-	if (initC.size() < _nComp)
-		throw InvalidParameterException("INIT_C does not contain enough values for all components");
-	
-	ad::copyToAd(initC.data(), _initConditions.data(), _nComp);
-
-	if (paramProvider.exists("INIT_Q"))
-	{
-		const std::vector<double> initQ = paramProvider.getDoubleArray("INIT_Q");
-		ad::copyToAd(initQ.data(), _initConditions.data() + _nComp, _totalBound);
-	}
-	else
-		ad::fillAd(_initConditions.data() + _nComp, _totalBound, 0.0);
-
-	if (paramProvider.exists("INIT_LIQUID_VOLUME"))
-		_initConditions[_nComp + _totalBound].setValue(paramProvider.getDouble("INIT_LIQUID_VOLUME"));
-	else if (paramProvider.exists("INIT_VOLUME")) // todo delete for breaking change with new interface version
-		_initConditions[_nComp + _totalBound].setValue(paramProvider.getDouble("INIT_VOLUME"));
-	else
-		_initConditions[_nComp + _totalBound].setValue(0.0);
-}
-
-void CSTRModel::consistentInitialState(const SimulationTime& simTime, double* const vecStateY, const AdJacobianParams& adJac, double errorTol, util::ThreadLocalStorage& threadLocalMem)
-{
-	double* const c = vecStateY + _nComp;
-	const double vLiquid = c[_nComp + _totalBound];
-	const double vSolid = static_cast<double>(_constSolidVolume);
-	const double porosity = static_cast<const double>(vLiquid) / (vSolid + static_cast<const double>(vLiquid));
-
-
-	// Check if liquid volume is 0
-	if (vLiquid == 0.0)
-	{
-		const double flowIn = static_cast<double>(_flowRateIn);
-		const double flowOut = static_cast<double>(_flowRateOut);
-
-		// Liquid Volume: \dot{V} = F_{in} - F_{out} - F_{filter}
-		const double vDot = flowIn - flowOut - static_cast<double>(_curFlowRateFilter);
-
-		// We have the equation
-		//    \dot{V}^l * c_i + V^l \dot{c}_i + V^s * ([sum_j sum_m d_j \dot{q}_{i,m}]) = c_{in,i} * F_in + c_i * F_out
-		// which is now algebraic wrt. c due to V^l = 0:
-		//    \dot{V}^l * c_i + V^s * [sum_j sum_m d_j \dot{q}_{i,m}] = c_{in,i} * F_in + c_i * F_out
-		// Separating knowns from unknowns gives
-		//    (\dot{V}^l + F_out) * c_i + V^s [sum_j sum_m d_j q_{i,m}] = c_in * F_in
-
-		// We assume that all binding models are fully dynamic (i.e., they do not have
-		// algebraic equations). 
-		// TODO: Figure out what to do when at least one binding model has algebraic equations.
-
-		// If the binding models do not have algebraic equations, the
-		// bound states q_{i,j} are dynamic and, thus, already determine
-		//    (\dot{V}^l + F_out) * c_i = c_in * F_in - V^s * [sum_j sum_m d_j q_{j,i,m}]
-		// This finally leads to
-		//    c_i = (c_in * F_in - V^s * [sum_j sum_m d_j q_{j,i,m}]) / (\dot{V}^l + F_out)
-
-		// Note that if the denominator (\dot{V} + F_out) were 0, we had
-		//    0 = \dot{V} + F_out = F_{in} - F_{filter}
-		// which leads to
-		//    F_in = F_filter
-		// Since F_out >= 0 and \dot{V} = -F_out, we get
-		//    \dot{V} <= 0
-		// Assuming a valid configuration, we obtain \dot{V} = 0
-		// as the tank would get a negative volume otherwise.
-		// Concluding, we arrive at \dot{V} = F_out = 0.
-		// In this situation, F_in = F_filter = 0 has to hold
-		// as otherwise the liquid (solvent) is immediately and
-		// fully taken out, leaving only the pure dry components.
-		// We, hence, assume that this doesn't happen and simply
-		// do nothing leaving the initial conditions in place.
-
-		const double denom = vDot + flowOut;
-		if (denom == 0.0)
-			return;
-
-		for (unsigned int i = 0; i < _nComp; ++i)
-			c[i] = vecStateY[i] * flowIn / denom;
-
-
-		const double qFactor = static_cast<double>(_constSolidVolume) / denom;
-		for (unsigned int type = 0; type < _nParType; ++type)
+		bool CSTRModel::configure(IParameterProvider& paramProvider)
 		{
-			unsigned int const* const bo = _boundOffset + type * _nComp;
-			unsigned int const* const nb = _nBound + type * _nComp;
-			double const* const typeQ = c + _nComp + _offsetParType[type];
+			_curFlowRateFilter = 0.0;
+			_flowRateFilter.clear();
+			const bool hasFlowrateFilter = paramProvider.exists("FLOWRATE_FILTER");
+			if (hasFlowrateFilter)
+				readScalarParameterOrArray(_flowRateFilter, paramProvider, "FLOWRATE_FILTER", 1);
+
+			_constSolidVolume = 0.0;
+			if (paramProvider.exists("CONST_SOLID_VOLUME"))
+				_constSolidVolume = paramProvider.getDouble("CONST_SOLID_VOLUME");
+			else if (paramProvider.exists("POROSITY")) // todo delete for breaking change with new interface version
+			{
+				LOG(Warning) << "Field POROSITY is only supported for backwards compatibility, but the implementation of the CSTR has changed, please refer to the documentation. The POROSITY will be used to compute the constant solid volume from the liquid volume.";
+
+				double init_liquid_volume = 0.0;
+				if (paramProvider.exists("INIT_LIQUID_VOLUME"))
+					init_liquid_volume = paramProvider.getDouble("INIT_LIQUID_VOLUME");
+
+				else if (paramProvider.exists("INIT_VOLUME")) // todo delete for breaking change with new interface version
+					init_liquid_volume = paramProvider.getDouble("INIT_VOLUME");
+
+				else
+					throw InvalidParameterException("Field CONST_SOLID_VOLUME or INIT_LIQUID_VOLUME required");
+
+				const double epsilon = paramProvider.getDouble("POROSITY");
+
+				if (epsilon > 0.0) // else, constant solid volume is already set to zero
+					_constSolidVolume = init_liquid_volume * (1.0 - epsilon) / epsilon; // V_s = (V_l + V_s) * (1 - epsilon) -> V_s = V_l * (1 - \epsilon) / \epsilon
+			}
+			_parameters[makeParamId(hashString("CONST_SOLID_VOLUME"), _unitOpIdx, CompIndep, ParTypeIndep, BoundStateIndep, ReactionIndep, SectionIndep)] = &_constSolidVolume;
+
+			if (_totalBound > 0)
+			{
+				// Let PAR_TYPE_VOLFRAC default to 1.0 for backwards compatibility
+				if (paramProvider.exists("PAR_TYPE_VOLFRAC"))
+					readScalarParameterOrArray(_parTypeVolFrac, paramProvider, "PAR_TYPE_VOLFRAC", 1);
+				else
+					_parTypeVolFrac.resize(1, 1.0);
+
+				if (_nParType != _parTypeVolFrac.size())
+					throw InvalidParameterException("Number of elements in field PAR_TYPE_VOLFRAC does not match number of particle types");
+
+				// Check that particle volume fractions sum to 1.0
+				const double volFracSum = std::accumulate(_parTypeVolFrac.begin(), _parTypeVolFrac.end(), 0.0,
+					[](double a, const active& b) -> double { return a + static_cast<double>(b); });
+				if (std::abs(1.0 - volFracSum) > 1e-10)
+					throw InvalidParameterException("Sum of field PAR_TYPE_VOLFRAC differs from 1.0 (is " + std::to_string(volFracSum) + ")");
+			}
+
+			_parameters.clear();
+			if (hasFlowrateFilter)
+				registerScalarSectionDependentParam(hashString("FLOWRATE_FILTER"), _parameters, _flowRateFilter, _unitOpIdx, ParTypeIndep);
+
+			if (_totalBound > 0)
+				registerParam1DArray(_parameters, _parTypeVolFrac, [=](bool multi, unsigned int type) { return makeParamId(hashString("PAR_TYPE_VOLFRAC"), _unitOpIdx, CompIndep, type, BoundStateIndep, ReactionIndep, SectionIndep); });
+
+			// Register initial conditions parameters
 			for (unsigned int i = 0; i < _nComp; ++i)
-			{
-				double qSum = 0.0;
-				double const* const localQ = typeQ + bo[i];
-				for (unsigned int j = 0; j < nb[i]; ++j)
-					qSum += localQ[j];
+				_parameters[makeParamId(hashString("INIT_C"), _unitOpIdx, i, ParTypeIndep, BoundStateIndep, ReactionIndep, SectionIndep)] = _initConditions.data() + i;
 
-				c[i] -= qFactor * static_cast<double>(_parTypeVolFrac[type]) * qSum;
-			}
-		}
-	}
-	if (_hasQuasiStationaryReactionBulk)
-	{
-
-		LinearBufferAllocator tlmAlloc = threadLocalMem.get();
-		BufferedArray<int> qsMask = tlmAlloc.array<int>(_nComp);
-	
-		// mark which concentrations need to be reacalculated
-		qsMask.copyFromVector(_QsCompBulk);
-
-		int nActiveStates= std::count(_QsCompBulk.begin(), _QsCompBulk.end(), 1);
-
-		const linalg::ConstMaskArray mask{ static_cast<int*>(qsMask), static_cast<int>(_nComp) };
-		const int probSize = linalg::numMaskActive(mask);
-
-		// Extract initial values from current state
-		BufferedArray<double> solution = tlmAlloc.array<double>(probSize);
-		linalg::selectVectorSubset(c, mask, static_cast<double*>(solution));
-
-		// Save values of conserved moieties;
-		const unsigned int numActiveComp = numMaskActive(mask, _nComp);
-		BufferedArray<double> conservedQuants = tlmAlloc.array<double>(nActiveStates); // number of conserved quantities
-
-		// Calculate conserved quantities for the inital state 
-
-		int mIdx = 0;
-		for (unsigned int i = 0; i < _nComp; ++i)
-		{
-			if(_QsCompBulk[i] == 0)
-				continue;
-			if (mIdx >= _nConservedQuants)
-				continue;
-			double dotProduct = 0.0;
-			for (unsigned int j = 0; j < _MconvMoityBulk2.cols(); ++j)
-				dotProduct += static_cast<double>(_MconvMoityBulk2(i, j)) * c[j];
-
-			conservedQuants[mIdx] = dotProduct;
-			mIdx++;
-		}
-
-		linalg::DenseMatrixView jacobianMatrix(_jacFact.data(), _jacFact.pivotData(), probSize, probSize);
-		BufferedArray<double> baFullX = tlmAlloc.array<double>(numDofs());
-		double* const fullX = static_cast<double*>(baFullX);
-
-		BufferedArray<double> baFullResidual = tlmAlloc.array<double>(numDofs());
-		double* const fullResidual = static_cast<double*>(baFullResidual);
-
-		BufferedArray<double> baNonlinMem = tlmAlloc.array<double>(_nonlinearSolver->workspaceSize(probSize));
-		double* const nonlinMem = static_cast<double*>(baNonlinMem);
-
-
-		std::function<bool(double const* const, linalg::detail::DenseMatrixBase&)> jacFunc;
-		if (adJac.adY && adJac.adRes)
-		{
-			ad::copyToAd(vecStateY, adJac.adY, _nComp);
-
-			jacFunc = [&](double const* const x, linalg::detail::DenseMatrixBase& mat)
-				{
-					active* const localAdY = adJac.adY + _nComp;
-					active* const localAdRes = adJac.adRes + _nComp;
-
-					// Copy over state vector to AD state vector (without changing directional values to keep seed vectors)
-					// and initialize residuals with zero (also resetting directional values)
-					ad::copyToAd(c, localAdY, mask.len);
-					// @todo Check if this is necessary
-					ad::resetAd(localAdRes, mask.len);
-
-					// Prepare input vector by overwriting masked items
-					linalg::applyVectorSubset(x, mask, localAdY);
-
-					// Call residual function
-					residualImpl<active, active, double, false>(simTime.t, simTime.secIdx, adJac.adY, nullptr, adJac.adRes, tlmAlloc.manageRemainingMemory());
-
-#ifdef CADET_CHECK_ANALYTIC_JACOBIAN
-					std::copy_n(c, mask.len, fullX);
-					linalg::applyVectorSubset(x, mask, fullX);
-
-					// Compute analytic Jacobian
-					residualImpl<double, double, double, true>(simTime.t, simTime.secIdx, fullX, nullptr, fullResidual, tlmAlloc.manageRemainingMemory());
-
-					// Compare
-					const double diff = ad::compareDenseJacobianWithAd(localAdRes, adJac.adDirOffset, _jac);
-					LOG(Debug) << "MaxDiff: " << diff;
-#endif
-
-					// Extract Jacobian from AD
-					ad::extractDenseJacobianFromAd(localAdRes, adJac.adDirOffset, _jac);
-
-					// Extract Jacobian from full Jacobian
-					mat.setAll(0.0);
-					linalg::copyMatrixSubset(_jac, mask, mask, mat);
-					int numConservedMoities = _nComp - _dynReactionBulk->numReactionQuasiStationary();
-
-					// Replace upper part with conservation relations
-					int  mIdx = 0;
-					for (unsigned int i = 0; i < _nComp; ++i)
-					{
-						if (_QsCompBulk[i] == 0)
-							continue;
-						if (mIdx >= _nConservedQuants)
-							continue;
-
-						int jIdx = 0;
-						for (unsigned int j = 0; j < _MconvMoityBulk2.cols(); ++j)
-						{
-							if (_QsCompBulk[j] == 0)
-								continue;
-
-							mat.native(mIdx, jIdx) = static_cast<double>(_MconvMoityBulk2(i, j));
-							jIdx++;
-						}
-						mIdx++;
-					}
-					return true;
-				};
-		}
-		else
-		{
-			jacFunc = [&](double const* const x, linalg::detail::DenseMatrixBase& mat)
-				{
-					// Prepare input vector by overwriting masked items
-					std::copy_n(c, mask.len, fullX + _nComp);
-
-					linalg::applyVectorSubset(x, mask, fullX + _nComp);
-
-					// Call residual function to initialize jacobian
-					residualImpl<double, double, double, true>(simTime.t, simTime.secIdx, fullX, nullptr, fullResidual, tlmAlloc.manageRemainingMemory());
-
-					// Extract Jacobian from full Jacobian
-					mat.setAll(0.0);
-					linalg::copyMatrixSubset(_jac, mask, mask, mat);
-					// Replace upper part with conservation relations
-					int  mIdx = 0;
-					int nConservedComps = _nComp - numActiveComp ; // _nComp - _dynReactionBulk->numReactionQuasiStationary();
-					for (unsigned int i = 0; i < _nComp; ++i)
-					{
-						if (_QsCompBulk[i] == 0)
-							continue;
-						if (mIdx >= _nConservedQuants)
-							continue;
-
-						int jIdx = 0;
-						for (unsigned int j = 0; j < _MconvMoityBulk2.cols(); ++j)
-						{
-							if(_QsCompBulk[j] == 0)
-								continue;
-
-							mat.native(mIdx, jIdx) = static_cast<double>(_MconvMoityBulk2(i, j));
-							jIdx++;
-						}
-						mIdx++;
-					}
-					return true;
-				};
-		}
-		std::copy_n(vecStateY, _nComp, fullX);
-		fullX[(2 * _nComp + _totalBound)] = c[(_nComp + _totalBound )]; // volume
-		_nonlinearSolver->solve(
-			[&](double const* const x, double* const r)
-			{
-				// Prepare input vector by overwriting masked items
-				std::copy_n(c, mask.len, fullX + _nComp);
-				linalg::applyVectorSubset(x, mask, fullX + _nComp);
-
-				// Call residual function
-				residualImpl<double, double, double, false>(simTime.t, simTime.secIdx, fullX, nullptr, fullResidual, tlmAlloc.manageRemainingMemory());
-
-				// Extract values from residual
-				linalg::selectVectorSubset(fullResidual + _nComp, mask, r);
-
-				int nConservedComps = _nComp - nActiveStates; // _nComp - _dynReactionBulk->numReactionQuasiStationary();
-				int  mIdx = 0;
-				for (unsigned int i = 0; i < _nComp; ++i)
-				{	
-					if(_QsCompBulk[i]==0) // 
-						continue;
-					if( mIdx >= _nConservedQuants)
-						continue;
-					int jIdx = 0;	
-					double dotProduct = 0.0;
-					for (unsigned int j = 0; j < _MconvMoityBulk2.cols(); ++j)
-					{
-						if (_QsCompBulk[j] == 0)
-							continue;
-						dotProduct += static_cast<double>(_MconvMoityBulk2(i, j)) * x[jIdx];
-						jIdx++;
-					}
-					r[mIdx] = dotProduct - conservedQuants[mIdx];
-					mIdx++;
-				}
-				
-				std::cout << "Residual: " << std::endl;
-				for (unsigned int i = 0; i < probSize; ++i) {
-					std::cout << r[i] << std::endl;
-				}
-				std::cout << "Solution: " << std::endl;
-				for (unsigned int i = 0; i < probSize; ++i)
-					std::cout << x[i] << std::endl;
-				
-				return true;
-			},
-			jacFunc, errorTol, static_cast<double*>(solution), nonlinMem, jacobianMatrix, probSize);
-
-		// Apply solution
-		linalg::applyVectorSubset(static_cast<double*>(solution), mask, c);
-		
-		std::cout << "Solution: " << std::endl;
-		for (unsigned int i = 0; i < _nComp; ++i)
-			std::cout << c[i] << std::endl;
-		
-		int a = 0;
-		// Refine / correct solution
-	}
-	else
-	{
-		LinearBufferAllocator tlmAlloc = threadLocalMem.get();
-		BufferedArray<int> qsMask = tlmAlloc.array<int>(_nComp + _totalBound);
-
-		// Check whether quasi-stationary reactions are present and construct mask array
-		bool hasNoQSreactions = true;
-		std::fill_n(static_cast<int*>(qsMask), _nComp + _totalBound, false);
-		int* localMask = static_cast<int*>(qsMask) + _nComp;
-		for (unsigned int type = 0; type < _nParType; localMask += _strideBound[type], ++type)
-		{
-			if (!_binding[type]->hasQuasiStationaryReactions())
-				continue;
-
-			// Determine whether nonlinear solver is required
-			const ColumnPosition colPos{ 0.0, 0.0, 0.0 };
-			if (!_binding[type]->preConsistentInitialState(simTime.t, simTime.secIdx, colPos, c + _nComp + _offsetParType[type], c, tlmAlloc))
-				continue;
-
-			hasNoQSreactions = false;
-
-			// Construct mask
-			int const* const qsMaskSrc = _binding[type]->reactionQuasiStationarity();
-			std::copy_n(qsMaskSrc, _strideBound[type], localMask);
-
-			// Mark component for conserved moiety if it has a quasi-stationary bound state
-			unsigned int idx = 0;
-			for (unsigned int comp = 0; comp < _nComp; ++comp)
-			{
-				// Skip components that are already marked
-				if (qsMask[comp])
-				{
-					idx += _nBound[type * _nComp + comp];
-					continue;
-				}
-
-				for (unsigned int state = 0; state < _nBound[type * _nComp + comp]; ++state, ++idx)
-				{
-					if (qsMaskSrc[idx])
-					{
-						qsMask[comp] = true;
-						break;
-					}
-				}
-			}
-		}
-
-		// Consistent init is not required as we do not have quasi-stationary reactions
-		if (hasNoQSreactions)
-			return;
-
-		const linalg::ConstMaskArray mask{ static_cast<int*>(qsMask), static_cast<int>(_nComp + _totalBound) };
-		const int probSize = linalg::numMaskActive(mask);
-
-		// Extract initial values from current state
-		BufferedArray<double> solution = tlmAlloc.array<double>(probSize);
-		linalg::selectVectorSubset(c, mask, static_cast<double*>(solution));
-
-		// Save values of conserved moieties
-		const unsigned int numActiveComp = numMaskActive(mask, _nComp);
-		BufferedArray<double> conservedQuants = tlmAlloc.array<double>(numActiveComp);
-		const double epsQ = 1.0 - porosity;
-		unsigned int idx = 0;
-		for (unsigned int comp = 0; comp < _nComp; ++comp)
-		{
-			if (!qsMask[comp])
-				continue;
-
-			conservedQuants[idx] = porosity * c[comp];
 			for (unsigned int type = 0; type < _nParType; ++type)
 			{
-				const double factor = epsQ * static_cast<double>(_parTypeVolFrac[type]);
-				for (unsigned int state = 0; state < _nBound[type * _nComp + comp]; ++state)
-				{
-					const unsigned int bndIdx = _offsetParType[type] + _boundOffset[type * _nComp + comp] + state;
-					if (!qsMask[_nComp + bndIdx])
-						continue;
-
-					conservedQuants[idx] += factor * c[_nComp + bndIdx]; 
-				}
-			}
-
-			++idx;
-		}
-
-		linalg::DenseMatrixView jacobianMatrix(_jacFact.data(), _jacFact.pivotData(), probSize, probSize);
-
-		BufferedArray<double> baFullX = tlmAlloc.array<double>(numDofs());
-		double* const fullX = static_cast<double*>(baFullX);
-
-		BufferedArray<double> baFullResidual = tlmAlloc.array<double>(numDofs());
-		double* const fullResidual = static_cast<double*>(baFullResidual);
-
-		BufferedArray<double> baNonlinMem = tlmAlloc.array<double>(_nonlinearSolver->workspaceSize(probSize));
-		double* const nonlinMem = static_cast<double*>(baNonlinMem);
-
-		std::function<bool(double const* const, linalg::detail::DenseMatrixBase&)> jacFunc;
-		if (adJac.adY && adJac.adRes)
-		{
-			ad::copyToAd(vecStateY, adJac.adY, _nComp);
-
-			jacFunc = [&](double const* const x, linalg::detail::DenseMatrixBase& mat)
-				{
-					active* const localAdY = adJac.adY + _nComp;
-					active* const localAdRes = adJac.adRes + _nComp;
-
-					// Copy over state vector to AD state vector (without changing directional values to keep seed vectors)
-					// and initialize residuals with zero (also resetting directional values)
-					ad::copyToAd(c, localAdY, mask.len);
-					// @todo Check if this is necessary
-					ad::resetAd(localAdRes, mask.len);
-
-					// Prepare input vector by overwriting masked items
-					linalg::applyVectorSubset(x, mask, localAdY);
-
-					// Call residual function
-					residualImpl<active, active, double, false>(simTime.t, simTime.secIdx, adJac.adY, nullptr, adJac.adRes, tlmAlloc.manageRemainingMemory());
-
-#ifdef CADET_CHECK_ANALYTIC_JACOBIAN
-					std::copy_n(c, mask.len, fullX);
-					linalg::applyVectorSubset(x, mask, fullX);
-
-					// Compute analytic Jacobian
-					residualImpl<double, double, double, true>(simTime.t, simTime.secIdx, fullX, nullptr, fullResidual, tlmAlloc.manageRemainingMemory());
-
-					// Compare
-					const double diff = ad::compareDenseJacobianWithAd(localAdRes, adJac.adDirOffset, _jac);
-					LOG(Debug) << "MaxDiff: " << diff;
-#endif
-
-					// Extract Jacobian from AD
-					ad::extractDenseJacobianFromAd(localAdRes, adJac.adDirOffset, _jac);
-
-					// Extract Jacobian from full Jacobian
-					mat.setAll(0.0);
-					linalg::copyMatrixSubset(_jac, mask, mask, mat);
-
-					// Replace upper part with conservation relations
-					mat.submatrixSetAll(0.0, 0, 0, numActiveComp, probSize);
-
-					unsigned int rIdx = 0;
-					const double epsQ = 1.0 - porosity;
-
-					for (unsigned int comp = 0; comp < _nComp; ++comp)
-					{
-						if (!mask.mask[comp])
-							continue;
-
-						mat.native(rIdx, rIdx) = porosity;
-
-						for (unsigned int type = 0; type < _nParType; ++type)
-						{
-							const double factor = epsQ * static_cast<double>(_parTypeVolFrac[type]);
-
-							const unsigned int offset = _nComp + _offsetParType[type] + _boundOffset[type * _nComp + comp];
-							unsigned int bIdx = numActiveComp + numMaskActive(mask, _nComp, _boundOffset[type * _nComp + comp]);
-							for (unsigned int state = 0; state < _nBound[type * _nComp + comp]; ++state)
-							{
-								if (!mask.mask[offset + state])
-									continue;
-
-								mat.native(rIdx, bIdx) = factor;
-								++bIdx;
-							}
-						}
-
-						++rIdx;
-					}
-
-					return true;
-				};
-		}
-		else
-		{
-			jacFunc = [&](double const* const x, linalg::detail::DenseMatrixBase& mat)
-				{
-					// Prepare input vector by overwriting masked items
-					std::copy_n(c, mask.len, fullX + _nComp);
-					linalg::applyVectorSubset(x, mask, fullX + _nComp);
-
-					// Call residual function
-					residualImpl<double, double, double, true>(simTime.t, simTime.secIdx, fullX, nullptr, fullResidual, tlmAlloc.manageRemainingMemory());
-
-					// Extract Jacobian from full Jacobian
-					mat.setAll(0.0);
-					linalg::copyMatrixSubset(_jac, mask, mask, mat);
-
-					// Replace upper part with conservation relations
-					mat.submatrixSetAll(0.0, 0, 0, numActiveComp, probSize);
-
-					unsigned int rIdx = 0;
-					const double epsQ = 1.0 - porosity;
-
-					for (unsigned int comp = 0; comp < _nComp; ++comp)
-					{
-						if (!mask.mask[comp])
-							continue;
-
-						mat.native(rIdx, rIdx) = porosity;
-
-						for (unsigned int type = 0; type < _nParType; ++type)
-						{
-							const double factor = epsQ * static_cast<double>(_parTypeVolFrac[type]);
-
-							const unsigned int offset = _nComp + _offsetParType[type] + _boundOffset[type * _nComp + comp];
-							unsigned int bIdx = numActiveComp + numMaskActive(mask, _nComp, _boundOffset[type * _nComp + comp]);
-							for (unsigned int state = 0; state < _nBound[type * _nComp + comp]; ++state)
-							{
-								if (!mask.mask[offset + state])
-									continue;
-
-								mat.native(rIdx, bIdx) = factor;
-								++bIdx;
-							}
-						}
-
-						++rIdx;
-					}
-
-					return true;
-				};
-		}
-
-		// Copy inlet values
-		std::copy_n(vecStateY, _nComp, fullX);
-
-		// Apply nonlinear solver
-		_nonlinearSolver->solve(
-			[&](double const* const x, double* const r)
-			{
-				// Prepare input vector by overwriting masked items
-				std::copy_n(c, mask.len, fullX + _nComp);
-				linalg::applyVectorSubset(x, mask, fullX + _nComp);
-
-				// Call residual function
-				residualImpl<double, double, double, false>(simTime.t, simTime.secIdx, fullX, nullptr, fullResidual, tlmAlloc.manageRemainingMemory());
-
-				// Extract values from residual
-				linalg::selectVectorSubset(fullResidual + _nComp, mask, r);
-
-				// Calculate residual of conserved moieties
-				std::fill_n(r, numActiveComp, 0.0);
-				unsigned int rIdx = 0;
-				const double epsQ = 1.0 - porosity;
-
-				for (unsigned int comp = 0; comp < _nComp; ++comp)
-				{
-					if (!mask.mask[comp])
-						continue;
-
-					r[rIdx] = porosity * x[rIdx] - conservedQuants[rIdx];
-
-					for (unsigned int type = 0; type < _nParType; ++type)
-					{
-						const double factor = epsQ * static_cast<double>(_parTypeVolFrac[type]);
-
-						const unsigned int offset = _nComp + _offsetParType[type] + _boundOffset[type * _nComp + comp];
-						unsigned int bIdx = numActiveComp + numMaskActive(mask, _nComp, _boundOffset[type * _nComp + comp]);
-						for (unsigned int state = 0; state < _nBound[type * _nComp + comp]; ++state)
-						{
-							if (!mask.mask[offset + state])
-								continue;
-
-							r[rIdx] += factor * x[bIdx];
-							++bIdx;
-						}
-					}
-
-					++rIdx;
-				}	
-
-				return true;
-			},
-			jacFunc, errorTol, static_cast<double*>(solution), nonlinMem, jacobianMatrix, probSize);
-
-		// Apply solution
-		linalg::applyVectorSubset(static_cast<double*>(solution), mask, c);
-
-		// Refine / correct solution
-		for (unsigned int type = 0; type < _nParType; ++type)
-		{
-			const ColumnPosition colPos{ 0.0, 0.0, 0.0 };
-			_binding[type]->postConsistentInitialState(simTime.t, simTime.secIdx, colPos, c + _nComp + _offsetParType[type], c, tlmAlloc);
-		}
-	}
-}
-
-void CSTRModel::consistentInitialTimeDerivative(const SimulationTime& simTime, double const* vecStateY, double* const vecStateYdot, util::ThreadLocalStorage& threadLocalMem)
-{
-	double const* const c = vecStateY + _nComp;
-	double* const cDot = vecStateYdot + _nComp;
-	const double vLiquid = c[_nComp + _totalBound];
-	const double vSolid = static_cast<double>(_constSolidVolume);
-
-	const double flowIn = static_cast<double>(_flowRateIn);
-	const double flowOut = static_cast<double>(_flowRateOut);
-
-	// Note that the residual has not been negated, yet. We will do that now. (t0 is cDot = res(t0))
-	for (unsigned int i = 0; i < numDofs(); ++i)
-		vecStateYdot[i] = -vecStateYdot[i];
-
-	// Assemble time derivative Jacobian
-	_jacFact.setAll(0.0);
-	addTimeDerivativeJacobian(simTime.t, 1.0, ConstSimulationState{ vecStateY, nullptr }, _jacFact);
-
-	// Check if volume is 0
-	if (vLiquid == 0.0)
-	{
-		// Volume: \dot{V} = F_{in} - F_{out} - F_{filter}
-		const double vDot = flowIn - flowOut - static_cast<double>(_curFlowRateFilter);
-		_jacFact.native(_nComp + _totalBound, _nComp + _totalBound) = 1.0;
-		cDot[_nComp + _totalBound] = vDot;
-
-		// We have the equation
-		//    V^l * \dot{c}_i + \dot{V}^l * c_i + V^s * [sum_j sum_m d_j q_{i,m}]} = c_{in,i} * F_in - c_i * F_out
-		// which is now algebraic wrt. c due to V = 0:
-		//    \dot{V}^l * c_i + V^s * [sum_j sum_m d_j q_{i,m}]) = c_{in,i} * F_in - c_i * F_out
-		// So we take the derivative wrt. to time t on both sides
-		//    \ddot{V}^l * c_i + \dot{V}^l * \dot{c}_i + V^s * [sum_j sum_m d_j \dot{q}_{i,m}]) = \dot{c}_{in,i} * F_in - \dot{c}_i * F_out
-		// and use the fact that \ddot{V}^l = 0 to arrive at
-		//    \dot{V}^l * \dot{c}_i + V^s * [sum_j sum_m d_j \dot{q}_{i,m}]) = \dot{c}_{in,i} * F_in - \dot{c}_i * F_out
-		// Separating knowns from unknowns gives
-		// \dot{c}_i = [ \dot{c}_{in,i} * F_in - + V^s * [sum_j sum_m d_j \dot{q}_{i,m}]) ] / (F_out + \dot{V}^l)
-
-		// Note that if the denominator was 0, we had
-		//    0 = \dot{V} + F_out = F_in - F_filter - F_out + F_out
-		// which leads to
-		//    F_in = F_filter
-		// Since F_out >= 0 and \dot{V} = -F_out, we get
-		//    \dot{V} <= 0
-		// Assuming a valid configuration, we obtain \dot{V} = 0
-		// as the tank would get a negative volume otherwise.
-		// Concluding, we arrive at \dot{V} = F_out = 0.
-		// In this situation, F_in = F_filter = 0 has to hold
-		// as otherwise the liquid (solvent) is immediately and
-		// fully taken out, leaving only the pure dry components.
-		// We, hence, assume that this doesn't happen and simply
-		// do nothing leaving the initial conditions in place.
-
-		typename linalg::DenseMatrix::RowIterator itRow = _jacFact.row(0);
-
-		const double denom = vDot + flowOut;
-		if (denom == 0.0)
-			return;
-		else
-		{
-			for (unsigned int i = 0; i < _nComp; ++i, ++itRow)
-			{
-				itRow.setAll(0.0);
-
-				// Jacobian of c_i + vSolid * [sum_j sum_m d_j q_{i,m}]
-
-				// d/dc_i
-				itRow[0] = 1.0;
-
-				// Advance to bound states
-				const int bndIdx = _nComp - i;
-				for (unsigned int type = 0; type < _nParType; ++type)
-				{
-					const int innerIdx = bndIdx + _offsetParType[type] + _boundOffset[type * _nComp + i];
-					const double innerFactor = static_cast<double>(_parTypeVolFrac[type]) * vSolid;
-					for (unsigned int j = 0; j < _nBound[type * _nComp + i]; ++j)
-					{
-						itRow[innerIdx + j] = innerFactor;
-					}
-				}
-
-				// \dot{c}_i = [ \dot{c}_{in,i} * F_in - + V^s * [sum_j sum_m d_j \dot{q}_{i,m}]) ] / (F_out + \dot{V}^l)
-				// TODO: This is wrong as vecStateYdot does not contain \dot{c}_in (on entry)
-				// This scenario violates the assumption that every outlet DOF is dynamic
-				// which is key to the consistent initialization algorithm. Fixing this problem
-				// requires fundamental changes to the consistent initialization concept
-				// implemented so far.
-				cDot[i] = 0.0;
-			}
-		}
-	}
-
-	LinearBufferAllocator tlmAlloc = threadLocalMem.get();
-	if (_hasQuasiStationaryReactionBulk)
-	{
-
-		//LinearBufferAllocator tlmAlloc = threadLocalMem.get(); // -> todo hier aufpassen ob ich den mem auch benutzen darf
-
-		// Overwrite rows corresponding to algebraic equations with the Jacobian and set right hand side to 0
-		BufferedArray<double> dReacDt = tlmAlloc.array<double>(_nComp + 1);
-
-		// Obtain derivative of fluxes wrt. time
-		std::fill_n(static_cast<double*>(dReacDt), _nComp + 1 , 0.0);
-
-		_dynReactionBulk->timeDerivativeQuasiStationaryReaction(simTime.t, _curSecIdx, ColumnPosition{ 0.0, 0.0, 0.0 }, c, static_cast<double*>(dReacDt), tlmAlloc);
-
-		// Copy row assioated to algebraic equation from original Jacobian and set right hand side
-		double* const cDot = vecStateYdot + _nComp;
-		int test = _nComp - _dynReactionBulk->numReactionQuasiStationary();
-		for (int i = test; i < _nComp; ++i)
-		{
-			_jacFact.copyRowFrom(_jac, i, i);
-			cDot[i] = -dReacDt[i];
-		}
-		std::cout << " jacFact: " << std::endl;
-		for (int i = 0; i < _nComp +1 ; ++i)
-		{
-			for (int j = 0; j < _nComp +1 ; ++j)
-			{
-				std::cout << _jacFact.native(i, j) << " ";
-			}
-			std::cout << std::endl;
-		}
-
-
-		// Factorize
-		const bool result = _jacFact.robustFactorize(static_cast<double*>(dReacDt));
-		if (!result)
-		{
-			LOG(Error) << "Factorize() failed";
-		}
-
-		// Solve
-		const bool result2 = _jacFact.robustSolve(vecStateYdot + _nComp, static_cast<double*>(dReacDt));
-		if (!result2)
-		{
-			LOG(Error) << "Solve() failed";
-		}
-	}
-	else {
-		// Overwrite rows corresponding to algebraic equations with the Jacobian and set right hand side to 0
-		BufferedArray<double> dFluxDt = tlmAlloc.array<double>(_nComp + _totalBound + 1);
-		unsigned int idx = _nComp;
-		for (unsigned int type = 0; type < _nParType; ++type)
-		{
-			if (!_binding[type]->hasQuasiStationaryReactions())
-			{
-				idx += _strideBound[type];
-				continue;
-			}
-
-			int const* const mask = _binding[type]->reactionQuasiStationarity();
-
-			// Obtain derivative of fluxes wrt. time
-			std::fill_n(static_cast<double*>(dFluxDt), _strideBound[type], 0.0);
-			if (_binding[type]->dependsOnTime())
-			{
-				_binding[type]->timeDerivativeQuasiStationaryFluxes(simTime.t, simTime.secIdx,
-					ColumnPosition{ 0.0, 0.0, 0.0 },
-					c, c + _nComp + _offsetParType[type], static_cast<double*>(dFluxDt), tlmAlloc);
-			}
-
-			// Copy row from original Jacobian and set right hand side
-			double* const qShellDot = cDot + _nComp + _offsetParType[type];
-			for (unsigned int i = 0; i < _strideBound[type]; ++i, ++idx)
-			{
-				if (!mask[i])
+				if (!_binding[type])
 					continue;
 
-				_jacFact.copyRowFrom(_jac, idx, idx);
-				qShellDot[i] = -dFluxDt[i];
+				std::vector<ParameterId> initParams(_strideBound[type]);
+				_binding[type]->fillBoundPhaseInitialParameters(initParams.data(), _unitOpIdx, type);
+
+				active* const ic = _initConditions.data() + _nComp + _offsetParType[type];
+				for (unsigned int i = 0; i < _strideBound[type]; ++i)
+					_parameters[initParams[i]] = ic + i;
 			}
-		}
 
-		// Factorize
-		const bool result = _jacFact.robustFactorize(static_cast<double*>(dFluxDt));
-		if (!result)
-		{
-			LOG(Error) << "Factorize() failed";
-		}
+			_parameters[makeParamId(hashString("INIT_LIQUID_VOLUME"), _unitOpIdx, CompIndep, ParTypeIndep, BoundStateIndep, ReactionIndep, SectionIndep)] = _initConditions.data() + _nComp + _totalBound;
 
-		// Solve
-		const bool result2 = _jacFact.robustSolve(vecStateYdot + _nComp, static_cast<double*>(dFluxDt));
-		if (!result2)
-		{
-			LOG(Error) << "Solve() failed";
-		}
-	}
-}
-
-void CSTRModel::leanConsistentInitialState(const SimulationTime& simTime, double* const vecStateY, const AdJacobianParams& adJac, double errorTol, util::ThreadLocalStorage& threadLocalMem)
-{
-	// It is assumed that the bound states are (approximately) correctly initialized.
-	// Thus, only the liquid phase has to be initialized
-
-	double* const c = vecStateY + _nComp;
-	const double vLiquid = c[_nComp];
-	const double vSolid = static_cast<double>(_constSolidVolume);
-	
-	if(!_hasQuasiStationaryReactionBulk)
-		return;
-	// Check if volume is 0
-	if (vLiquid == 0.0)
-	{
-		const double flowIn = static_cast<double>(_flowRateIn);
-		const double flowOut = static_cast<double>(_flowRateOut);
-
-		// Volume: \dot{V} = F_{in} - F_{out} - F_{filter}
-		const double vDot = flowIn - flowOut - static_cast<double>(_curFlowRateFilter);
-
-		// We have the equation
-		//    \dot{V}^l * c + \dot{c} * V^l + V^s * [sum_j q_j] = c_in * F_in - c * F_out
-		// which is now algebraic wrt. c due to V = 0:
-		//    (\dot{V}^l + F_out) * c = - V^s * [sum_j q_j] + c_in * F_in
-		// Separating knowns from unknowns gives
-		//    (\dot{V} + F_out) * c = c_in * F_in - V^s * [sum_j q_j]
-		// Hence, we obtain
-		//    c = (c_in * F_in - \dot{V} / V^s * [sum_j q_j]) / (\dot{V} + F_out)
-
-		// Note that if the denominator was 0, we had
-		//    0 = \dot{V} + F_out = F_in - F_filter
-		// which leads to
-		//    F_in = F_filter
-		// Since F_out >= 0 and \dot{V} = -F_out, we get
-		//    \dot{V} <= 0
-		// Assuming a valid configuration, we obtain \dot{V} = 0
-		// as the tank would get a negative volume otherwise.
-		// Concluding, we arrive at \dot{V} = F_out = 0.
-		// In this situation, F_in = F_filter = 0 has to hold
-		// as otherwise the liquid (solvent) is immediately and
-		// fully taken out, leaving only the pure dry components.
-		// We, hence, assume that this doesn't happen and simply
-		// do nothing leaving the initial conditions in place.
-
-		const double denom = vDot + flowOut;
-		if (denom == 0.0)
-			return;
-
-		for (unsigned int i = 0; i < _nComp; ++i)
-			c[i] = vecStateY[i] * flowIn / denom;;
-
-				const double qFactor = vSolid / denom;
-		for (unsigned int type = 0; type < _nParType; ++type)
-		{
-			unsigned int const* const bo = _boundOffset + type * _nComp;
-			unsigned int const* const nb = _nBound + type * _nComp;
-			double const* const typeQ = c + _nComp + _offsetParType[type];
-			for (unsigned int i = 0; i < _nComp; ++i)
+			// Reconfigure binding model
+			bool bindingConfSuccess = true;
+			if (!_binding.empty())
 			{
-				double qSum = 0.0;
-				double const* const localQ = typeQ + bo[i];
-				for (unsigned int j = 0; j < nb[i]; ++j)
-					qSum += localQ[j];
+				for (unsigned int type = 0; type < _nParType; ++type)
+				{
+					if (!_binding[type] || !_binding[type]->requiresConfiguration())
+						continue;
 
-				c[i] -= qFactor * static_cast<double>(_parTypeVolFrac[type]) * qSum;
+					MultiplexedScopeSelector scopeGuard(paramProvider, "adsorption", type, _nParType == 1, true);
+					bindingConfSuccess = _binding[type]->configure(paramProvider, _unitOpIdx, type) && bindingConfSuccess;
+				}
 			}
-		}
-	}
-}
 
-void CSTRModel::leanConsistentInitialTimeDerivative(double t, double const* const vecStateY, double* const vecStateYdot, double* const res, util::ThreadLocalStorage& threadLocalMem)
-{
-	// It is assumed that the bound states are (approximately) correctly initialized.
-	// Thus, only the liquid phase has to be initialized
-
-	double const* const c = vecStateY + _nComp;
-	double* const cDot = vecStateYdot + _nComp;
-	double* const resC = res + _nComp;
-	const double vLiquid = c[_nComp];
-	const double vSolid = static_cast<double>(_constSolidVolume);
-	const double flowIn = static_cast<double>(_flowRateIn);
-	const double flowOut = static_cast<double>(_flowRateOut);
-
-	LinearBufferAllocator tlmAlloc = threadLocalMem.get();
-
-	// Volume: \dot{V} = F_{in} - F_{out} - F_{filter}
-	const double vDot = flowIn - flowOut - static_cast<double>(_curFlowRateFilter);
-	cDot[_nComp] = vDot;
-	
-	
-	// Check if volume is 0
-	if (vLiquid == 0.0 && !_hasQuasiStationaryReactionBulk)
-	{
-		// We have the equation
-		//    V^l * \dot{c}_i + \dot{V}^l * c_i + V^s * [sum_j sum_m d_j q_{i,m}]} = c_{in,i} * F_in - c_i * F_out
-		// which is now algebraic wrt. c due to V = 0:
-		//    \dot{V}^l * c_i + V^s * [sum_j sum_m d_j q_{i,m}]) = c_{in,i} * F_in - c_i * F_out
-		// So we take the derivative wrt. to time t on both sides
-		//    \ddot{V}^l * c_i + \dot{V}^l * \dot{c}_i + V^s * [sum_j sum_m d_j \dot{q}_{i,m}]) = \dot{c}_{in,i} * F_in - \dot{c}_i * F_out
-		// and use the fact that \ddot{V}^l = 0 to arrive at
-		//    \dot{V}^l * \dot{c}_i + V^s * [sum_j sum_m d_j \dot{q}_{i,m}]) = \dot{c}_{in,i} * F_in - \dot{c}_i * F_out
-		// Separating knowns from unknowns gives
-		// \dot{c}_i = [ \dot{c}_{in,i} * F_in - + V^s * [sum_j sum_m d_j \dot{q}_{i,m}]) ] / (F_out + \dot{V}^l)
-
-		// Note that if the denominator was 0, we had
-		//    0 = \dot{V} + F_out = F_in - F_filter - F_out + F_out
-		// which leads to
-		//    F_in = F_filter
-		// Since F_out >= 0 and \dot{V} = -F_out, we get
-		//    \dot{V} <= 0
-		// Assuming a valid configuration, we obtain \dot{V} = 0
-		// as the tank would get a negative volume otherwise.
-		// Concluding, we arrive at \dot{V} = F_out = 0.
-		// In this situation, F_in = F_filter = 0 has to hold
-		// as otherwise the liquid (solvent) is immediately and
-		// fully taken out, leaving only the pure dry components.
-		// We, hence, assume that this doesn't happen and simply
-		// do nothing leaving the initial conditions in place.
-
-		typename linalg::DenseMatrix::RowIterator itRow = _jacFact.row(0);
-
-		const double denom = vDot + flowOut;
-		if (denom == 0.0)
-			return;
-		else
-		{
-			const double qFactor = 2.0 * vSolid / denom;
-			const double factor = flowIn / denom;
-
-			for (unsigned int i = 0; i < _nComp; ++i)
+			// Reconfigure reaction model
+			bool dynReactionConfSuccess = true;
+			_hasQuasiStationaryReactionBulk = false;
+			_MconvMoityBulk = Eigen::Matrix<active, Eigen::Dynamic, Eigen::Dynamic>::Zero(0, 0); // matrix for conserved moities
+			_QsCompBulk.clear();
+			_nConservedQuants = 0;
+			if (_dynReactionBulk && _dynReactionBulk->requiresConfiguration())
 			{
-				// TODO: This is wrong as vecStateYdot does not contain \dot{c}_in (on entry)
-				// This scenario violates the assumption that every outlet DOF is dynamic
-				// which is key to the consistent initialization algorithm. Fixing this problem
-				// requires fundamental changes to the consistent initialization concept
-				// implemented so far.
-				vecStateYdot[i] = 0.0;
+				paramProvider.pushScope("reaction_bulk");
+				dynReactionConfSuccess = _dynReactionBulk->configure(paramProvider, _unitOpIdx, ParTypeIndep);
+				paramProvider.popScope();
 
-				cDot[i] = vecStateYdot[i] * factor;
+				// Get quasi stationary reactions information vector
+				_dynReactionBulk->hasQuasiStationaryReactionsBulk();
 
+				if (_dynReactionBulk->hasQuasiStationaryReactionsBulk())
+				{
+					_QsCompBulk.resize(_nComp);
+					_dynReactionBulk->fillConservedMoietiesBulk(_MconvMoityBulk, _nConservedQuants, _QsCompBulk);
+
+
+					bool hasQSBinding = false;
+					for (int i = 0; i < _nParType; i++)
+					{
+						if (_binding[i] && _binding[i]->hasQuasiStationaryReactions())
+						{
+							hasQSBinding = true;
+							break;
+						}
+					}
+					_hasQuasiStationaryReactionBulk = _dynReactionBulk->hasQuasiStationaryReactionsBulk();
+					if (hasQSBinding && _hasQuasiStationaryReactionBulk)
+					{
+						throw InvalidParameterException("Quasi stationary reactions in binding and bulk reaction model are not supported");
+					}
+				}
+			}
+			
+
+			for (unsigned int type = 0; type < _nParType; ++type)
+			{
+				if (!_dynReaction[type] || !_dynReaction[type]->requiresConfiguration())
+					continue;
+
+				MultiplexedScopeSelector scopeGuard(paramProvider, "reaction_particle", type, _nParType == 1, true);
+				dynReactionConfSuccess = _dynReaction[type]->configure(paramProvider, _unitOpIdx, type) && dynReactionConfSuccess;
+			}
+
+			return bindingConfSuccess && dynReactionConfSuccess;
+		}
+
+		unsigned int CSTRModel::threadLocalMemorySize() const CADET_NOEXCEPT
+		{
+			LinearMemorySizer lms;
+
+			// Memory for residualImpl()
+			for (unsigned int i = 0; i < _nParType; ++i)
+			{
+				if (_binding[i] && _binding[i]->requiresWorkspace())
+					lms.fitBlock(_binding[i]->workspaceSize(_nComp, _strideBound[i], _nBound + i * _nComp));
+				if (_dynReaction[i] && _dynReaction[i]->requiresWorkspace())
+					lms.fitBlock(_dynReaction[i]->workspaceSize(_nComp, _strideBound[i], _nBound + i * _nComp));
+			}
+
+			if (_dynReactionBulk && _dynReactionBulk->requiresWorkspace())
+				lms.fitBlock(_dynReactionBulk->workspaceSize(_nComp, 0, nullptr));
+
+			const unsigned int maxStrideBound = _strideBound ? *std::max_element(_strideBound, _strideBound + _nParType) : 0;
+			lms.add<active>(_nComp + maxStrideBound);
+			lms.add<double>((maxStrideBound + _nComp) * (maxStrideBound + _nComp));
+
+			lms.commit();
+			const std::size_t resImplSize = lms.bufferSize();
+
+			// Memory for consistentInitialTimeDerivative()
+			for (unsigned int i = 0; i < _nParType; ++i)
+			{
+				if (_binding[i] && _binding[i]->requiresWorkspace())
+					lms.fitBlock(_binding[i]->workspaceSize(_nComp, _strideBound[i], _nBound + i * _nComp));
+			}
+			lms.add<double>(_nComp + _totalBound + 1);
+			lms.commit();
+
+			// Memory for consistentInitialState()
+			lms.add<int>(_nComp + _totalBound);
+			lms.add<double>(_nComp + _totalBound);
+			lms.add<double>(_nComp);
+			lms.add<double>(_nComp + _totalBound);
+			lms.add<double>(numDofs());
+			lms.add<double>(_nonlinearSolver->workspaceSize(_nComp + _totalBound) * sizeof(double));
+			lms.addBlock(resImplSize);
+			lms.commit();
+
+			// Memory for consistentInitialSensitivity
+			lms.add<int>(_totalBound);
+			lms.add<double>(_nComp + _totalBound + 1);
+			lms.add<double>(_nComp + _totalBound);
+			lms.add<double>(_totalBound);
+			lms.commit();
+
+			return lms.bufferSize();
+		}
+
+		void CSTRModel::setSectionTimes(double const* secTimes, bool const* secContinuity, unsigned int nSections) {}
+
+		void CSTRModel::useAnalyticJacobian(const bool analyticJac)
+		{
+#ifndef CADET_CHECK_ANALYTIC_JACOBIAN
+			_analyticJac = analyticJac;
+#else
+			// Use AD Jacobian if analytic Jacobian is to be checked
+			_analyticJac = false;
+#endif
+		}
+
+		void CSTRModel::notifyDiscontinuousSectionTransition(double t, unsigned int secIdx, const ConstSimulationState& simState, const AdJacobianParams& adJac)
+		{
+			if (_flowRateFilter.size() > 1)
+			{
+				_curFlowRateFilter = _flowRateFilter[secIdx];
+			}
+			else if (_flowRateFilter.size() == 1)
+			{
+				_curFlowRateFilter = _flowRateFilter[0];
+			}
+
+			_curSecIdx = secIdx;
+		}
+
+		void CSTRModel::reportSolution(ISolutionRecorder& recorder, double const* const solution) const
+		{
+			Exporter expr(_nComp, _nParType, _nBound, _strideBound, _boundOffset, _totalBound, solution);
+			recorder.beginUnitOperation(_unitOpIdx, *this, expr);
+			recorder.endUnitOperation();
+		}
+
+		void CSTRModel::reportSolutionStructure(ISolutionRecorder& recorder) const
+		{
+			Exporter expr(_nComp, _nParType, _nBound, _strideBound, _boundOffset, _totalBound, nullptr);
+			recorder.unitOperationStructure(_unitOpIdx, *this, expr);
+		}
+
+		unsigned int CSTRModel::requiredADdirs() const CADET_NOEXCEPT
+		{
+#ifndef CADET_CHECK_ANALYTIC_JACOBIAN
+			if (_analyticJac)
+				// Only use AD if binding models require it
+				return maxBindingAdDirs();
+#endif
+
+			// We always need AD if CADET_CHECK_ANALYTIC_JACOBIAN and if analytic Jacobian is disabled
+			return _nComp + _totalBound + 1;
+		}
+
+		void CSTRModel::prepareADvectors(const AdJacobianParams& adJac) const
+		{
+			// Early out if AD is disabled
+			if (!adJac.adY)
+				return;
+
+			ad::prepareAdVectorSeedsForDenseMatrix(adJac.adY + _nComp, adJac.adDirOffset, _jac.columns());
+		}
+
+		void CSTRModel::applyInitialCondition(const SimulationState& simState) const
+		{
+			// Inlet DOFs
+			std::fill(simState.vecStateY, simState.vecStateY + _nComp, 0.0);
+			std::fill(simState.vecStateYdot, simState.vecStateYdot + _nComp, 0.0);
+
+			const unsigned int nDof = numPureDofs();
+			ad::copyFromAd(_initConditions.data(), simState.vecStateY + _nComp, nDof);
+
+			std::copy(_initConditionsDot.data(), _initConditionsDot.data() + nDof, simState.vecStateYdot + _nComp);
+		}
+
+		void CSTRModel::readInitialCondition(IParameterProvider& paramProvider)
+		{
+			// Clear time derivative
+			std::fill(_initConditionsDot.begin(), _initConditionsDot.end(), 0.0);
+
+			// Check if INIT_STATE is present
+			if (paramProvider.exists("INIT_STATE"))
+			{
+				const unsigned int nDof = numPureDofs();
+				const std::vector<double> initState = paramProvider.getDoubleArray("INIT_STATE");
+
+				ad::copyToAd(initState.data(), _initConditions.data(), nDof);
+
+				// Check if INIT_STATE contains the full state and its time derivative
+				if (initState.size() >= 2 * nDof)
+					std::copy(initState.data() + nDof, initState.data() + 2 * nDof, _initConditionsDot.data());
+
+				return;
+			}
+
+			const std::vector<double> initC = paramProvider.getDoubleArray("INIT_C");
+
+			if (initC.size() < _nComp)
+				throw InvalidParameterException("INIT_C does not contain enough values for all components");
+
+			ad::copyToAd(initC.data(), _initConditions.data(), _nComp);
+
+			if (paramProvider.exists("INIT_Q"))
+			{
+				const std::vector<double> initQ = paramProvider.getDoubleArray("INIT_Q");
+				ad::copyToAd(initQ.data(), _initConditions.data() + _nComp, _totalBound);
+			}
+			else
+				ad::fillAd(_initConditions.data() + _nComp, _totalBound, 0.0);
+
+			if (paramProvider.exists("INIT_LIQUID_VOLUME"))
+				_initConditions[_nComp + _totalBound].setValue(paramProvider.getDouble("INIT_LIQUID_VOLUME"));
+			else if (paramProvider.exists("INIT_VOLUME")) // todo delete for breaking change with new interface version
+				_initConditions[_nComp + _totalBound].setValue(paramProvider.getDouble("INIT_VOLUME"));
+			else
+				_initConditions[_nComp + _totalBound].setValue(0.0);
+		}
+
+		void CSTRModel::consistentInitialState(const SimulationTime& simTime, double* const vecStateY, const AdJacobianParams& adJac, double errorTol, util::ThreadLocalStorage& threadLocalMem)
+		{
+			double* const c = vecStateY + _nComp;
+			const double vLiquid = c[_nComp + _totalBound];
+			const double vSolid = static_cast<double>(_constSolidVolume);
+			const double porosity = static_cast<const double>(vLiquid) / (vSolid + static_cast<const double>(vLiquid));
+
+
+			// Check if liquid volume is 0
+			if (vLiquid == 0.0)
+			{
+				const double flowIn = static_cast<double>(_flowRateIn);
+				const double flowOut = static_cast<double>(_flowRateOut);
+
+				// Liquid Volume: \dot{V} = F_{in} - F_{out} - F_{filter}
+				const double vDot = flowIn - flowOut - static_cast<double>(_curFlowRateFilter);
+
+				// We have the equation
+				//    \dot{V}^l * c_i + V^l \dot{c}_i + V^s * ([sum_j sum_m d_j \dot{q}_{i,m}]) = c_{in,i} * F_in + c_i * F_out
+				// which is now algebraic wrt. c due to V^l = 0:
+				//    \dot{V}^l * c_i + V^s * [sum_j sum_m d_j \dot{q}_{i,m}] = c_{in,i} * F_in + c_i * F_out
+				// Separating knowns from unknowns gives
+				//    (\dot{V}^l + F_out) * c_i + V^s [sum_j sum_m d_j q_{i,m}] = c_in * F_in
+
+				// We assume that all binding models are fully dynamic (i.e., they do not have
+				// algebraic equations). 
+				// TODO: Figure out what to do when at least one binding model has algebraic equations.
+
+				// If the binding models do not have algebraic equations, the
+				// bound states q_{i,j} are dynamic and, thus, already determine
+				//    (\dot{V}^l + F_out) * c_i = c_in * F_in - V^s * [sum_j sum_m d_j q_{j,i,m}]
+				// This finally leads to
+				//    c_i = (c_in * F_in - V^s * [sum_j sum_m d_j q_{j,i,m}]) / (\dot{V}^l + F_out)
+
+				// Note that if the denominator (\dot{V} + F_out) were 0, we had
+				//    0 = \dot{V} + F_out = F_{in} - F_{filter}
+				// which leads to
+				//    F_in = F_filter
+				// Since F_out >= 0 and \dot{V} = -F_out, we get
+				//    \dot{V} <= 0
+				// Assuming a valid configuration, we obtain \dot{V} = 0
+				// as the tank would get a negative volume otherwise.
+				// Concluding, we arrive at \dot{V} = F_out = 0.
+				// In this situation, F_in = F_filter = 0 has to hold
+				// as otherwise the liquid (solvent) is immediately and
+				// fully taken out, leaving only the pure dry components.
+				// We, hence, assume that this doesn't happen and simply
+				// do nothing leaving the initial conditions in place.
+
+				const double denom = vDot + flowOut;
+				if (denom == 0.0)
+					return;
+
+				for (unsigned int i = 0; i < _nComp; ++i)
+					c[i] = vecStateY[i] * flowIn / denom;
+
+
+				const double qFactor = static_cast<double>(_constSolidVolume) / denom;
 				for (unsigned int type = 0; type < _nParType; ++type)
 				{
 					unsigned int const* const bo = _boundOffset + type * _nComp;
 					unsigned int const* const nb = _nBound + type * _nComp;
-					double const* const localQdot = cDot + _nComp + _offsetParType[type] + bo[i];
+					double const* const typeQ = c + _nComp + _offsetParType[type];
+					for (unsigned int i = 0; i < _nComp; ++i)
+					{
+						double qSum = 0.0;
+						double const* const localQ = typeQ + bo[i];
+						for (unsigned int j = 0; j < nb[i]; ++j)
+							qSum += localQ[j];
 
-					double qDotSum = 0.0;
-					for (unsigned int j = 0; j < nb[i]; ++j)
-						qDotSum += localQdot[j];
-
-					cDot[i] -= qFactor * static_cast<double>(_parTypeVolFrac[type]) * qDotSum;
+						c[i] -= qFactor * static_cast<double>(_parTypeVolFrac[type]) * qSum;
+					}
 				}
 			}
-		}
-	}
-	
-	else
-	{
-			// Concentrations: V^l * \dot{c} + \dot{V}^l * c + V^s * [sum_j sum_m d_j \dot{q}_{j,m}] = c_in * F_in + c * F_out
-			//             <=> V^l * \dot{c} = c_in * F_in + c * F_out - V^s * [sum_j sum_m d_j \dot{q}_{j,m}] - \dot{V}^l * c 
-			//                               = -res - V^s * [sum_j sum_m d_j \dot{q}_{j,m}] - \dot{V}^l * c
-			// => \dot{c} = (-res - V^s * [sum_j sum_m d_j \dot{q}_{j,m}] - \dot{V}^l * c) / V^l
-			for (unsigned int i = 0; i < _nComp; ++i)
+			if (_hasQuasiStationaryReactionBulk)
 			{
-				double qSum = 0.0;
-				double qDotSum = 0.0;
+
+				LinearBufferAllocator tlmAlloc = threadLocalMem.get();
+				BufferedArray<int> qsMask = tlmAlloc.array<int>(_nComp);
+
+				// mark which concentrations need to be reacalculated
+				qsMask.copyFromVector(_QsCompBulk);
+
+				int nActiveStates = std::count(_QsCompBulk.begin(), _QsCompBulk.end(), 1);
+
+				const linalg::ConstMaskArray mask{ static_cast<int*>(qsMask), static_cast<int>(_nComp) };
+				const int probSize = linalg::numMaskActive(mask);
+
+				// Extract initial values from current state
+				BufferedArray<double> solution = tlmAlloc.array<double>(probSize);
+				linalg::selectVectorSubset(c, mask, static_cast<double*>(solution));
+
+				// Save values of conserved moieties;
+				const unsigned int numActiveComp = numMaskActive(mask, _nComp);
+				BufferedArray<double> conservedQuants = tlmAlloc.array<double>(nActiveStates); // number of conserved quantities
+
+				// Calculate conserved quantities for the inital state 
+
+				int mIdx = 0;
+				for (unsigned int i = 0; i < _nComp; ++i)
+				{
+					if (_QsCompBulk[i] == 0)
+						continue;
+					if (mIdx >= _nConservedQuants)
+						continue;
+					double dotProduct = 0.0;
+					for (unsigned int j = 0; j < _MconvMoityBulk.cols(); ++j)
+						dotProduct += static_cast<double>(_MconvMoityBulk(i, j)) * c[j];
+
+					conservedQuants[mIdx] = dotProduct;
+					mIdx++;
+				}
+
+				linalg::DenseMatrixView jacobianMatrix(_jacFact.data(), _jacFact.pivotData(), probSize, probSize);
+				BufferedArray<double> baFullX = tlmAlloc.array<double>(numDofs());
+				double* const fullX = static_cast<double*>(baFullX);
+
+				BufferedArray<double> baFullResidual = tlmAlloc.array<double>(numDofs());
+				double* const fullResidual = static_cast<double*>(baFullResidual);
+
+				BufferedArray<double> baNonlinMem = tlmAlloc.array<double>(_nonlinearSolver->workspaceSize(probSize));
+				double* const nonlinMem = static_cast<double*>(baNonlinMem);
+
+
+				std::function<bool(double const* const, linalg::detail::DenseMatrixBase&)> jacFunc;
+				if (adJac.adY && adJac.adRes)
+				{
+					ad::copyToAd(vecStateY, adJac.adY, _nComp);
+
+					jacFunc = [&](double const* const x, linalg::detail::DenseMatrixBase& mat)
+						{
+							active* const localAdY = adJac.adY + _nComp;
+							active* const localAdRes = adJac.adRes + _nComp;
+
+							// Copy over state vector to AD state vector (without changing directional values to keep seed vectors)
+							// and initialize residuals with zero (also resetting directional values)
+							ad::copyToAd(c, localAdY, mask.len);
+							// @todo Check if this is necessary
+							ad::resetAd(localAdRes, mask.len);
+
+							// Prepare input vector by overwriting masked items
+							linalg::applyVectorSubset(x, mask, localAdY);
+
+							// Call residual function
+							residualImpl<active, active, double, false>(simTime.t, simTime.secIdx, adJac.adY, nullptr, adJac.adRes, tlmAlloc.manageRemainingMemory());
+
+#ifdef CADET_CHECK_ANALYTIC_JACOBIAN
+							std::copy_n(c, mask.len, fullX);
+							linalg::applyVectorSubset(x, mask, fullX);
+
+							// Compute analytic Jacobian
+							residualImpl<double, double, double, true>(simTime.t, simTime.secIdx, fullX, nullptr, fullResidual, tlmAlloc.manageRemainingMemory());
+
+							// Compare
+							const double diff = ad::compareDenseJacobianWithAd(localAdRes, adJac.adDirOffset, _jac);
+							LOG(Debug) << "MaxDiff: " << diff;
+#endif
+
+							// Extract Jacobian from AD
+							ad::extractDenseJacobianFromAd(localAdRes, adJac.adDirOffset, _jac);
+
+							// Extract Jacobian from full Jacobian
+							mat.setAll(0.0);
+							linalg::copyMatrixSubset(_jac, mask, mask, mat);
+							int numConservedMoities = _nComp - _dynReactionBulk->numReactionQuasiStationary();
+
+							// Replace upper part with conservation relations
+							int  mIdx = 0;
+							for (unsigned int i = 0; i < _nComp; ++i)
+							{
+								if (_QsCompBulk[i] == 0)
+									continue;
+								if (mIdx >= _nConservedQuants)
+									continue;
+
+								int jIdx = 0;
+								for (unsigned int j = 0; j < _MconvMoityBulk.cols(); ++j)
+								{
+									if (_QsCompBulk[j] == 0)
+										continue;
+
+									mat.native(mIdx, jIdx) = static_cast<double>(_MconvMoityBulk(i, j));
+									jIdx++;
+								}
+								mIdx++;
+							}
+							return true;
+						};
+				}
+				else
+				{
+					jacFunc = [&](double const* const x, linalg::detail::DenseMatrixBase& mat)
+						{
+							// Prepare input vector by overwriting masked items
+							std::copy_n(c, mask.len, fullX + _nComp);
+
+							linalg::applyVectorSubset(x, mask, fullX + _nComp);
+
+							// Call residual function to initialize jacobian
+							residualImpl<double, double, double, true>(simTime.t, simTime.secIdx, fullX, nullptr, fullResidual, tlmAlloc.manageRemainingMemory());
+
+							// Extract Jacobian from full Jacobian
+							mat.setAll(0.0);
+							linalg::copyMatrixSubset(_jac, mask, mask, mat);
+							// Replace upper part with conservation relations
+							int  mIdx = 0;
+							int nConservedComps = _nComp - numActiveComp; // _nComp - _dynReactionBulk->numReactionQuasiStationary();
+							for (unsigned int i = 0; i < _nComp; ++i)
+							{
+								if (_QsCompBulk[i] == 0)
+									continue;
+								if (mIdx >= _nConservedQuants)
+									continue;
+
+								int jIdx = 0;
+								for (unsigned int j = 0; j < _MconvMoityBulk.cols(); ++j)
+								{
+									if (_QsCompBulk[j] == 0)
+										continue;
+
+									mat.native(mIdx, jIdx) = static_cast<double>(_MconvMoityBulk(i, j));
+									jIdx++;
+								}
+								mIdx++;
+							}
+							return true;
+						};
+				}
+				std::copy_n(vecStateY, _nComp, fullX);
+				fullX[(2 * _nComp + _totalBound)] = c[(_nComp + _totalBound)]; // volume
+				_nonlinearSolver->solve(
+					[&](double const* const x, double* const r)
+					{
+						// Prepare input vector by overwriting masked items
+						std::copy_n(c, mask.len, fullX + _nComp);
+						linalg::applyVectorSubset(x, mask, fullX + _nComp);
+
+						// Call residual function
+						residualImpl<double, double, double, false>(simTime.t, simTime.secIdx, fullX, nullptr, fullResidual, tlmAlloc.manageRemainingMemory());
+
+						// Extract values from residual
+						linalg::selectVectorSubset(fullResidual + _nComp, mask, r);
+
+						int nConservedComps = _nComp - nActiveStates; // _nComp - _dynReactionBulk->numReactionQuasiStationary();
+						int  mIdx = 0;
+						for (unsigned int i = 0; i < _nComp; ++i)
+						{
+							if (_QsCompBulk[i] == 0) // 
+								continue;
+							if (mIdx >= _nConservedQuants)
+								continue;
+							int jIdx = 0;
+							double dotProduct = 0.0;
+							for (unsigned int j = 0; j < _MconvMoityBulk.cols(); ++j)
+							{
+								if (_QsCompBulk[j] == 0)
+									continue;
+								dotProduct += static_cast<double>(_MconvMoityBulk(i, j)) * x[jIdx];
+								jIdx++;
+							}
+							r[mIdx] = dotProduct - conservedQuants[mIdx];
+							mIdx++;
+						}
+
+						return true;
+					},
+					jacFunc, errorTol, static_cast<double*>(solution), nonlinMem, jacobianMatrix, probSize);
+
+				// Apply solution
+				linalg::applyVectorSubset(static_cast<double*>(solution), mask, c);
+
+				int a = 0;
+				// Refine / correct solution
+			}
+			else
+			{
+				LinearBufferAllocator tlmAlloc = threadLocalMem.get();
+				BufferedArray<int> qsMask = tlmAlloc.array<int>(_nComp + _totalBound);
+
+				// Check whether quasi-stationary reactions are present and construct mask array
+				bool hasNoQSreactions = true;
+				std::fill_n(static_cast<int*>(qsMask), _nComp + _totalBound, false);
+				int* localMask = static_cast<int*>(qsMask) + _nComp;
+				for (unsigned int type = 0; type < _nParType; localMask += _strideBound[type], ++type)
+				{
+					if (!_binding[type]->hasQuasiStationaryReactions())
+						continue;
+
+					// Determine whether nonlinear solver is required
+					const ColumnPosition colPos{ 0.0, 0.0, 0.0 };
+					if (!_binding[type]->preConsistentInitialState(simTime.t, simTime.secIdx, colPos, c + _nComp + _offsetParType[type], c, tlmAlloc))
+						continue;
+
+					hasNoQSreactions = false;
+
+					// Construct mask
+					int const* const qsMaskSrc = _binding[type]->reactionQuasiStationarity();
+					std::copy_n(qsMaskSrc, _strideBound[type], localMask);
+
+					// Mark component for conserved moiety if it has a quasi-stationary bound state
+					unsigned int idx = 0;
+					for (unsigned int comp = 0; comp < _nComp; ++comp)
+					{
+						// Skip components that are already marked
+						if (qsMask[comp])
+						{
+							idx += _nBound[type * _nComp + comp];
+							continue;
+						}
+
+						for (unsigned int state = 0; state < _nBound[type * _nComp + comp]; ++state, ++idx)
+						{
+							if (qsMaskSrc[idx])
+							{
+								qsMask[comp] = true;
+								break;
+							}
+						}
+					}
+				}
+
+				// Consistent init is not required as we do not have quasi-stationary reactions
+				if (hasNoQSreactions)
+					return;
+
+				const linalg::ConstMaskArray mask{ static_cast<int*>(qsMask), static_cast<int>(_nComp + _totalBound) };
+				const int probSize = linalg::numMaskActive(mask);
+
+				// Extract initial values from current state
+				BufferedArray<double> solution = tlmAlloc.array<double>(probSize);
+				linalg::selectVectorSubset(c, mask, static_cast<double*>(solution));
+
+				// Save values of conserved moieties
+				const unsigned int numActiveComp = numMaskActive(mask, _nComp);
+				BufferedArray<double> conservedQuants = tlmAlloc.array<double>(numActiveComp);
+				const double epsQ = 1.0 - porosity;
+				unsigned int idx = 0;
+				for (unsigned int comp = 0; comp < _nComp; ++comp)
+				{
+					if (!qsMask[comp])
+						continue;
+
+					conservedQuants[idx] = porosity * c[comp];
+					for (unsigned int type = 0; type < _nParType; ++type)
+					{
+						const double factor = epsQ * static_cast<double>(_parTypeVolFrac[type]);
+						for (unsigned int state = 0; state < _nBound[type * _nComp + comp]; ++state)
+						{
+							const unsigned int bndIdx = _offsetParType[type] + _boundOffset[type * _nComp + comp] + state;
+							if (!qsMask[_nComp + bndIdx])
+								continue;
+
+							conservedQuants[idx] += factor * c[_nComp + bndIdx];
+						}
+					}
+
+					++idx;
+				}
+
+				linalg::DenseMatrixView jacobianMatrix(_jacFact.data(), _jacFact.pivotData(), probSize, probSize);
+
+				BufferedArray<double> baFullX = tlmAlloc.array<double>(numDofs());
+				double* const fullX = static_cast<double*>(baFullX);
+
+				BufferedArray<double> baFullResidual = tlmAlloc.array<double>(numDofs());
+				double* const fullResidual = static_cast<double*>(baFullResidual);
+
+				BufferedArray<double> baNonlinMem = tlmAlloc.array<double>(_nonlinearSolver->workspaceSize(probSize));
+				double* const nonlinMem = static_cast<double*>(baNonlinMem);
+
+				std::function<bool(double const* const, linalg::detail::DenseMatrixBase&)> jacFunc;
+				if (adJac.adY && adJac.adRes)
+				{
+					ad::copyToAd(vecStateY, adJac.adY, _nComp);
+
+					jacFunc = [&](double const* const x, linalg::detail::DenseMatrixBase& mat)
+						{
+							active* const localAdY = adJac.adY + _nComp;
+							active* const localAdRes = adJac.adRes + _nComp;
+
+							// Copy over state vector to AD state vector (without changing directional values to keep seed vectors)
+							// and initialize residuals with zero (also resetting directional values)
+							ad::copyToAd(c, localAdY, mask.len);
+							// @todo Check if this is necessary
+							ad::resetAd(localAdRes, mask.len);
+
+							// Prepare input vector by overwriting masked items
+							linalg::applyVectorSubset(x, mask, localAdY);
+
+							// Call residual function
+							residualImpl<active, active, double, false>(simTime.t, simTime.secIdx, adJac.adY, nullptr, adJac.adRes, tlmAlloc.manageRemainingMemory());
+
+#ifdef CADET_CHECK_ANALYTIC_JACOBIAN
+							std::copy_n(c, mask.len, fullX);
+							linalg::applyVectorSubset(x, mask, fullX);
+
+							// Compute analytic Jacobian
+							residualImpl<double, double, double, true>(simTime.t, simTime.secIdx, fullX, nullptr, fullResidual, tlmAlloc.manageRemainingMemory());
+
+							// Compare
+							const double diff = ad::compareDenseJacobianWithAd(localAdRes, adJac.adDirOffset, _jac);
+							LOG(Debug) << "MaxDiff: " << diff;
+#endif
+
+							// Extract Jacobian from AD
+							ad::extractDenseJacobianFromAd(localAdRes, adJac.adDirOffset, _jac);
+
+							// Extract Jacobian from full Jacobian
+							mat.setAll(0.0);
+							linalg::copyMatrixSubset(_jac, mask, mask, mat);
+
+							// Replace upper part with conservation relations
+							mat.submatrixSetAll(0.0, 0, 0, numActiveComp, probSize);
+
+							unsigned int rIdx = 0;
+							const double epsQ = 1.0 - porosity;
+
+							for (unsigned int comp = 0; comp < _nComp; ++comp)
+							{
+								if (!mask.mask[comp])
+									continue;
+
+								mat.native(rIdx, rIdx) = porosity;
+
+								for (unsigned int type = 0; type < _nParType; ++type)
+								{
+									const double factor = epsQ * static_cast<double>(_parTypeVolFrac[type]);
+
+									const unsigned int offset = _nComp + _offsetParType[type] + _boundOffset[type * _nComp + comp];
+									unsigned int bIdx = numActiveComp + numMaskActive(mask, _nComp, _boundOffset[type * _nComp + comp]);
+									for (unsigned int state = 0; state < _nBound[type * _nComp + comp]; ++state)
+									{
+										if (!mask.mask[offset + state])
+											continue;
+
+										mat.native(rIdx, bIdx) = factor;
+										++bIdx;
+									}
+								}
+
+								++rIdx;
+							}
+
+							return true;
+						};
+				}
+				else
+				{
+					jacFunc = [&](double const* const x, linalg::detail::DenseMatrixBase& mat)
+						{
+							// Prepare input vector by overwriting masked items
+							std::copy_n(c, mask.len, fullX + _nComp);
+							linalg::applyVectorSubset(x, mask, fullX + _nComp);
+
+							// Call residual function
+							residualImpl<double, double, double, true>(simTime.t, simTime.secIdx, fullX, nullptr, fullResidual, tlmAlloc.manageRemainingMemory());
+
+							// Extract Jacobian from full Jacobian
+							mat.setAll(0.0);
+							linalg::copyMatrixSubset(_jac, mask, mask, mat);
+
+							// Replace upper part with conservation relations
+							mat.submatrixSetAll(0.0, 0, 0, numActiveComp, probSize);
+
+							unsigned int rIdx = 0;
+							const double epsQ = 1.0 - porosity;
+
+							for (unsigned int comp = 0; comp < _nComp; ++comp)
+							{
+								if (!mask.mask[comp])
+									continue;
+
+								mat.native(rIdx, rIdx) = porosity;
+
+								for (unsigned int type = 0; type < _nParType; ++type)
+								{
+									const double factor = epsQ * static_cast<double>(_parTypeVolFrac[type]);
+
+									const unsigned int offset = _nComp + _offsetParType[type] + _boundOffset[type * _nComp + comp];
+									unsigned int bIdx = numActiveComp + numMaskActive(mask, _nComp, _boundOffset[type * _nComp + comp]);
+									for (unsigned int state = 0; state < _nBound[type * _nComp + comp]; ++state)
+									{
+										if (!mask.mask[offset + state])
+											continue;
+
+										mat.native(rIdx, bIdx) = factor;
+										++bIdx;
+									}
+								}
+
+								++rIdx;
+							}
+
+							return true;
+						};
+				}
+
+				// Copy inlet values
+				std::copy_n(vecStateY, _nComp, fullX);
+
+				// Apply nonlinear solver
+				_nonlinearSolver->solve(
+					[&](double const* const x, double* const r)
+					{
+						// Prepare input vector by overwriting masked items
+						std::copy_n(c, mask.len, fullX + _nComp);
+						linalg::applyVectorSubset(x, mask, fullX + _nComp);
+
+						// Call residual function
+						residualImpl<double, double, double, false>(simTime.t, simTime.secIdx, fullX, nullptr, fullResidual, tlmAlloc.manageRemainingMemory());
+
+						// Extract values from residual
+						linalg::selectVectorSubset(fullResidual + _nComp, mask, r);
+
+						// Calculate residual of conserved moieties
+						std::fill_n(r, numActiveComp, 0.0);
+						unsigned int rIdx = 0;
+						const double epsQ = 1.0 - porosity;
+
+						for (unsigned int comp = 0; comp < _nComp; ++comp)
+						{
+							if (!mask.mask[comp])
+								continue;
+
+							r[rIdx] = porosity * x[rIdx] - conservedQuants[rIdx];
+
+							for (unsigned int type = 0; type < _nParType; ++type)
+							{
+								const double factor = epsQ * static_cast<double>(_parTypeVolFrac[type]);
+
+								const unsigned int offset = _nComp + _offsetParType[type] + _boundOffset[type * _nComp + comp];
+								unsigned int bIdx = numActiveComp + numMaskActive(mask, _nComp, _boundOffset[type * _nComp + comp]);
+								for (unsigned int state = 0; state < _nBound[type * _nComp + comp]; ++state)
+								{
+									if (!mask.mask[offset + state])
+										continue;
+
+									r[rIdx] += factor * x[bIdx];
+									++bIdx;
+								}
+							}
+
+							++rIdx;
+						}
+
+						return true;
+					},
+					jacFunc, errorTol, static_cast<double*>(solution), nonlinMem, jacobianMatrix, probSize);
+
+				// Apply solution
+				linalg::applyVectorSubset(static_cast<double*>(solution), mask, c);
+
+				// Refine / correct solution
 				for (unsigned int type = 0; type < _nParType; ++type)
 				{
-					double const* const localQ = c + _nComp + _offsetParType[type] + _boundOffset[type * _nComp + i];
-					double const* const localQdot = cDot + _nComp + _offsetParType[type] + _boundOffset[type * _nComp + i];
-					double qSumType = 0.0;
-					double qDotSumType = 0.0;
-					for (unsigned int j = 0; j < _nBound[type * _nComp + i]; ++j)
+					const ColumnPosition colPos{ 0.0, 0.0, 0.0 };
+					_binding[type]->postConsistentInitialState(simTime.t, simTime.secIdx, colPos, c + _nComp + _offsetParType[type], c, tlmAlloc);
+				}
+			}
+		}
+
+		void CSTRModel::consistentInitialTimeDerivative(const SimulationTime& simTime, double const* vecStateY, double* const vecStateYdot, util::ThreadLocalStorage& threadLocalMem)
+		{
+			double const* const c = vecStateY + _nComp;
+			double* const cDot = vecStateYdot + _nComp;
+			const double vLiquid = c[_nComp + _totalBound];
+			const double vSolid = static_cast<double>(_constSolidVolume);
+
+			const double flowIn = static_cast<double>(_flowRateIn);
+			const double flowOut = static_cast<double>(_flowRateOut);
+
+			// Note that the residual has not been negated, yet. We will do that now. (t0 is cDot = res(t0))
+			for (unsigned int i = 0; i < numDofs(); ++i)
+				vecStateYdot[i] = -vecStateYdot[i];
+
+			// Assemble time derivative Jacobian
+			_jacFact.setAll(0.0);
+			addTimeDerivativeJacobian(simTime.t, 1.0, ConstSimulationState{ vecStateY, nullptr }, _jacFact);
+
+			// Check if volume is 0
+			if (vLiquid == 0.0)
+			{
+				// Volume: \dot{V} = F_{in} - F_{out} - F_{filter}
+				const double vDot = flowIn - flowOut - static_cast<double>(_curFlowRateFilter);
+				_jacFact.native(_nComp + _totalBound, _nComp + _totalBound) = 1.0;
+				cDot[_nComp + _totalBound] = vDot;
+
+				// We have the equation
+				//    V^l * \dot{c}_i + \dot{V}^l * c_i + V^s * [sum_j sum_m d_j q_{i,m}]} = c_{in,i} * F_in - c_i * F_out
+				// which is now algebraic wrt. c due to V = 0:
+				//    \dot{V}^l * c_i + V^s * [sum_j sum_m d_j q_{i,m}]) = c_{in,i} * F_in - c_i * F_out
+				// So we take the derivative wrt. to time t on both sides
+				//    \ddot{V}^l * c_i + \dot{V}^l * \dot{c}_i + V^s * [sum_j sum_m d_j \dot{q}_{i,m}]) = \dot{c}_{in,i} * F_in - \dot{c}_i * F_out
+				// and use the fact that \ddot{V}^l = 0 to arrive at
+				//    \dot{V}^l * \dot{c}_i + V^s * [sum_j sum_m d_j \dot{q}_{i,m}]) = \dot{c}_{in,i} * F_in - \dot{c}_i * F_out
+				// Separating knowns from unknowns gives
+				// \dot{c}_i = [ \dot{c}_{in,i} * F_in - + V^s * [sum_j sum_m d_j \dot{q}_{i,m}]) ] / (F_out + \dot{V}^l)
+
+				// Note that if the denominator was 0, we had
+				//    0 = \dot{V} + F_out = F_in - F_filter - F_out + F_out
+				// which leads to
+				//    F_in = F_filter
+				// Since F_out >= 0 and \dot{V} = -F_out, we get
+				//    \dot{V} <= 0
+				// Assuming a valid configuration, we obtain \dot{V} = 0
+				// as the tank would get a negative volume otherwise.
+				// Concluding, we arrive at \dot{V} = F_out = 0.
+				// In this situation, F_in = F_filter = 0 has to hold
+				// as otherwise the liquid (solvent) is immediately and
+				// fully taken out, leaving only the pure dry components.
+				// We, hence, assume that this doesn't happen and simply
+				// do nothing leaving the initial conditions in place.
+
+				typename linalg::DenseMatrix::RowIterator itRow = _jacFact.row(0);
+
+				const double denom = vDot + flowOut;
+				if (denom == 0.0)
+					return;
+				else
+				{
+					for (unsigned int i = 0; i < _nComp; ++i, ++itRow)
 					{
-						qSumType += localQ[j];
-						qDotSumType += localQdot[j];
+						itRow.setAll(0.0);
+
+						// Jacobian of c_i + vSolid * [sum_j sum_m d_j q_{i,m}]
+
+						// d/dc_i
+						itRow[0] = 1.0;
+
+						// Advance to bound states
+						const int bndIdx = _nComp - i;
+						for (unsigned int type = 0; type < _nParType; ++type)
+						{
+							const int innerIdx = bndIdx + _offsetParType[type] + _boundOffset[type * _nComp + i];
+							const double innerFactor = static_cast<double>(_parTypeVolFrac[type]) * vSolid;
+							for (unsigned int j = 0; j < _nBound[type * _nComp + i]; ++j)
+							{
+								itRow[innerIdx + j] = innerFactor;
+							}
+						}
+
+						// \dot{c}_i = [ \dot{c}_{in,i} * F_in - + V^s * [sum_j sum_m d_j \dot{q}_{i,m}]) ] / (F_out + \dot{V}^l)
+						// TODO: This is wrong as vecStateYdot does not contain \dot{c}_in (on entry)
+						// This scenario violates the assumption that every outlet DOF is dynamic
+						// which is key to the consistent initialization algorithm. Fixing this problem
+						// requires fundamental changes to the consistent initialization concept
+						// implemented so far.
+						cDot[i] = 0.0;
 					}
-					qSum += static_cast<double>(_parTypeVolFrac[type]) * qSumType;
-					qDotSum += static_cast<double>(_parTypeVolFrac[type]) * qDotSumType;
+				}
+			}
+
+			if (_hasQuasiStationaryReactionBulk)
+			{
+
+				//LinearBufferAllocator tlmAlloc = threadLocalMem.get(); // -> todo hier aufpassen ob ich den mem auch benutzen darf
+				LinearBufferAllocator tlmAlloc = threadLocalMem.get();
+
+				// Overwrite rows corresponding to algebraic equations with the Jacobian and set right hand side to 0
+				BufferedArray<double> dReacDt = tlmAlloc.array<double>(_nComp + 1);
+
+				// Obtain derivative of fluxes wrt. time
+				std::fill_n(static_cast<double*>(dReacDt), _nComp + 1, 0.0);
+
+				_dynReactionBulk->timeDerivativeQuasiStationaryReaction(simTime.t, _curSecIdx, ColumnPosition{ 0.0, 0.0, 0.0 }, c, static_cast<double*>(dReacDt), tlmAlloc);
+
+				// Copy row assioated to algebraic equation from original Jacobian and set right hand side
+				double* const cDot = vecStateYdot + _nComp;
+				int test = _nComp - _dynReactionBulk->numReactionQuasiStationary();
+				for (int i = test; i < _nComp; ++i)
+				{
+					_jacFact.copyRowFrom(_jac, i, i);
+					cDot[i] = -dReacDt[i];
 				}
 
-				cDot[i] = (-resC[i] - vSolid * qDotSum - vLiquid * c[i]) / vLiquid;
+
+				// Factorize
+				const bool result = _jacFact.robustFactorize(static_cast<double*>(dReacDt));
+				if (!result)
+				{
+					LOG(Error) << "Factorize() failed";
+				}
+
+				// Solve
+				const bool result2 = _jacFact.robustSolve(vecStateYdot + _nComp, static_cast<double*>(dReacDt));
+				if (!result2)
+				{
+					LOG(Error) << "Solve() failed";
+				}
 			}
-	}
-	
-}
+			else {
+				// Overwrite rows corresponding to algebraic equations with the Jacobian and set right hand side to 0
+				LinearBufferAllocator tlmAlloc = threadLocalMem.get();
+				BufferedArray<double> dFluxDt = tlmAlloc.array<double>(_nComp + _totalBound + 1);
+				unsigned int idx = _nComp;
+				for (unsigned int type = 0; type < _nParType; ++type)
+				{
+					if (!_binding[type]->hasQuasiStationaryReactions())
+					{
+						idx += _strideBound[type];
+						continue;
+					}
 
-void CSTRModel::leanConsistentInitialSensitivity(const SimulationTime& simTime, const ConstSimulationState& simState,
-	std::vector<double*>& vecSensY, std::vector<double*>& vecSensYdot, active const* const adRes, util::ThreadLocalStorage& threadLocalMem)
-{
-	consistentInitialSensitivity(simTime, simState, vecSensY, vecSensYdot, adRes, threadLocalMem);
-}
+					int const* const mask = _binding[type]->reactionQuasiStationarity();
 
-int CSTRModel::jacobian(const SimulationTime& simTime, const ConstSimulationState& simState, double* const res, const AdJacobianParams& adJac, util::ThreadLocalStorage& threadLocalMem)
-{
-	return residual(simTime, simState, res, adJac, threadLocalMem, true, false);
-}
+					// Obtain derivative of fluxes wrt. time
+					std::fill_n(static_cast<double*>(dFluxDt), _strideBound[type], 0.0);
+					if (_binding[type]->dependsOnTime())
+					{
+						_binding[type]->timeDerivativeQuasiStationaryFluxes(simTime.t, simTime.secIdx,
+							ColumnPosition{ 0.0, 0.0, 0.0 },
+							c, c + _nComp + _offsetParType[type], static_cast<double*>(dFluxDt), tlmAlloc);
+					}
 
-int CSTRModel::residual(const SimulationTime& simTime, const ConstSimulationState& simState, double* const res, util::ThreadLocalStorage& threadLocalMem)
-{
-	return residualImpl<double, double, double, false>(simTime.t, simTime.secIdx, simState.vecStateY, simState.vecStateYdot, res, threadLocalMem.get());
-}
-template <typename StateType, typename ResidualType, typename ParamType, bool wantJac>
-void CSTRModel::applyConservedMoitiesBulk(double t, unsigned int secIdx, const ColumnPosition& colPos, StateType const* const c, double const* const yDot, ResidualType* const resC,  LinearBufferAllocator tlmAlloc)
-{
-	const ParamType flowIn = static_cast<ParamType>(_flowRateIn);
-	const ParamType flowOut = static_cast<ParamType>(_flowRateOut);
-	double const* const cDot = yDot ? yDot + _nComp : nullptr;
-	const double vDot = yDot ? yDot[2 * _nComp + _totalBound] : 0.0;
-	
-	LinearBufferAllocator subAlloc = tlmAlloc.manageRemainingMemory();
+					// Copy row from original Jacobian and set right hand side
+					double* const qShellDot = cDot + _nComp + _offsetParType[type];
+					for (unsigned int i = 0; i < _strideBound[type]; ++i, ++idx)
+					{
+						if (!mask[i])
+							continue;
 
-	BufferedArray<ResidualType> temp = subAlloc.array<ResidualType>(_nComp);
-	Eigen::Map<Eigen::Vector<ResidualType, Eigen::Dynamic>> resCWithMoities(static_cast<ResidualType*>(temp), _nComp);
-	resCWithMoities.setZero();
+						_jacFact.copyRowFrom(_jac, idx, idx);
+						qShellDot[i] = -dFluxDt[i];
+					}
+				}
 
-	BufferedArray<ResidualType> temp2 = subAlloc.array<ResidualType>(_nComp);
-	Eigen::Map<Eigen::Vector<ResidualType, Eigen::Dynamic>> qsFlux(static_cast<ResidualType*>(temp2), _dynReactionBulk->numReactionsLiquid());
-	qsFlux.setZero();
-	
-	_dynReactionBulk->computeQuasiStationaryReactionFlux(t, secIdx, colPos, c, qsFlux, _qsReactionBulk, subAlloc);
-	Eigen::Map<Eigen::Vector<ResidualType, Eigen::Dynamic>> mapResC(resC, _nComp);
+				// Factorize
+				const bool result = _jacFact.robustFactorize(static_cast<double*>(dFluxDt));
+				if (!result)
+				{
+					LOG(Error) << "Factorize() failed";
+				}
 
-	int  MoityIdx = 0;
-	int qsreac = 0;
-	int comp = 0;
-	
-	for (unsigned int state = 0; state < _nComp; state++)
-	{
-		if (_stateMap[state].test(0)) // dynamic
+				// Solve
+				const bool result2 = _jacFact.robustSolve(vecStateYdot + _nComp, static_cast<double*>(dFluxDt));
+				if (!result2)
+				{
+					LOG(Error) << "Solve() failed";
+				}
+			}
+		}
+
+		void CSTRModel::leanConsistentInitialState(const SimulationTime& simTime, double* const vecStateY, const AdJacobianParams& adJac, double errorTol, util::ThreadLocalStorage& threadLocalMem)
 		{
-			resCWithMoities[state] = resC[state];
+			// It is assumed that the bound states are (approximately) correctly initialized.
+			// Thus, only the liquid phase has to be initialized
+
+			double* const c = vecStateY + _nComp;
+			const double vLiquid = c[_nComp];
+			const double vSolid = static_cast<double>(_constSolidVolume);
+
+			if (!_hasQuasiStationaryReactionBulk)
+				return;
+			// Check if volume is 0
+			if (vLiquid == 0.0)
+			{
+				const double flowIn = static_cast<double>(_flowRateIn);
+				const double flowOut = static_cast<double>(_flowRateOut);
+
+				// Volume: \dot{V} = F_{in} - F_{out} - F_{filter}
+				const double vDot = flowIn - flowOut - static_cast<double>(_curFlowRateFilter);
+
+				// We have the equation
+				//    \dot{V}^l * c + \dot{c} * V^l + V^s * [sum_j q_j] = c_in * F_in - c * F_out
+				// which is now algebraic wrt. c due to V = 0:
+				//    (\dot{V}^l + F_out) * c = - V^s * [sum_j q_j] + c_in * F_in
+				// Separating knowns from unknowns gives
+				//    (\dot{V} + F_out) * c = c_in * F_in - V^s * [sum_j q_j]
+				// Hence, we obtain
+				//    c = (c_in * F_in - \dot{V} / V^s * [sum_j q_j]) / (\dot{V} + F_out)
+
+				// Note that if the denominator was 0, we had
+				//    0 = \dot{V} + F_out = F_in - F_filter
+				// which leads to
+				//    F_in = F_filter
+				// Since F_out >= 0 and \dot{V} = -F_out, we get
+				//    \dot{V} <= 0
+				// Assuming a valid configuration, we obtain \dot{V} = 0
+				// as the tank would get a negative volume otherwise.
+				// Concluding, we arrive at \dot{V} = F_out = 0.
+				// In this situation, F_in = F_filter = 0 has to hold
+				// as otherwise the liquid (solvent) is immediately and
+				// fully taken out, leaving only the pure dry components.
+				// We, hence, assume that this doesn't happen and simply
+				// do nothing leaving the initial conditions in place.
+
+				const double denom = vDot + flowOut;
+				if (denom == 0.0)
+					return;
+
+				for (unsigned int i = 0; i < _nComp; ++i)
+					c[i] = vecStateY[i] * flowIn / denom;;
+
+				const double qFactor = vSolid / denom;
+				for (unsigned int type = 0; type < _nParType; ++type)
+				{
+					unsigned int const* const bo = _boundOffset + type * _nComp;
+					unsigned int const* const nb = _nBound + type * _nComp;
+					double const* const typeQ = c + _nComp + _offsetParType[type];
+					for (unsigned int i = 0; i < _nComp; ++i)
+					{
+						double qSum = 0.0;
+						double const* const localQ = typeQ + bo[i];
+						for (unsigned int j = 0; j < nb[i]; ++j)
+							qSum += localQ[j];
+
+						c[i] -= qFactor * static_cast<double>(_parTypeVolFrac[type]) * qSum;
+					}
+				}
+			}
+		}
+
+		void CSTRModel::leanConsistentInitialTimeDerivative(double t, double const* const vecStateY, double* const vecStateYdot, double* const res, util::ThreadLocalStorage& threadLocalMem)
+		{
+			// It is assumed that the bound states are (approximately) correctly initialized.
+			// Thus, only the liquid phase has to be initialized
+
+			double const* const c = vecStateY + _nComp;
+			double* const cDot = vecStateYdot + _nComp;
+			double* const resC = res + _nComp;
+			const double vLiquid = c[_nComp];
+			const double vSolid = static_cast<double>(_constSolidVolume);
+			const double flowIn = static_cast<double>(_flowRateIn);
+			const double flowOut = static_cast<double>(_flowRateOut);
+
+			LinearBufferAllocator tlmAlloc = threadLocalMem.get();
+
+			// Volume: \dot{V} = F_{in} - F_{out} - F_{filter}
+			const double vDot = flowIn - flowOut - static_cast<double>(_curFlowRateFilter);
+			cDot[_nComp] = vDot;
+
+
+			// Check if volume is 0
+			if (vLiquid == 0.0 && !_hasQuasiStationaryReactionBulk)
+			{
+				// We have the equation
+				//    V^l * \dot{c}_i + \dot{V}^l * c_i + V^s * [sum_j sum_m d_j q_{i,m}]} = c_{in,i} * F_in - c_i * F_out
+				// which is now algebraic wrt. c due to V = 0:
+				//    \dot{V}^l * c_i + V^s * [sum_j sum_m d_j q_{i,m}]) = c_{in,i} * F_in - c_i * F_out
+				// So we take the derivative wrt. to time t on both sides
+				//    \ddot{V}^l * c_i + \dot{V}^l * \dot{c}_i + V^s * [sum_j sum_m d_j \dot{q}_{i,m}]) = \dot{c}_{in,i} * F_in - \dot{c}_i * F_out
+				// and use the fact that \ddot{V}^l = 0 to arrive at
+				//    \dot{V}^l * \dot{c}_i + V^s * [sum_j sum_m d_j \dot{q}_{i,m}]) = \dot{c}_{in,i} * F_in - \dot{c}_i * F_out
+				// Separating knowns from unknowns gives
+				// \dot{c}_i = [ \dot{c}_{in,i} * F_in - + V^s * [sum_j sum_m d_j \dot{q}_{i,m}]) ] / (F_out + \dot{V}^l)
+
+				// Note that if the denominator was 0, we had
+				//    0 = \dot{V} + F_out = F_in - F_filter - F_out + F_out
+				// which leads to
+				//    F_in = F_filter
+				// Since F_out >= 0 and \dot{V} = -F_out, we get
+				//    \dot{V} <= 0
+				// Assuming a valid configuration, we obtain \dot{V} = 0
+				// as the tank would get a negative volume otherwise.
+				// Concluding, we arrive at \dot{V} = F_out = 0.
+				// In this situation, F_in = F_filter = 0 has to hold
+				// as otherwise the liquid (solvent) is immediately and
+				// fully taken out, leaving only the pure dry components.
+				// We, hence, assume that this doesn't happen and simply
+				// do nothing leaving the initial conditions in place.
+
+				typename linalg::DenseMatrix::RowIterator itRow = _jacFact.row(0);
+
+				const double denom = vDot + flowOut;
+				if (denom == 0.0)
+					return;
+				else
+				{
+					const double qFactor = 2.0 * vSolid / denom;
+					const double factor = flowIn / denom;
+
+					for (unsigned int i = 0; i < _nComp; ++i)
+					{
+						// TODO: This is wrong as vecStateYdot does not contain \dot{c}_in (on entry)
+						// This scenario violates the assumption that every outlet DOF is dynamic
+						// which is key to the consistent initialization algorithm. Fixing this problem
+						// requires fundamental changes to the consistent initialization concept
+						// implemented so far.
+						vecStateYdot[i] = 0.0;
+
+						cDot[i] = vecStateYdot[i] * factor;
+
+						for (unsigned int type = 0; type < _nParType; ++type)
+						{
+							unsigned int const* const bo = _boundOffset + type * _nComp;
+							unsigned int const* const nb = _nBound + type * _nComp;
+							double const* const localQdot = cDot + _nComp + _offsetParType[type] + bo[i];
+
+							double qDotSum = 0.0;
+							for (unsigned int j = 0; j < nb[i]; ++j)
+								qDotSum += localQdot[j];
+
+							cDot[i] -= qFactor * static_cast<double>(_parTypeVolFrac[type]) * qDotSum;
+						}
+					}
+				}
+			}
+
+			else
+			{
+				// Concentrations: V^l * \dot{c} + \dot{V}^l * c + V^s * [sum_j sum_m d_j \dot{q}_{j,m}] = c_in * F_in + c * F_out
+				//             <=> V^l * \dot{c} = c_in * F_in + c * F_out - V^s * [sum_j sum_m d_j \dot{q}_{j,m}] - \dot{V}^l * c 
+				//                               = -res - V^s * [sum_j sum_m d_j \dot{q}_{j,m}] - \dot{V}^l * c
+				// => \dot{c} = (-res - V^s * [sum_j sum_m d_j \dot{q}_{j,m}] - \dot{V}^l * c) / V^l
+				for (unsigned int i = 0; i < _nComp; ++i)
+				{
+					double qSum = 0.0;
+					double qDotSum = 0.0;
+					for (unsigned int type = 0; type < _nParType; ++type)
+					{
+						double const* const localQ = c + _nComp + _offsetParType[type] + _boundOffset[type * _nComp + i];
+						double const* const localQdot = cDot + _nComp + _offsetParType[type] + _boundOffset[type * _nComp + i];
+						double qSumType = 0.0;
+						double qDotSumType = 0.0;
+						for (unsigned int j = 0; j < _nBound[type * _nComp + i]; ++j)
+						{
+							qSumType += localQ[j];
+							qDotSumType += localQdot[j];
+						}
+						qSum += static_cast<double>(_parTypeVolFrac[type]) * qSumType;
+						qDotSum += static_cast<double>(_parTypeVolFrac[type]) * qDotSumType;
+					}
+
+					cDot[i] = (-resC[i] - vSolid * qDotSum - vLiquid * c[i]) / vLiquid;
+				}
+			}
+
+		}
+
+		void CSTRModel::leanConsistentInitialSensitivity(const SimulationTime& simTime, const ConstSimulationState& simState,
+			std::vector<double*>& vecSensY, std::vector<double*>& vecSensYdot, active const* const adRes, util::ThreadLocalStorage& threadLocalMem)
+		{
+			consistentInitialSensitivity(simTime, simState, vecSensY, vecSensYdot, adRes, threadLocalMem);
+		}
+
+		int CSTRModel::jacobian(const SimulationTime& simTime, const ConstSimulationState& simState, double* const res, const AdJacobianParams& adJac, util::ThreadLocalStorage& threadLocalMem)
+		{
+			return residual(simTime, simState, res, adJac, threadLocalMem, true, false);
+		}
+
+		int CSTRModel::residual(const SimulationTime& simTime, const ConstSimulationState& simState, double* const res, util::ThreadLocalStorage& threadLocalMem)
+		{
+			return residualImpl<double, double, double, false>(simTime.t, simTime.secIdx, simState.vecStateY, simState.vecStateYdot, res, threadLocalMem.get());
+		}
+
+		template <typename ResidualType>
+		void CSTRModel::EigenMatrixTimesDenseMatrix(Eigen::Matrix<ResidualType, Eigen::Dynamic, Eigen::Dynamic> A, linalg::DenseMatrix& B)
+		{
+
+
+			Eigen::SparseMatrix<double> jacSparse(_nComp + 1, _nComp + 1);
+
+			// Reserve space for non-zeros (optional but recommended for performance)
+			jacSparse.reserve(Eigen::VectorXi::Constant(_nComp + 1, _nComp + 1)); // Assumes average of 5 entries per column
+
+			// Copy data from original Jacobian - use triplet list for initialization
+			std::vector<Eigen::Triplet<double>> tripletList;
+			for (int i = 0; i < _nComp + 1; ++i) {
+				for (int j = 0; j < _nComp + 1; ++j) {
+					double val = B.native(i, j);
+					if (std::abs(val) > 1e-15) { // Only insert non-zero elements
+						tripletList.push_back(Eigen::Triplet<double>(i, j, val));
+					}
+				}
+			}
+			jacSparse.setFromTriplets(tripletList.begin(), tripletList.end());
+			jacSparse.makeCompressed();
+
+			// apply conserved moities to jacobian
+			Eigen::SparseMatrix<double> sparseMoieties(_nComp + 1, _nComp + 1);
+			// Create sparseMoieties also using triplets
+			std::vector<Eigen::Triplet<double>> moietyTriplets;
+			for (int i = 0; i < A.rows(); ++i) {
+				for (int j = 0; j < A.cols(); ++j) {
+					if (std::abs(static_cast<double>(A(i, j))) > 1e-15) {
+						moietyTriplets.push_back(Eigen::Triplet<double>(i, j, static_cast<double>(A(i, j))));
+					}
+				}
+			}
+			sparseMoieties.setFromTriplets(moietyTriplets.begin(), moietyTriplets.end());
+			sparseMoieties.makeCompressed();
+
+			// Multiply matrices
+			Eigen::SparseMatrix<double> jacSparseMoities = sparseMoieties * jacSparse;
+
+			// Copy transformed Jacobian back
+			for (int k = 0; k < jacSparseMoities.outerSize(); ++k) {
+				for (typename Eigen::SparseMatrix<double>::InnerIterator it(jacSparseMoities, k); it; ++it) {
+					B.native(it.row(), it.col()) = it.value();
+				}
+			}
+
+
+		}
+
+		template <typename StateType, typename ResidualType, typename ParamType, bool wantJac>
+		void CSTRModel::applyConservedMoitiesBulk(double t, unsigned int secIdx, const ColumnPosition& colPos, StateType const* const c, double const* const yDot, ResidualType* const resC, LinearBufferAllocator tlmAlloc)
+		{
+			// prepare memory
+			LinearBufferAllocator subAlloc = tlmAlloc.manageRemainingMemory();
+
+			// create map to residual vector of concentrations
+			Eigen::Map<Eigen::Vector<ResidualType, Eigen::Dynamic>> mapResC(resC, _nComp);
+
+			// calculate flux for quasi stationary reactions
+			BufferedArray<ResidualType> temp2 = subAlloc.array<ResidualType>(_nComp);
+			Eigen::Map<Eigen::Vector<ResidualType, Eigen::Dynamic>> qsFlux(static_cast<ResidualType*>(temp2), _dynReactionBulk->numReactionsLiquid());
+			qsFlux.setZero();
+			_dynReactionBulk->computeQuasiStationaryReactionFlux(t, secIdx, colPos, c, qsFlux, subAlloc);
+
+			// buffer memory for transformed residual
+			BufferedArray<ResidualType> temp = subAlloc.array<ResidualType>(_nComp);
+			Eigen::Map<Eigen::Vector<ResidualType, Eigen::Dynamic>> resCWithMoities(static_cast<ResidualType*>(temp), _nComp);
+			resCWithMoities.setZero();
+
+			Eigen::Matrix<ResidualType, Eigen::Dynamic, Eigen::Dynamic> MconvMoityBulkCast = _MconvMoityBulk.template cast<ResidualType>();
+
+			// multiply conserved moities matrix with residual
+			resCWithMoities = MconvMoityBulkCast * mapResC;
+
+			// add quasi stationary reaction to residium
+			const int nQsReac = _dynReactionBulk->numReactionQuasiStationary();
+			int mIdx = 0;
+			int rIdx = 0;
+			for (int i = 0; i < _nComp; i++)
+			{
+				if (_QsCompBulk[i] == 0)
+					continue;
+				else if (mIdx < _nConservedQuants)
+					mIdx++;
+				else if (rIdx < nQsReac)
+				{
+					resCWithMoities[i] = qsFlux[rIdx];
+					rIdx++;
+				}
+
+			}
+
+			mapResC = resCWithMoities;
+
 			if (wantJac)
 			{
-				_jac.native(state, state) += (static_cast<double>(vDot) + static_cast<double>(flowOut)); // dF_{ci}/dcj = v_liquidDot + F_out
-				_dynReactionBulk->analyticJacobianLiquidSingleFluxAdd(t, secIdx, colPos, reinterpret_cast<double const*>(c), state, 0, _jac.row(state), subAlloc);
+				EigenMatrixTimesDenseMatrix(MconvMoityBulkCast, _jac);
+				int mIdx = 0;
+				int rIdx = 0;
+				for (int i = 0; i < _nComp; i++)
+				{
+					if (_QsCompBulk[i] == 0)
+						continue;
+					else if (mIdx < _nConservedQuants)
+						mIdx++;
+					else if (rIdx < nQsReac)
+					{
+						_dynReactionBulk->analyticJacobianQuasiStationaryReaction(t, secIdx, colPos, reinterpret_cast<double const*>(c), i, rIdx, _jac.row(i), subAlloc);
+						_jac.native(i, _nComp + _totalBound) = 0.0; // dF_{ci}/dvliquid = 0
+					}
+
+				}
 			}
-			comp++;
+
 		}
-		else if (_stateMap[state].test(1)) // conserved
+
+
+		template <typename StateType, typename ResidualType, typename ParamType, bool wantJac>
+		int CSTRModel::residualImpl(double t, unsigned int secIdx, StateType const* const y, double const* const yDot, ResidualType* const res, LinearBufferAllocator tlmAlloc)
 		{
-			// todo test of matrix times vector isfaster
-			ResidualType dotProduct = 0.0;
-			for (unsigned int i = 0; i < _MconvMoityBulk.cols(); ++i)
+			StateType const* const cIn = y;
+			StateType const* const c = y + _nComp;
+			const StateType& v = y[2 * _nComp + _totalBound];
+
+			double const* const cDot = yDot ? yDot + _nComp : nullptr;
+			const double vDot = yDot ? yDot[2 * _nComp + _totalBound] : 0.0;
+			const ParamType flowIn = static_cast<ParamType>(_flowRateIn);
+			const ParamType flowOut = static_cast<ParamType>(_flowRateOut);
+
+			// Inlet DOF
+			for (unsigned int i = 0; i < _nComp; ++i)
 			{
-				dotProduct += _MconvMoityBulk(MoityIdx, i) * (mapResC[i]);
+				res[i] = cIn[i];
+			}
+
+			// Concentrations: \dot{V^l} * c + V^l * \dot{c} + V^s * sum_j sum_m \dot{q}_{j,m}] = c_in * F_in - c * F_out
+			const ParamType vsolid = static_cast<ParamType>(_constSolidVolume);
+			ResidualType* resC = res + _nComp;
+			for (unsigned int i = 0; i < _nComp; ++i)
+			{
+				resC[i] = 0.0;
+
+				// Add time derivatives
+				if (cadet_likely(yDot))
+				{
+					// Ultimately, we need V^l dc_{i} / dt + dV^l / dt + V^s * [ sum_j sum_m d_j dq_{j,i,m} / dt ]
+					// Compute the sum in the brackets first, then divide by beta and add remaining term
+
+					// sum dq_{i,1} / dt + dq_{i,2} / dt + ... + dq_{i,N_i} / dt
+					typename ActivePromoter<ParamType>::type qDotSum = 0.0;
+
+					for (unsigned int type = 0; type < _nParType; ++type)
+					{
+						double const* const qDot = cDot + _nComp + _offsetParType[type] + _boundOffset[type * _nComp + i];
+
+						double qDotSumType = 0.0;
+						for (unsigned int j = 0; j < _nBound[type * _nComp + i]; ++j)
+						{
+							qDotSumType += qDot[j];
+						}
+						qDotSum += static_cast<ParamType>(_parTypeVolFrac[type]) * qDotSumType;
+					}
+
+					// Divide by beta and add c_i and dc_i / dt
+					resC[i] = cDot[i] * v + vDot * c[i] + vsolid * qDotSum;
+				}
+				resC[i] += -flowIn * cIn[i] + flowOut * c[i];
+			}
+
+			if (wantJac)
+			{
+				_jac.setAll(0.0);
+
+				// Assemble Jacobian: Liquid phase
+
+				// Concentrations: V^l * \dot{c}_i + \dot{V^l} * c_i + V^s * ([sum_j sum_m d_j \dot{q}_{j,i,m}]) - c_{in,i} * F_in + c_i * F_out == 0
+				const double vDotTimeFactor = static_cast<double>(vDot);
+				for (unsigned int i = 0; i < _nComp; ++i)
+				{
+					_jac.native(i, i) = vDotTimeFactor + static_cast<double>(flowOut); // dF/dci = v_liquidDot + F_out
+
+					if (cadet_likely(yDot))
+					{
+						_jac.native(i, _nComp + _totalBound) = cDot[i]; // dF/dvliquid = cDot 
+					}
+				}
+			}
+
+			// Reactions in liquid phase
+			const ColumnPosition colPos{ 0.0, 0.0, 0.0 };
+			if (_dynReactionBulk && (_dynReactionBulk->numReactionsLiquid() > 0))
+			{
+				LinearBufferAllocator subAlloc = tlmAlloc.manageRemainingMemory();
+
+				BufferedArray<ResidualType> flux = subAlloc.array<ResidualType>(_nComp);
+				std::fill_n(static_cast<ResidualType*>(flux), _nComp, 0.0);
+				_dynReactionBulk->residualLiquidAdd(t, secIdx, colPos, c, static_cast<ResidualType*>(flux), -1.0, subAlloc);
+
+				for (unsigned int comp = 0; comp < _nComp; ++comp)
+					resC[comp] += v * flux[comp];
+
 				if (wantJac)
 				{
-					_jac.native(state, i) += (static_cast<double>(vDot) + static_cast<double>(flowOut)) * _MconvMoityBulk(MoityIdx, i); // dF_{ci}/dcj = v_liquidDot + F_out  
-					if (cadet_likely(yDot))
-						_jac.native(i, _nComp + _totalBound) += _MconvMoityBulk(MoityIdx, i) * cDot[i] ; // dF/dvliquid = cDot 
+					for (unsigned int comp = 0; comp < _nComp; ++comp)
+						_jac.native(comp, _nComp + _totalBound) += static_cast<double>(flux[comp]); // dF/dvliquid = flux
+
+					_dynReactionBulk->analyticJacobianLiquidAdd(t, secIdx, colPos, reinterpret_cast<double const*>(c), -static_cast<double>(v), _jac.row(0), subAlloc);
+				}
+
+				if (_hasQuasiStationaryReactionBulk)
+				{
+					applyConservedMoitiesBulk<StateType, ResidualType, ParamType, wantJac>(t, secIdx, colPos, c, yDot, resC, subAlloc);
+
 				}
 			}
-			if (wantJac)
-				_dynReactionBulk->analyticJacobianLiquidSingleFluxAdd(t, secIdx, colPos, reinterpret_cast<double const*>(c), state, 0, _jac.row(state), subAlloc);
-			resCWithMoities[state] = dotProduct;
-			MoityIdx++;
-			comp++;
-		}
-		else if (_stateMap[state].test(2)) // algebraic
-		{
-			resCWithMoities[state] = qsFlux[qsreac];
-
-			if (wantJac)
-			{
-				_dynReactionBulk->analyticJacobianQuasiStationaryReaction(t, secIdx, colPos, reinterpret_cast<double const*>(c), state, qsreac, _jac.row(state), subAlloc);
-				_jac.native(state, _nComp + _totalBound) = 0.0; // dF_{ci}/dvliquid = 0
-			}
-			qsreac++;
-		}
-	}
-	mapResC = resCWithMoities;
-
-	std::cout << "Jacobian with conserved moities" << std::endl;
-	std::cout << "Jacobian after" << std::endl;
-	for (int i = 0; i < _nComp + 1; i++)
-	{
-		for (int j = 0; j < _nComp + 1; j++)
-		{
-			std::cout << _jac.native(i, j) << " ";
-		}
-		std::cout << std::endl;
-	}
-}
-template <typename ResidualType>
-void CSTRModel::EigenMatrixTimesDemseMatrix(Eigen::Matrix<ResidualType, Eigen::Dynamic, Eigen::Dynamic> A, linalg::DenseMatrix& B)
-{
-
-
-	Eigen::SparseMatrix<double> jacSparse(_nComp + 1, _nComp + 1);
-
-	// Reserve space for non-zeros (optional but recommended for performance)
-	jacSparse.reserve(Eigen::VectorXi::Constant(_nComp+1, _nComp+1)); // Assumes average of 5 entries per column
-
-	// Copy data from original Jacobian - use triplet list for initialization
-	std::vector<Eigen::Triplet<double>> tripletList;
-	for (int i = 0; i < _nComp + 1; ++i) {
-		for (int j = 0; j < _nComp + 1; ++j) {
-			double val = B.native(i, j);
-			if (std::abs(val) > 1e-15) { // Only insert non-zero elements
-				tripletList.push_back(Eigen::Triplet<double>(i, j, val));
-			}
-		}
-	}
-	jacSparse.setFromTriplets(tripletList.begin(), tripletList.end());
-	jacSparse.makeCompressed();
-
-	// apply conserved moities to jacobian
-	Eigen::SparseMatrix<double> sparseMoieties(_nComp + 1, _nComp + 1);
-	// Create sparseMoieties also using triplets
-	std::vector<Eigen::Triplet<double>> moietyTriplets;
-	for (int i = 0; i < A.rows(); ++i) {
-		for (int j = 0; j < A.cols(); ++j) {
-			if (std::abs(static_cast<double>(A(i, j))) > 1e-15) {
-				moietyTriplets.push_back(Eigen::Triplet<double>(i, j, static_cast<double>(A(i, j))));
-			}
-		}
-	}
-	sparseMoieties.setFromTriplets(moietyTriplets.begin(), moietyTriplets.end());
-	sparseMoieties.makeCompressed();
-
-	// Multiply matrices
-	Eigen::SparseMatrix<double> jacSparseMoities = sparseMoieties * jacSparse;
-
-	// Copy transformed Jacobian back
-	for (int k = 0; k < jacSparseMoities.outerSize(); ++k) {
-		for (typename Eigen::SparseMatrix<double>::InnerIterator it(jacSparseMoities, k); it; ++it) {
-			B.native(it.row(), it.col()) = it.value();
-		}
-	}
-
-
-}
-
-template <typename StateType, typename ResidualType, typename ParamType, bool wantJac>
-void CSTRModel::applyConservedMoitiesBulk2(double t, unsigned int secIdx, const ColumnPosition& colPos, StateType const* const c, double const* const yDot, ResidualType* const resC, LinearBufferAllocator tlmAlloc)
-{
-	// prepare memory
-	LinearBufferAllocator subAlloc = tlmAlloc.manageRemainingMemory();
-
-	// create map to residual vector of concentrations
-	Eigen::Map<Eigen::Vector<ResidualType, Eigen::Dynamic>> mapResC(resC, _nComp);
-
-	// calculate flux for quasi stationary reactions
-	BufferedArray<ResidualType> temp2 = subAlloc.array<ResidualType>(_nComp);
-	Eigen::Map<Eigen::Vector<ResidualType, Eigen::Dynamic>> qsFlux(static_cast<ResidualType*>(temp2), _dynReactionBulk->numReactionsLiquid());
-	qsFlux.setZero();
-
-	_dynReactionBulk->computeQuasiStationaryReactionFlux(t, secIdx, colPos, c, qsFlux, _qsReactionBulk, subAlloc);
-
-	// calculate conserved moities
-	Eigen::Matrix<ResidualType, Eigen::Dynamic, Eigen::Dynamic> M(_nComp, _nComp);
-	_dynReactionBulk->fillConservedMoietiesBulk2(M, _nConservedQuants, _QsCompBulk); // fill conserved moities matrix (alternative method)
-
-
-	// buffer memory for transformed residual
-	BufferedArray<ResidualType> temp = subAlloc.array<ResidualType>(_nComp);
-	Eigen::Map<Eigen::Vector<ResidualType, Eigen::Dynamic>> resCWithMoities(static_cast<ResidualType*>(temp), _nComp);
-	resCWithMoities.setZero();
-
-	Eigen::Matrix<ResidualType, Eigen::Dynamic, Eigen::Dynamic> MconvMoityBulk2Cast = _MconvMoityBulk2.template cast<ResidualType>();
-
-	// multiply conserved moities matrix with residual
-	resCWithMoities = MconvMoityBulk2Cast * mapResC;
-
-	// add quasi stationary reaction to residium
-	const int nQsReac = _dynReactionBulk->numReactionQuasiStationary();
-	int mIdx = 0;
-	int rIdx = 0;
-	for (int i = 0; i < _nComp; i++)
-	{
-		if (_QsCompBulk[i] == 0)
-			continue;
-		else if (mIdx < _nConservedQuants)
-			mIdx++;
-		else if (rIdx < nQsReac)
-		{
-			resCWithMoities[i] = qsFlux[rIdx];
-			rIdx++;
-		}
-
-	}
-
-	mapResC = resCWithMoities;
-
-	if (wantJac)
-	{
-		EigenMatrixTimesDemseMatrix(MconvMoityBulk2Cast, _jac);
-		int mIdx = 0;
-		int rIdx = 0;
-		for (int i = 0; i < _nComp; i++)
-		{
-			if (_QsCompBulk[i] == 0)
-				continue;
-			else if (mIdx < _nConservedQuants)
-				mIdx++;
-			else if (rIdx < nQsReac)
-			{
-				_dynReactionBulk->analyticJacobianQuasiStationaryReaction(t, secIdx, colPos, reinterpret_cast<double const*>(c), i, rIdx, _jac.row(i), subAlloc);
-				_jac.native(i, _nComp + _totalBound) = 0.0; // dF_{ci}/dvliquid = 0
-			}
-
-		}
-
-	}
-
-}
-
-
-template <typename StateType, typename ResidualType, typename ParamType, bool wantJac>
-int CSTRModel::residualImpl(double t, unsigned int secIdx, StateType const* const y, double const* const yDot, ResidualType* const res, LinearBufferAllocator tlmAlloc)
-{
-	StateType const* const cIn = y; 
-	StateType const* const c = y + _nComp;
-	const StateType& v = y[2 * _nComp + _totalBound];
-
-	double const* const cDot = yDot ? yDot + _nComp : nullptr; 
-	const double vDot = yDot ? yDot[2 * _nComp + _totalBound] : 0.0;
-	const ParamType flowIn = static_cast<ParamType>(_flowRateIn);
-	const ParamType flowOut = static_cast<ParamType>(_flowRateOut);
-	
-	// Inlet DOF
-	for (unsigned int i = 0; i < _nComp; ++i)
-	{
-		res[i] = cIn[i];
-	}
-
-	// Concentrations: \dot{V^l} * c + V^l * \dot{c} + V^s * sum_j sum_m \dot{q}_{j,m}] = c_in * F_in - c * F_out
-	const ParamType vsolid = static_cast<ParamType>(_constSolidVolume);
-	ResidualType* resC = res + _nComp;
-	for (unsigned int i = 0; i < _nComp; ++i)
-	{
-		resC[i] = 0.0;
-
-		// Add time derivatives
-		if (cadet_likely(yDot))
-		{
-			// Ultimately, we need V^l dc_{i} / dt + dV^l / dt + V^s * [ sum_j sum_m d_j dq_{j,i,m} / dt ]
-			// Compute the sum in the brackets first, then divide by beta and add remaining term
-
-			// sum dq_{i,1} / dt + dq_{i,2} / dt + ... + dq_{i,N_i} / dt
-			typename ActivePromoter<ParamType>::type qDotSum = 0.0;
-
+			// Bound states
 			for (unsigned int type = 0; type < _nParType; ++type)
 			{
-				double const* const qDot = cDot + _nComp + _offsetParType[type] + _boundOffset[type * _nComp + i];
-				
-				double qDotSumType = 0.0;
-				for (unsigned int j = 0; j < _nBound[type * _nComp + i]; ++j)
+				// Binding
+				IBindingModel* const binding = _binding[type];
+				bindingFlux(binding, t, secIdx, colPos, c, c + _nComp + _offsetParType[type], res + 2 * _nComp + _offsetParType[type], tlmAlloc, typename ParamSens<ParamType>::enabled());
+
+				int const* const qsReaction = binding->reactionQuasiStationarity();
+
+				if (binding->hasDynamicReactions() && yDot)
 				{
-					qDotSumType += qDot[j];
+					double const* const qDot = yDot + 2 * _nComp + _offsetParType[type];
+					ResidualType* const resQ = resC + _nComp + _offsetParType[type];
+					unsigned int idx = 0;
+					for (unsigned int comp = 0; comp < _nComp; ++comp)
+					{
+						for (unsigned int state = 0; state < _nBound[type * _nComp + comp]; ++state, ++idx)
+						{
+							// Skip quasi-stationary fluxes
+							if (qsReaction[idx])
+								continue;
+
+							// Add time derivative to solid phase
+							resQ[idx] += qDot[idx];
+						}
+					}
 				}
-				qDotSum += static_cast<ParamType>(_parTypeVolFrac[type]) * qDotSumType;
+
+				if (wantJac)
+				{
+					// Assemble Jacobian: Binding
+					_binding[type]->analyticJacobian(t, secIdx, colPos, reinterpret_cast<double const*>(y) + 2 * _nComp + _offsetParType[type], _nComp + _offsetParType[type], _jac.row(_nComp + _offsetParType[type]), tlmAlloc);
+				}
+
+				// Reaction
+				IDynamicReactionModel* const dynReaction = _dynReaction[type];
+				if (dynReaction && (dynReaction->numReactionsCombined() > 0))
+				{
+					LinearBufferAllocator subAlloc = tlmAlloc.manageRemainingMemory();
+
+					ResidualType* const resQ = resC + _nComp + _offsetParType[type];
+					BufferedArray<ResidualType> fluxBuffer = subAlloc.array<ResidualType>(_nComp + _strideBound[type]);
+					ResidualType* const fluxLiquid = static_cast<ResidualType*>(fluxBuffer);
+					ResidualType* const fluxSolid = fluxLiquid + _nComp;
+
+					std::fill_n(fluxLiquid, _nComp, 0.0);
+					std::fill_n(fluxSolid, _strideBound[type], 0.0);
+					dynReaction->residualCombinedAdd(t, secIdx, colPos, c, c + _nComp + _offsetParType[type], fluxLiquid, fluxSolid, -1.0, subAlloc);
+
+					for (unsigned int comp = 0; comp < _nComp; ++comp)
+						resC[comp] += v * fluxLiquid[comp];
+
+					typedef typename DoubleActivePromoter<StateType, ParamType>::type FactorType;
+					const FactorType liquidFactor = vsolid * static_cast<ParamType>(_parTypeVolFrac[type]);
+					unsigned int idx = 0;
+					for (unsigned int comp = 0; comp < _nComp; ++comp)
+					{
+						for (unsigned int bnd = 0; bnd < _nBound[type * _nComp + comp]; ++bnd, ++idx)
+						{
+							// Add reaction term to mobile phase
+							resC[comp] += static_cast<typename DoubleActiveDemoter<FactorType, ResidualType>::type>(liquidFactor)* fluxSolid[idx];
+
+							if (!qsReaction[idx])
+							{
+								// Add reaction term to solid phase
+								resQ[idx] += fluxSolid[idx];
+							}
+						}
+					}
+					if (wantJac)
+					{
+						// Assemble Jacobian: Reaction
+
+						// dRes / dC and dRes / dQ
+						BufferedArray<double> fluxJacobianMem = subAlloc.array<double>((_strideBound[type] + _nComp) * (_strideBound[type] + _nComp));
+						linalg::DenseMatrixView jacFlux(static_cast<double*>(fluxJacobianMem), nullptr, _strideBound[type] + _nComp, _strideBound[type] + _nComp);
+						dynReaction->analyticJacobianCombinedAdd(t, secIdx, colPos, reinterpret_cast<double const*>(c), reinterpret_cast<double const*>(c + _nComp + _offsetParType[type]),
+							-1.0, jacFlux.row(0), jacFlux.row(_nComp), subAlloc);
+
+						idx = 0;
+						const double liquidFactor = static_cast<double>(vsolid) * static_cast<double>(_parTypeVolFrac[type]);
+						for (unsigned int comp = 0; comp < _nComp; ++comp)
+						{
+							// Add bulk part of reaction to mobile phase Jacobian
+							jacFlux.addSubmatrixTo(_jac, static_cast<double>(v), comp, 0, 1, _nComp, comp, 0);
+							jacFlux.addSubmatrixTo(_jac, static_cast<double>(v), comp, _nComp, 1, _strideBound[type], comp, _nComp + _offsetParType[type]);
+
+							for (unsigned int bnd = 0; bnd < _nBound[type * _nComp + comp]; ++bnd, ++idx)
+							{
+								// Add Jacobian row to mobile phase
+								jacFlux.addSubmatrixTo(_jac, liquidFactor, _nComp + idx, 0, 1, _nComp, comp, 0);
+								jacFlux.addSubmatrixTo(_jac, liquidFactor, _nComp + idx, _nComp, 1, _strideBound[type], comp, _nComp + _offsetParType[type]);
+
+								if (!qsReaction[idx])
+								{
+									// Add Jacobian row to solid phase
+									jacFlux.addSubmatrixTo(_jac, 1.0, _nComp + idx, 0, 1, _nComp, _nComp + _offsetParType[type] + idx, 0);
+									jacFlux.addSubmatrixTo(_jac, 1.0, _nComp + idx, _nComp, 1, _strideBound[type], _nComp + _offsetParType[type] + idx, _nComp + _offsetParType[type]);
+								}
+							}
+						}
+					}
+				}
 			}
 
-			// Divide by beta and add c_i and dc_i / dt
-			resC[i] = cDot[i] * v + vDot * c[i] + vsolid * qDotSum;
+			// Volume: \dot{V} = F_{in} - F_{out} - F_{filter}
+			res[2 * _nComp + _totalBound] = vDot - flowIn + flowOut + static_cast<ParamType>(_curFlowRateFilter);
+
+
+			return 0;
 		}
-		resC[i] += -flowIn * cIn[i] + flowOut * c[i];
-	}
-	
-	if (wantJac)
-	{
-		_jac.setAll(0.0);
 
-		// Assemble Jacobian: Liquid phase
-
-		// Concentrations: V^l * \dot{c}_i + \dot{V^l} * c_i + V^s * ([sum_j sum_m d_j \dot{q}_{j,i,m}]) - c_{in,i} * F_in + c_i * F_out == 0
-		const double vDotTimeFactor = static_cast<double>(vDot);
-		for (unsigned int i = 0; i < _nComp; ++i)
+		int CSTRModel::residual(const SimulationTime& simTime, const ConstSimulationState& simState, double* const res,
+			const AdJacobianParams& adJac, util::ThreadLocalStorage& threadLocalMem, bool updateJacobian, bool paramSensitivity)
 		{
-			_jac.native(i, i) = vDotTimeFactor + static_cast<double>(flowOut); // dF/dci = v_liquidDot + F_out
-
-			if (cadet_likely(yDot))
+			if (updateJacobian)
 			{
-				_jac.native(i, _nComp + _totalBound) = cDot[i]; // dF/dvliquid = cDot 
+				_factorizeJac = true;
+
+#ifndef CADET_CHECK_ANALYTIC_JACOBIAN
+				if (_analyticJac)
+				{
+					if (paramSensitivity)
+					{
+						const int retCode = residualImpl<double, active, active, true>(simTime.t, simTime.secIdx, simState.vecStateY, simState.vecStateYdot, adJac.adRes, threadLocalMem.get());
+
+						// Copy AD residuals to original residuals vector
+						if (res)
+							ad::copyFromAd(adJac.adRes, res, numDofs());
+
+						return retCode;
+					}
+					else
+						return residualImpl<double, double, double, true>(simTime.t, simTime.secIdx, simState.vecStateY, simState.vecStateYdot, res, threadLocalMem.get());
+				}
+				else
+				{
+					// Compute Jacobian via AD
+
+					// Copy over state vector to AD state vector (without changing directional values to keep seed vectors)
+					// and initialize residuals with zero (also resetting directional values)
+					ad::copyToAd(simState.vecStateY, adJac.adY, numDofs());
+					// @todo Check if this is necessary
+					ad::resetAd(adJac.adRes, numDofs());
+
+					// Evaluate with AD enabled
+					int retCode = 0;
+					if (paramSensitivity)
+						retCode = residualImpl<active, active, active, false>(simTime.t, simTime.secIdx, adJac.adY, simState.vecStateYdot, adJac.adRes, threadLocalMem.get());
+					else
+						retCode = residualImpl<active, active, double, false>(simTime.t, simTime.secIdx, adJac.adY, simState.vecStateYdot, adJac.adRes, threadLocalMem.get());
+
+					// Copy AD residuals to original residuals vector
+					if (res)
+						ad::copyFromAd(adJac.adRes, res, numDofs());
+
+					// Extract Jacobian
+					extractJacobianFromAD(adJac.adRes, adJac.adDirOffset);
+					/*
+					std::cout << "Jacobian: " << std::endl;
+					for (unsigned int i = 0; i < _nComp + 1; ++i)
+					{
+						for (unsigned int j = 0; j < _nComp + 1; ++j)
+							std::cout << _jac.native(i, j) << " ";
+						std::cout << std::endl;
+					}*/
+					return retCode;
+				}
+#else
+				// Compute Jacobian via AD
+
+				// Copy over state vector to AD state vector (without changing directional values to keep seed vectors)
+				// and initialize residuals with zero (also resetting directional values)
+				ad::copyToAd(simState.vecStateY, adJac.adY, numDofs());
+				// @todo Check if this is necessary
+				ad::resetAd(adJac.adRes, numDofs());
+
+				// Evaluate with AD enabled
+				int retCode = 0;
+				if (paramSensitivity)
+					retCode = residualImpl<active, active, active, false>(simTime.t, simTime.secIdx, adJac.adY, simState.vecStateYdot, adJac.adRes, threadLocalMem.get());
+				else
+					retCode = residualImpl<active, active, double, false>(simTime.t, simTime.secIdx, adJac.adY, simState.vecStateYdot, adJac.adRes, threadLocalMem.get());
+
+				// Only do comparison if we have a residuals vector (which is not always the case)
+				if (res)
+				{
+					// Evaluate with analytical Jacobian which is stored in the band matrices
+					retCode = residualImpl<double, double, double, true>(simTime.t, simTime.secIdx, simState.vecStateY, simState.vecStateYdot, res, threadLocalMem.get());
+
+					// Compare AD with anaytic Jacobian
+					checkAnalyticJacobianAgainstAd(adJac.adRes, adJac.adDirOffset);
+				}
+
+				// Extract Jacobian
+				extractJacobianFromAD(adJac.adRes, adJac.adDirOffset);
+
+				return retCode;
+#endif
+			}
+			else
+			{
+				if (paramSensitivity)
+				{
+					// initialize residuals with zero
+					// @todo Check if this is necessary
+					ad::resetAd(adJac.adRes, numDofs());
+
+					const int retCode = residualImpl<double, active, active, false>(simTime.t, simTime.secIdx, simState.vecStateY, simState.vecStateYdot, adJac.adRes, threadLocalMem.get());
+
+					// Copy AD residuals to original residuals vector
+					if (res)
+						ad::copyFromAd(adJac.adRes, res, numDofs());
+
+					return retCode;
+				}
+				else
+					return residualImpl<double, double, double, false>(simTime.t, simTime.secIdx, simState.vecStateY, simState.vecStateYdot, res, threadLocalMem.get());
 			}
 		}
-	}
 
-	// Reactions in liquid phase
-	const ColumnPosition colPos{0.0, 0.0, 0.0};
-	if (_dynReactionBulk && (_dynReactionBulk->numReactionsLiquid() > 0))
-	{
-		LinearBufferAllocator subAlloc = tlmAlloc.manageRemainingMemory();
-
-		BufferedArray<ResidualType> flux = subAlloc.array<ResidualType>(_nComp);
-		std::fill_n(static_cast<ResidualType*>(flux), _nComp, 0.0);
-		_dynReactionBulk->residualLiquidAdd(t, secIdx, colPos, c, static_cast<ResidualType*>(flux), -1.0, subAlloc);
-
-		for (unsigned int comp = 0; comp < _nComp; ++comp)
-			resC[comp] += v * flux[comp];
-
-		if (wantJac)
+		int CSTRModel::residualWithJacobian(const SimulationTime& simTime, const ConstSimulationState& simState, double* const res, const AdJacobianParams& adJac, util::ThreadLocalStorage& threadLocalMem)
 		{
-			for (unsigned int comp = 0; comp < _nComp; ++comp)
-				_jac.native(comp, _nComp + _totalBound) += static_cast<double>(flux[comp]); // dF/dvliquid = flux
-
-			_dynReactionBulk->analyticJacobianLiquidAdd(t, secIdx, colPos, reinterpret_cast<double const*>(c), -static_cast<double>(v), _jac.row(0), subAlloc);
+			return residual(simTime, simState, res, adJac, threadLocalMem, true, false);
 		}
 
-		if (_hasQuasiStationaryReactionBulk)
+		int CSTRModel::residualSensFwdAdOnly(const SimulationTime& simTime, const ConstSimulationState& simState, active* const adRes, util::ThreadLocalStorage& threadLocalMem)
 		{
-			applyConservedMoitiesBulk2<StateType, ResidualType, ParamType, wantJac>(t, secIdx, colPos, c, yDot, resC, subAlloc);
-			
+			// Evaluate residual for all parameters using AD in vector mode
+			return residualImpl<double, active, active, false>(simTime.t, simTime.secIdx, simState.vecStateY, simState.vecStateYdot, adRes, threadLocalMem.get());
 		}
-	}
-	// Bound states
-	for (unsigned int type = 0; type < _nParType; ++type)
-	{
-		// Binding
-		IBindingModel* const binding = _binding[type];
-		bindingFlux(binding, t, secIdx, colPos, c, c + _nComp + _offsetParType[type], res + 2 * _nComp + _offsetParType[type], tlmAlloc, typename ParamSens<ParamType>::enabled());
 
-		int const* const qsReaction = binding->reactionQuasiStationarity();
-
-		if (binding->hasDynamicReactions() && yDot)
+		int CSTRModel::residualSensFwdWithJacobian(const SimulationTime& simTime, const ConstSimulationState& simState, const AdJacobianParams& adJac, util::ThreadLocalStorage& threadLocalMem)
 		{
-			double const* const qDot = yDot + 2 * _nComp + _offsetParType[type];
-			ResidualType* const resQ = resC + _nComp + _offsetParType[type];
-			unsigned int idx = 0;
-			for (unsigned int comp = 0; comp < _nComp; ++comp)
+			// Evaluate residual for all parameters using AD in vector mode and at the same time update the 
+			// Jacobian (in one AD run, if analytic Jacobians are disabled)
+			return residual(simTime, simState, nullptr, adJac, threadLocalMem, true, true);
+		}
+
+		void CSTRModel::initializeSensitivityStates(const std::vector<double*>& vecSensY) const
+		{
+			const unsigned int nDof = numPureDofs();
+			for (std::size_t param = 0; param < vecSensY.size(); ++param)
 			{
-				for (unsigned int state = 0; state < _nBound[type * _nComp + comp]; ++state, ++idx)
+				double* const sensY = vecSensY[param];
+				ad::copyFromAdDirection(_initConditions.data(), sensY + _nComp, nDof, param);
+			}
+		}
+
+		void CSTRModel::consistentInitialSensitivity(const SimulationTime& simTime, const ConstSimulationState& simState,
+			std::vector<double*>& vecSensY, std::vector<double*>& vecSensYdot, active const* const adRes, util::ThreadLocalStorage& threadLocalMem)
+		{
+			// TODO: Handle v = 0
+
+			LinearBufferAllocator tlmAlloc = threadLocalMem.get();
+			BufferedArray<int> qsMaskBuffer = tlmAlloc.array<int>(_totalBound);
+			int* const qsMask = static_cast<int*>(qsMaskBuffer);
+			int* localMask = static_cast<int*>(qsMask);
+
+			// Check whether quasi-stationary reactions are present and construct mask array
+			bool hasQSreactions = false;
+			std::fill_n(static_cast<int*>(qsMask), _totalBound, false);
+			for (unsigned int type = 0; type < _nParType; localMask += _strideBound[type], ++type)
+			{
+				if (!_binding[type]->hasQuasiStationaryReactions())
+					continue;
+
+				hasQSreactions = true;
+
+				// Construct mask
+				int const* const qsMaskSrc = _binding[type]->reactionQuasiStationarity();
+				std::copy_n(qsMaskSrc, _strideBound[type], localMask);
+			}
+
+			const linalg::ConstMaskArray mask{ static_cast<int*>(qsMask), static_cast<int>(_totalBound) };
+			const int probSize = linalg::numMaskActive(mask);
+			BufferedArray<double> buffer = tlmAlloc.array<double>(_nComp + _totalBound + 1);
+			BufferedArray<double> rhs = tlmAlloc.array<double>(probSize);
+			BufferedArray<double> rhsUnmasked = tlmAlloc.array<double>(_totalBound);
+
+			for (std::size_t param = 0; param < vecSensY.size(); ++param)
+			{
+				double* const sensY = vecSensY[param];
+				double* const sensYdot = vecSensYdot[param];
+
+				// Copy parameter derivative dF / dp from AD and negate it
+				for (unsigned int i = _nComp; i < numDofs(); ++i)
+					sensYdot[i] = -adRes[i].getADValue(param);
+
+				// Step 1: Solve algebraic equations
+
+				// Step 1a: Compute quasi-stationary binding model state
+				if (hasQSreactions)
+				{
+					double* const maskedMultiplier = static_cast<double*>(buffer);
+
+					linalg::DenseMatrixView jacobianMatrix(_jacFact.data(), _jacFact.pivotData(), probSize, probSize);
+					jacobianMatrix.setAll(0.0);
+
+					// Extract subproblem Jacobian from full Jacobian
+					linalg::copyMatrixSubset(_jac, mask, mask, _nComp, _nComp, jacobianMatrix, 0);
+
+					// Construct right hand side
+					linalg::selectVectorSubset(sensYdot + 2 * _nComp, mask, static_cast<double*>(rhs));
+
+					// Zero out masked elements
+					std::copy_n(sensY + _nComp, _nComp + _totalBound + 1, maskedMultiplier);
+					linalg::fillVectorSubset(maskedMultiplier + _nComp, mask, 0.0);
+
+					// Assemble right hand side
+					_jac.submatrixMultiplyVector(maskedMultiplier, _nComp, 0, _totalBound, _nComp + _totalBound + 1, static_cast<double*>(rhsUnmasked));
+					linalg::vectorSubsetAdd(static_cast<double*>(rhsUnmasked), mask, -1.0, 1.0, static_cast<double*>(rhs));
+
+					// Precondition
+					double* const scaleFactors = static_cast<double*>(buffer);
+					jacobianMatrix.rowScaleFactors(scaleFactors);
+					jacobianMatrix.scaleRows(scaleFactors);
+
+					// Solve
+					jacobianMatrix.factorize();
+					jacobianMatrix.solve(scaleFactors, static_cast<double*>(rhs));
+
+					// Write back
+					linalg::applyVectorSubset(static_cast<double*>(rhs), mask, sensY + 2 * _nComp);
+				}
+
+				// Step 2: Compute the correct time derivative of the state vector
+
+				// Step 2a: Assemble, factorize, and solve diagonal blocks of linear system
+
+				// Compute right hand side by adding -dF / dy * s = -J * s to -dF / dp which is already stored in sensYdot
+				multiplyWithJacobian(simTime, simState, sensY, -1.0, 1.0, sensYdot);
+
+				// Note that we have correctly negated the right hand side
+
+				// Assemble dF / dYdot
+				_jacFact.setAll(0.0);
+				addTimeDerivativeJacobian(simTime.t, 1.0, simState, _jacFact);
+
+				// Overwrite rows corresponding to algebraic equations with the Jacobian and set right hand side to 0
+				for (unsigned int type = 0; type < _nParType; ++type)
+				{
+					if (!_binding[type]->hasQuasiStationaryReactions())
+						continue;
+
+					double* const localQdot = sensYdot + 2 * _nComp + _offsetParType[type];
+					int const* const localMask = mask.mask + _offsetParType[type];
+					for (unsigned int i = 0; i < _strideBound[type]; ++i)
+					{
+						if (!localMask[i])
+							continue;
+
+						const unsigned int idx = _nComp + _offsetParType[type] + i;
+						_jacFact.copyRowFrom(_jac, idx, idx);
+
+						// Right hand side is -\frac{\partial^2 res(t, y, \dot{y})}{\partial p \partial t}
+						// If the residual is not explicitly depending on time, this expression is 0
+						// @todo This is wrong if external functions are used. Take that into account!
+						localQdot[i] = 0.0;
+					}
+				}
+
+				// Factorize
+				const bool result = _jacFact.robustFactorize(static_cast<double*>(buffer));
+				if (!result)
+				{
+					LOG(Error) << "Factorize() failed";
+				}
+
+				// Solve
+				const bool result2 = _jacFact.robustSolve(sensYdot + _nComp, static_cast<double*>(buffer));
+				if (!result2)
+				{
+					LOG(Error) << "Solve() failed";
+				}
+			}
+		}
+
+		void CSTRModel::multiplyWithJacobian(const SimulationTime& simTime, const ConstSimulationState& simState, double const* yS, double alpha, double beta, double* ret)
+		{
+			const double flowIn = static_cast<double>(_flowRateIn);
+			double* const resTank = ret + _nComp;
+
+			// Inlet DOFs
+			for (unsigned int i = 0; i < _nComp; ++i)
+			{
+				ret[i] = alpha * yS[i] + beta * ret[i];
+			}
+
+			// Multiply with main body Jacobian: dRes / dy
+			_jac.multiplyVector(yS + _nComp, alpha, beta, resTank);
+
+			// Map inlet DOFs to the tank (tank cells)
+			for (unsigned int i = 0; i < _nComp; ++i)
+			{
+				resTank[i] -= alpha * flowIn * yS[i];
+			}
+		}
+
+		void CSTRModel::multiplyWithDerivativeJacobian(const SimulationTime& simTime, const ConstSimulationState& simState, double const* sDot, double* ret)
+		{
+			// Handle inlet DOFs (all algebraic)
+			std::fill_n(ret, _nComp, 0.0);
+
+			// Handle actual ODE DOFs
+			double const* const c = simState.vecStateY + _nComp;
+			double const* const q = simState.vecStateY + 2 * _nComp;
+			const double v = simState.vecStateY[2 * _nComp + _totalBound];
+			const double timeV = v;
+			const double vSolid = static_cast<double>(_constSolidVolume);
+			double* const r = ret + _nComp;
+			double const* const s = sDot + _nComp;
+
+			// Concentrations: V^l * \dot{c}_i \dot{V^l} * c_i + V^s * ([sum_j sum_m d_j \dot{q}_{j,i,m}]) - c_{in,i} * F_in + c_i * F_out == 0
+			for (unsigned int i = 0; i < _nComp; ++i)
+			{
+				r[i] = timeV * s[i]; // dRes / dcDot
+
+				double qSum = 0.0;
+				for (unsigned int type = 0; type < _nParType; ++type)
+				{
+					double const* const qi = q + _offsetParType[type] + _boundOffset[type * _nComp + i];
+					const unsigned int localOffset = _nComp + _offsetParType[type] + _boundOffset[type * _nComp + i];
+					const double vSolidParVolFrac = vSolid * static_cast<double>(_parTypeVolFrac[type]);
+					double qSumType = 0.0;
+					for (unsigned int j = 0; j < _nBound[type * _nComp + i]; ++j)
+					{
+						r[i] += vSolidParVolFrac * s[localOffset + j]; // dRes / d_qDot
+						// + _nComp: Moves over liquid phase components
+						// + _offsetParType[type]: Moves to particle type
+						// + _boundOffset[i]: Moves over bound states of previous components
+						// + j: Moves to current bound state j of component i
+
+						qSumType += qi[j];
+					}
+
+					qSum += static_cast<double>(_parTypeVolFrac[type]) * qSumType;
+				}
+				r[i] += c[i] * s[_nComp + _totalBound]; // dRes / dvLiquidDot
+			}
+
+			// Bound states
+			for (unsigned int type = 0; type < _nParType; ++type)
+			{
+				// Jump to solid phase of current particle type
+				double* const rQ = r + _nComp + _offsetParType[type];
+				double const* const sQ = s + _nComp + _offsetParType[type];
+				std::fill_n(rQ, _strideBound[type], 0.0);
+
+				// Skip binding models without dynamic binding fluxes
+				IBindingModel* const binding = _binding[type];
+				if (!binding->hasDynamicReactions())
+					continue;
+
+				int const* const qsReaction = binding->reactionQuasiStationarity();
+				for (unsigned int idx = 0; idx < _strideBound[type]; ++idx)
 				{
 					// Skip quasi-stationary fluxes
 					if (qsReaction[idx])
 						continue;
 
-					// Add time derivative to solid phase
-					resQ[idx] += qDot[idx];
+					rQ[idx] = sQ[idx];
 				}
 			}
+
+			// Volume: \dot{V} - F_{in} + F_{out} + F_{filter} == 0
+			r[_nComp + _totalBound] = s[_nComp + _totalBound];
 		}
 
-		if (wantJac)
+		int CSTRModel::linearSolve(double t, double alpha, double tol, double* const rhs, double const* const weight,
+			const ConstSimulationState& simState)
 		{
-			// Assemble Jacobian: Binding
-			_binding[type]->analyticJacobian(t, secIdx, colPos, reinterpret_cast<double const*>(y) + 2 * _nComp + _offsetParType[type], _nComp + _offsetParType[type], _jac.row(_nComp + _offsetParType[type]), tlmAlloc);
-		}
+			const double flowIn = static_cast<double>(_flowRateIn);
 
-		// Reaction
-		IDynamicReactionModel* const dynReaction = _dynReaction[type];
-		if (dynReaction && (dynReaction->numReactionsCombined() > 0))
-		{
-			LinearBufferAllocator subAlloc = tlmAlloc.manageRemainingMemory();
-
-			ResidualType* const resQ = resC + _nComp + _offsetParType[type];
-			BufferedArray<ResidualType> fluxBuffer = subAlloc.array<ResidualType>(_nComp + _strideBound[type]);
-			ResidualType* const fluxLiquid = static_cast<ResidualType*>(fluxBuffer);
-			ResidualType* const fluxSolid = fluxLiquid + _nComp;
-
-			std::fill_n(fluxLiquid, _nComp, 0.0);
-			std::fill_n(fluxSolid, _strideBound[type], 0.0);
-			dynReaction->residualCombinedAdd(t, secIdx, colPos, c, c + _nComp + _offsetParType[type], fluxLiquid, fluxSolid, -1.0, subAlloc);
-
-			for (unsigned int comp = 0; comp < _nComp; ++comp)
-				resC[comp] += v * fluxLiquid[comp];
-
-			typedef typename DoubleActivePromoter<StateType, ParamType>::type FactorType;
-			const FactorType liquidFactor = vsolid * static_cast<ParamType>(_parTypeVolFrac[type]);
-			unsigned int idx = 0;
-			for (unsigned int comp = 0; comp < _nComp; ++comp)
+			// Handle inlet equations by backsubstitution
+			for (unsigned int i = 0; i < _nComp; ++i)
 			{
-				for (unsigned int bnd = 0; bnd < _nBound[type * _nComp + comp]; ++bnd, ++idx)
-				{
-					// Add reaction term to mobile phase
-					resC[comp] += static_cast<typename DoubleActiveDemoter<FactorType, ResidualType>::type>(liquidFactor) * fluxSolid[idx];
+				rhs[i + _nComp] += flowIn * rhs[i];
+			}
 
-					if (!qsReaction[idx])
+			bool success = true;
+			if (_factorizeJac)
+			{
+				// Factorization is necessary
+				_factorizeJac = false;
+				_jacFact.copyFrom(_jac);
+
+				addTimeDerivativeJacobian(t, alpha, simState, _jacFact);
+				success = _jacFact.factorize();
+			}
+			success = success && _jacFact.solve(rhs + _nComp);
+
+			// Return 0 on success and 1 on failure
+			return success ? 0 : 1;
+		}
+
+		template <typename MatrixType>
+		void CSTRModel::addTimeDerivativeJacobian(double t, double alpha, const ConstSimulationState& simState, MatrixType& mat)
+		{
+			double const* const c = simState.vecStateY + _nComp;
+			double const* const q = simState.vecStateY + 2 * _nComp;
+			const double v = simState.vecStateY[2 * _nComp + _totalBound];
+			const double timeV = v * alpha;
+			const double timeVSolid = static_cast<double>(_constSolidVolume) * alpha;
+
+			// Assemble Jacobian: dRes / dyDot
+
+			// Concentrations: \dot{V^l} * c_i + V^l * \dot{c}_i + V^s * [sum_j sum_m d_j \dot{q}_{j,i,m}]) - c_{in,i} * F_in + c_i * F_out == 0
+
+
+			if (_hasQuasiStationaryReactionBulk)
+			{
+				int  MoityIdx = 0;
+				for (unsigned int i = 0; i < _nComp; i++)
+				{
+					if (_QsCompBulk[i] == 0)
 					{
-						// Add reaction term to solid phase
-						resQ[idx] += fluxSolid[idx];
+						mat.native(i, i) += timeV; // dRes / dcDot
+					}
+					else if (MoityIdx >= _nConservedQuants)
+						continue;
+					else
+					{
+						for (int j = 0; j < _nComp; j++)
+						{
+							mat.native(i, j) += timeV * static_cast<double>(_MconvMoityBulk(i, j)); // dRes / dcDot
+							mat.native(i, _nComp + _totalBound) += alpha * static_cast<double>(_MconvMoityBulk(i, j)) * c[j]; // dRes / dVlDot
+						}
+						MoityIdx++;
 					}
 				}
+
 			}
-			if (wantJac)
+			else
 			{
-				// Assemble Jacobian: Reaction
-
-				// dRes / dC and dRes / dQ
-				BufferedArray<double> fluxJacobianMem = subAlloc.array<double>((_strideBound[type] + _nComp) * (_strideBound[type] + _nComp));
-				linalg::DenseMatrixView jacFlux(static_cast<double*>(fluxJacobianMem), nullptr, _strideBound[type] + _nComp, _strideBound[type] + _nComp);
-				dynReaction->analyticJacobianCombinedAdd(t, secIdx, colPos, reinterpret_cast<double const*>(c), reinterpret_cast<double const*>(c + _nComp + _offsetParType[type]),
-					-1.0, jacFlux.row(0), jacFlux.row(_nComp), subAlloc);
-
-				idx = 0;
-				const double liquidFactor = static_cast<double>(vsolid) * static_cast<double>(_parTypeVolFrac[type]);
-				for (unsigned int comp = 0; comp < _nComp; ++comp)
+				for (unsigned int i = 0; i < _nComp; ++i)
 				{
-					// Add bulk part of reaction to mobile phase Jacobian
-					jacFlux.addSubmatrixTo(_jac, static_cast<double>(v), comp, 0, 1, _nComp, comp, 0);
-					jacFlux.addSubmatrixTo(_jac, static_cast<double>(v), comp, _nComp, 1, _strideBound[type], comp, _nComp + _offsetParType[type]);
+					mat.native(i, i) += timeV; // dRes / dcDot
 
-					for (unsigned int bnd = 0; bnd < _nBound[type * _nComp + comp]; ++bnd, ++idx)
+					double qSum = 0.0;
+					for (unsigned int type = 0; type < _nParType; ++type)
 					{
-						// Add Jacobian row to mobile phase
-						jacFlux.addSubmatrixTo(_jac, liquidFactor, _nComp + idx, 0, 1, _nComp, comp, 0);
-						jacFlux.addSubmatrixTo(_jac, liquidFactor, _nComp + idx, _nComp, 1, _strideBound[type], comp, _nComp + _offsetParType[type]);
-
-						if (!qsReaction[idx])
+						double const* const qi = q + _offsetParType[type] + _boundOffset[type * _nComp + i];
+						const unsigned int localOffset = _nComp + _offsetParType[type] + _boundOffset[type * _nComp + i];
+						const double vSolidParVolFrac = timeVSolid * static_cast<double>(_parTypeVolFrac[type]);
+						for (unsigned int j = 0; j < _nBound[type * _nComp + i]; ++j)
 						{
-							// Add Jacobian row to solid phase
-							jacFlux.addSubmatrixTo(_jac, 1.0, _nComp + idx, 0, 1, _nComp, _nComp + _offsetParType[type] + idx, 0);
-							jacFlux.addSubmatrixTo(_jac, 1.0, _nComp + idx, _nComp, 1, _strideBound[type], _nComp + _offsetParType[type] + idx, _nComp + _offsetParType[type]);
+							mat.native(i, localOffset + j) += vSolidParVolFrac; // dRes / dqDot
+							// + _nComp: Moves over liquid phase components
+							// + _offsetParType[type]: Moves to particle type
+							// + _boundOffset[i]: Moves over bound states of previous components
+							// + j: Moves to current bound state j of component i
+
 						}
 					}
+
+					mat.native(i, _nComp + _totalBound) += alpha * c[i]; // dRes / dVlDot
 				}
 			}
-		}
-	}
 
-	// Volume: \dot{V} = F_{in} - F_{out} - F_{filter}
-	res[2 * _nComp + _totalBound] = vDot - flowIn + flowOut + static_cast<ParamType>(_curFlowRateFilter);
-	
-	/*
-	std::cout << "Jacobian: " << std::endl;
-	for (unsigned int i = 0; i < _nComp + 1; ++i)
-	{
-		for (unsigned int j = 0; j < _nComp + 1; ++j)
-			std::cout << _jac.native(i, j) << " ";
-		std::cout << std::endl;
-	}*/
-	return 0;
-}
-
-int CSTRModel::residual(const SimulationTime& simTime, const ConstSimulationState& simState, double* const res,
-	const AdJacobianParams& adJac, util::ThreadLocalStorage& threadLocalMem, bool updateJacobian, bool paramSensitivity)
-{
-	if (updateJacobian)
-	{
-		_factorizeJac = true;
-
-#ifndef CADET_CHECK_ANALYTIC_JACOBIAN
-		if (_analyticJac)
-		{
-			if (paramSensitivity)
-			{
-				const int retCode = residualImpl<double, active, active, true>(simTime.t, simTime.secIdx, simState.vecStateY, simState.vecStateYdot, adJac.adRes, threadLocalMem.get());
-
-				// Copy AD residuals to original residuals vector
-				if (res)
-					ad::copyFromAd(adJac.adRes, res, numDofs());
-
-				return retCode;
-			}
-			else
-				return residualImpl<double, double, double, true>(simTime.t, simTime.secIdx, simState.vecStateY, simState.vecStateYdot, res, threadLocalMem.get());
-		}
-		else
-		{
-			// Compute Jacobian via AD
-
-			// Copy over state vector to AD state vector (without changing directional values to keep seed vectors)
-			// and initialize residuals with zero (also resetting directional values)
-			ad::copyToAd(simState.vecStateY, adJac.adY, numDofs());
-			// @todo Check if this is necessary
-			ad::resetAd(adJac.adRes, numDofs());
-
-			// Evaluate with AD enabled
-			int retCode = 0;
-			if (paramSensitivity)
-				retCode = residualImpl<active, active, active, false>(simTime.t, simTime.secIdx, adJac.adY, simState.vecStateYdot, adJac.adRes, threadLocalMem.get());
-			else
-				retCode = residualImpl<active, active, double, false>(simTime.t, simTime.secIdx, adJac.adY, simState.vecStateYdot, adJac.adRes, threadLocalMem.get());
-
-			// Copy AD residuals to original residuals vector
-			if (res)
-				ad::copyFromAd(adJac.adRes, res, numDofs());
-
-			// Extract Jacobian
-			extractJacobianFromAD(adJac.adRes, adJac.adDirOffset);
-			/*
-			std::cout << "Jacobian: " << std::endl;
-			for (unsigned int i = 0; i < _nComp + 1; ++i)
-			{
-				for (unsigned int j = 0; j < _nComp + 1; ++j)
-					std::cout << _jac.native(i, j) << " ";
-				std::cout << std::endl;
-			}*/
-			return retCode;
-		}
-#else
-		// Compute Jacobian via AD
-
-		// Copy over state vector to AD state vector (without changing directional values to keep seed vectors)
-		// and initialize residuals with zero (also resetting directional values)
-		ad::copyToAd(simState.vecStateY, adJac.adY, numDofs());
-		// @todo Check if this is necessary
-		ad::resetAd(adJac.adRes, numDofs());
-
-		// Evaluate with AD enabled
-		int retCode = 0;
-		if (paramSensitivity)
-			retCode = residualImpl<active, active, active, false>(simTime.t, simTime.secIdx, adJac.adY, simState.vecStateYdot, adJac.adRes, threadLocalMem.get());
-		else
-			retCode = residualImpl<active, active, double, false>(simTime.t, simTime.secIdx, adJac.adY, simState.vecStateYdot, adJac.adRes, threadLocalMem.get());
-
-		// Only do comparison if we have a residuals vector (which is not always the case)
-		if (res)
-		{
-			// Evaluate with analytical Jacobian which is stored in the band matrices
-			retCode = residualImpl<double, double, double, true>(simTime.t, simTime.secIdx, simState.vecStateY, simState.vecStateYdot, res, threadLocalMem.get());
-
-			// Compare AD with anaytic Jacobian
-			checkAnalyticJacobianAgainstAd(adJac.adRes, adJac.adDirOffset);
-		}
-
-		// Extract Jacobian
-		extractJacobianFromAD(adJac.adRes, adJac.adDirOffset);
-
-		return retCode;
-#endif
-	}
-	else
-	{
-		if (paramSensitivity)
-		{
-			// initialize residuals with zero
-			// @todo Check if this is necessary
-			ad::resetAd(adJac.adRes, numDofs());
-
-			const int retCode = residualImpl<double, active, active, false>(simTime.t, simTime.secIdx, simState.vecStateY, simState.vecStateYdot, adJac.adRes, threadLocalMem.get());
-
-			// Copy AD residuals to original residuals vector
-			if (res)
-				ad::copyFromAd(adJac.adRes, res, numDofs());
-
-			return retCode;
-		}
-		else
-			return residualImpl<double, double, double, false>(simTime.t, simTime.secIdx, simState.vecStateY, simState.vecStateYdot, res, threadLocalMem.get());
-	}
-}
-
-int CSTRModel::residualWithJacobian(const SimulationTime& simTime, const ConstSimulationState& simState, double* const res, const AdJacobianParams& adJac, util::ThreadLocalStorage& threadLocalMem)
-{
-	return residual(simTime, simState, res, adJac, threadLocalMem, true, false);
-}
-
-int CSTRModel::residualSensFwdAdOnly(const SimulationTime& simTime, const ConstSimulationState& simState, active* const adRes, util::ThreadLocalStorage& threadLocalMem)
-{
-	// Evaluate residual for all parameters using AD in vector mode
-	return residualImpl<double, active, active, false>(simTime.t, simTime.secIdx, simState.vecStateY, simState.vecStateYdot, adRes, threadLocalMem.get());
-}
-
-int CSTRModel::residualSensFwdWithJacobian(const SimulationTime& simTime, const ConstSimulationState& simState, const AdJacobianParams& adJac, util::ThreadLocalStorage& threadLocalMem)
-{
-	// Evaluate residual for all parameters using AD in vector mode and at the same time update the 
-	// Jacobian (in one AD run, if analytic Jacobians are disabled)
-	return residual(simTime, simState, nullptr, adJac, threadLocalMem, true, true);
-}
-
-void CSTRModel::initializeSensitivityStates(const std::vector<double*>& vecSensY) const
-{
-	const unsigned int nDof = numPureDofs();
-	for (std::size_t param = 0; param < vecSensY.size(); ++param)
-	{
-		double* const sensY = vecSensY[param];
-		ad::copyFromAdDirection(_initConditions.data(), sensY + _nComp, nDof, param);
-	}
-}
-
-void CSTRModel::consistentInitialSensitivity(const SimulationTime& simTime, const ConstSimulationState& simState,
-	std::vector<double*>& vecSensY, std::vector<double*>& vecSensYdot, active const* const adRes, util::ThreadLocalStorage& threadLocalMem)
-{
-	// TODO: Handle v = 0
-
-	LinearBufferAllocator tlmAlloc = threadLocalMem.get();
-	BufferedArray<int> qsMaskBuffer = tlmAlloc.array<int>(_totalBound);
-	int* const qsMask = static_cast<int*>(qsMaskBuffer);
-	int* localMask = static_cast<int*>(qsMask);
-
-	// Check whether quasi-stationary reactions are present and construct mask array
-	bool hasQSreactions = false;
-	std::fill_n(static_cast<int*>(qsMask), _totalBound, false);
-	for (unsigned int type = 0; type < _nParType; localMask += _strideBound[type], ++type)
-	{
-		if (!_binding[type]->hasQuasiStationaryReactions())
-			continue;
-
-		hasQSreactions = true;
-
-		// Construct mask
-		int const* const qsMaskSrc = _binding[type]->reactionQuasiStationarity();
-		std::copy_n(qsMaskSrc, _strideBound[type], localMask);
-	}
-
-	const linalg::ConstMaskArray mask{static_cast<int*>(qsMask), static_cast<int>(_totalBound)};
-	const int probSize = linalg::numMaskActive(mask);
-	BufferedArray<double> buffer = tlmAlloc.array<double>(_nComp + _totalBound + 1);
-	BufferedArray<double> rhs = tlmAlloc.array<double>(probSize);
-	BufferedArray<double> rhsUnmasked = tlmAlloc.array<double>(_totalBound);
-
-	for (std::size_t param = 0; param < vecSensY.size(); ++param)
-	{
-		double* const sensY = vecSensY[param];
-		double* const sensYdot = vecSensYdot[param];
-
-		// Copy parameter derivative dF / dp from AD and negate it
-		for (unsigned int i = _nComp; i < numDofs(); ++i)
-			sensYdot[i] = -adRes[i].getADValue(param);
-
-		// Step 1: Solve algebraic equations
-
-		// Step 1a: Compute quasi-stationary binding model state
-		if (hasQSreactions)
-		{
-			double* const maskedMultiplier = static_cast<double*>(buffer);
-
-			linalg::DenseMatrixView jacobianMatrix(_jacFact.data(), _jacFact.pivotData(), probSize, probSize);
-			jacobianMatrix.setAll(0.0);
-
-			// Extract subproblem Jacobian from full Jacobian
-			linalg::copyMatrixSubset(_jac, mask, mask, _nComp, _nComp, jacobianMatrix, 0);
-
-			// Construct right hand side
-			linalg::selectVectorSubset(sensYdot + 2 * _nComp, mask, static_cast<double*>(rhs));
-
-			// Zero out masked elements
-			std::copy_n(sensY + _nComp, _nComp + _totalBound + 1, maskedMultiplier);
-			linalg::fillVectorSubset(maskedMultiplier + _nComp, mask, 0.0);
-
-			// Assemble right hand side
-			_jac.submatrixMultiplyVector(maskedMultiplier, _nComp, 0, _totalBound, _nComp + _totalBound + 1, static_cast<double*>(rhsUnmasked));
-			linalg::vectorSubsetAdd(static_cast<double*>(rhsUnmasked), mask, -1.0, 1.0, static_cast<double*>(rhs));
-
-			// Precondition
-			double* const scaleFactors = static_cast<double*>(buffer);
-			jacobianMatrix.rowScaleFactors(scaleFactors);
-			jacobianMatrix.scaleRows(scaleFactors);
-
-			// Solve
-			jacobianMatrix.factorize();
-			jacobianMatrix.solve(scaleFactors, static_cast<double*>(rhs));
-
-			// Write back
-			linalg::applyVectorSubset(static_cast<double*>(rhs), mask, sensY + 2 * _nComp);
-		}
-
-		// Step 2: Compute the correct time derivative of the state vector
-
-		// Step 2a: Assemble, factorize, and solve diagonal blocks of linear system
-
-		// Compute right hand side by adding -dF / dy * s = -J * s to -dF / dp which is already stored in sensYdot
-		multiplyWithJacobian(simTime, simState, sensY, -1.0, 1.0, sensYdot);
-
-		// Note that we have correctly negated the right hand side
-
-		// Assemble dF / dYdot
-		_jacFact.setAll(0.0);
-		addTimeDerivativeJacobian(simTime.t, 1.0, simState, _jacFact);
-
-		// Overwrite rows corresponding to algebraic equations with the Jacobian and set right hand side to 0
-		for (unsigned int type = 0; type < _nParType; ++type)
-		{
-			if (!_binding[type]->hasQuasiStationaryReactions())
-				continue;
-
-			double* const localQdot = sensYdot + 2 * _nComp + _offsetParType[type];
-			int const* const localMask = mask.mask + _offsetParType[type];
-			for (unsigned int i = 0; i < _strideBound[type]; ++i)
-			{
-				if (!localMask[i])
-					continue;
-
-				const unsigned int idx = _nComp + _offsetParType[type] + i;
-				_jacFact.copyRowFrom(_jac, idx, idx);
-
-				// Right hand side is -\frac{\partial^2 res(t, y, \dot{y})}{\partial p \partial t}
-				// If the residual is not explicitly depending on time, this expression is 0
-				// @todo This is wrong if external functions are used. Take that into account!
-				localQdot[i] = 0.0;
-			}
-		}
-
-		// Factorize
-		const bool result = _jacFact.robustFactorize(static_cast<double*>(buffer));
-		if (!result)
-		{
-			LOG(Error) << "Factorize() failed";
-		}
-
-		// Solve
-		const bool result2 = _jacFact.robustSolve(sensYdot + _nComp, static_cast<double*>(buffer));
-		if (!result2)
-		{
-			LOG(Error) << "Solve() failed";
-		}
-	}
-}
-
-void CSTRModel::multiplyWithJacobian(const SimulationTime& simTime, const ConstSimulationState& simState, double const* yS, double alpha, double beta, double* ret)
-{
-	const double flowIn = static_cast<double>(_flowRateIn);
-	double* const resTank = ret + _nComp;
-
-	// Inlet DOFs
-	for (unsigned int i = 0; i < _nComp; ++i)
-	{
-		ret[i] = alpha * yS[i] + beta * ret[i];
-	}
-
-	// Multiply with main body Jacobian: dRes / dy
-	_jac.multiplyVector(yS + _nComp, alpha, beta, resTank);
-
-	// Map inlet DOFs to the tank (tank cells)
-	for (unsigned int i = 0; i < _nComp; ++i)
-	{
-		resTank[i] -= alpha * flowIn * yS[i];
-	}
-}
-
-void CSTRModel::multiplyWithDerivativeJacobian(const SimulationTime& simTime, const ConstSimulationState& simState, double const* sDot, double* ret)
-{
-	// Handle inlet DOFs (all algebraic)
-	std::fill_n(ret, _nComp, 0.0);
-
-	// Handle actual ODE DOFs
-	double const* const c = simState.vecStateY + _nComp;
-	double const* const q = simState.vecStateY + 2 * _nComp;
-	const double v = simState.vecStateY[2 * _nComp + _totalBound];
-	const double timeV = v;
-	const double vSolid = static_cast<double>(_constSolidVolume);
-	double* const r = ret + _nComp;
-	double const* const s = sDot + _nComp;
-
-	// Concentrations: V^l * \dot{c}_i \dot{V^l} * c_i + V^s * ([sum_j sum_m d_j \dot{q}_{j,i,m}]) - c_{in,i} * F_in + c_i * F_out == 0
-	for (unsigned int i = 0; i < _nComp; ++i)
-	{
-		r[i] = timeV * s[i]; // dRes / dcDot
-
-		double qSum = 0.0;
-		for (unsigned int type = 0; type < _nParType; ++type)
-		{
-			double const* const qi = q + _offsetParType[type] + _boundOffset[type * _nComp + i];
-			const unsigned int localOffset = _nComp + _offsetParType[type] + _boundOffset[type * _nComp + i];
-			const double vSolidParVolFrac = vSolid * static_cast<double>(_parTypeVolFrac[type]);
-			double qSumType = 0.0;
-			for (unsigned int j = 0; j < _nBound[type * _nComp + i]; ++j)
-			{
-				r[i] += vSolidParVolFrac * s[localOffset + j]; // dRes / d_qDot
-				// + _nComp: Moves over liquid phase components
-				// + _offsetParType[type]: Moves to particle type
-				// + _boundOffset[i]: Moves over bound states of previous components
-				// + j: Moves to current bound state j of component i
-
-				qSumType += qi[j];
-			}
-
-			qSum += static_cast<double>(_parTypeVolFrac[type]) * qSumType;
-		}
-		r[i] += c[i] * s[_nComp + _totalBound]; // dRes / dvLiquidDot
-	}
-
-	// Bound states
-	for (unsigned int type = 0; type < _nParType; ++type)
-	{
-		// Jump to solid phase of current particle type
-		double* const rQ = r + _nComp + _offsetParType[type];
-		double const* const sQ = s + _nComp + _offsetParType[type];
-		std::fill_n(rQ, _strideBound[type], 0.0);
-
-		// Skip binding models without dynamic binding fluxes
-		IBindingModel* const binding = _binding[type];
-		if (!binding->hasDynamicReactions())
-			continue;
-
-		int const* const qsReaction = binding->reactionQuasiStationarity();
-		for (unsigned int idx = 0; idx < _strideBound[type]; ++idx)
-		{
-			// Skip quasi-stationary fluxes
-			if (qsReaction[idx])
-				continue;
-
-			rQ[idx] = sQ[idx];
-		}
-	}
-
-	// Volume: \dot{V} - F_{in} + F_{out} + F_{filter} == 0
-	r[_nComp + _totalBound] = s[_nComp + _totalBound];
-}
-
-int CSTRModel::linearSolve(double t, double alpha, double tol, double* const rhs, double const* const weight,
-	const ConstSimulationState& simState)
-{
-	const double flowIn = static_cast<double>(_flowRateIn);
-
-	// Handle inlet equations by backsubstitution
-	for (unsigned int i = 0; i < _nComp; ++i)
-	{
-		rhs[i + _nComp] += flowIn * rhs[i];
-	}
-
-	bool success = true;
-	if (_factorizeJac)
-	{
-		// Factorization is necessary
-		_factorizeJac = false;
-		_jacFact.copyFrom(_jac);
-
-		addTimeDerivativeJacobian(t, alpha, simState, _jacFact);
-		success = _jacFact.factorize();
-	}
-	success = success && _jacFact.solve(rhs + _nComp);
-
-	// Return 0 on success and 1 on failure
-	return success ? 0 : 1;
-}
-
-template <typename MatrixType>
-void CSTRModel::addTimeDerivativeJacobian(double t, double alpha, const ConstSimulationState& simState, MatrixType& mat)
-{
-	double const* const c = simState.vecStateY + _nComp;
-	double const* const q = simState.vecStateY + 2 * _nComp;
-	const double v = simState.vecStateY[2 * _nComp + _totalBound];
-	const double timeV = v * alpha;
-	const double timeVSolid = static_cast<double>(_constSolidVolume) * alpha;
-
-	// Assemble Jacobian: dRes / dyDot
-
-	// Concentrations: \dot{V^l} * c_i + V^l * \dot{c}_i + V^s * [sum_j sum_m d_j \dot{q}_{j,i,m}]) - c_{in,i} * F_in + c_i * F_out == 0
-
-	
-	if(_hasQuasiStationaryReactionBulk)
-	{ 
-		int  MoityIdx = 0;
-		for (unsigned int i = 0; i < _nComp; i++)
-		{
-			if (_QsCompBulk[i] == 0)
-			{
-				mat.native(i, i) += timeV; // dRes / dcDot
-			}
-			else if( MoityIdx >= _nConservedQuants)
-				continue;
-			else
-			{
-				//mat.native(state, state) += timeV * (static_cast<double>(_MconvMoityBulk(MoityIdx, MoityIdx))); // dRes / dcDot
-				for (int j = 0; j < _nComp; j++)
-				{
-					mat.native(i, j) += timeV * static_cast<double>(_MconvMoityBulk2(i, j)); // dRes / dcDot
-					mat.native(i, _nComp + _totalBound) += alpha * static_cast<double>(_MconvMoityBulk2(i, j)) * c[j]; // dRes / dVlDot
-				}
-				MoityIdx++;
-			}
-		}
-	
-	}else
-	{ 
-		for (unsigned int i = 0; i < _nComp; ++i)
-		{
-			mat.native(i, i) += timeV; // dRes / dcDot
-
-			double qSum = 0.0;
+			// Bound states
+			unsigned int globalIdx = _nComp;
 			for (unsigned int type = 0; type < _nParType; ++type)
 			{
-				double const* const qi = q + _offsetParType[type] + _boundOffset[type * _nComp + i];
-				const unsigned int localOffset = _nComp + _offsetParType[type] + _boundOffset[type * _nComp + i];
-				const double vSolidParVolFrac = timeVSolid * static_cast<double>(_parTypeVolFrac[type]);
-				for (unsigned int j = 0; j < _nBound[type * _nComp + i]; ++j)
+				IBindingModel* const binding = _binding[type];
+				if (!binding->hasDynamicReactions())
 				{
-					mat.native(i, localOffset + j) += vSolidParVolFrac; // dRes / dqDot
-					// + _nComp: Moves over liquid phase components
-					// + _offsetParType[type]: Moves to particle type
-					// + _boundOffset[i]: Moves over bound states of previous components
-					// + j: Moves to current bound state j of component i
+					// Skip binding models without dynamic binding fluxes
+					globalIdx += _strideBound[type];
+					continue;
+				}
 
+				int const* const qsReaction = binding->reactionQuasiStationarity();
+				for (unsigned int idx = 0; idx < _strideBound[type]; ++idx, ++globalIdx)
+				{
+					// Skip quasi-stationary fluxes
+					if (qsReaction[idx])
+						continue;
+
+					mat.native(globalIdx, globalIdx) += alpha;
 				}
 			}
 
-			mat.native(i, _nComp + _totalBound) += alpha * c[i]; // dRes / dVlDot
-		}
-	}
+			// Volume: \dot{V} - F_{in} + F_{out} + F_{filter} == 0
+			mat.native(_nComp + _totalBound, _nComp + _totalBound) += alpha;
 
-		// Bound states
-		unsigned int globalIdx = _nComp;
-		for (unsigned int type = 0; type < _nParType; ++type)
+			//std::cout << "Jacobian Derivative: " << std::endl;
+			//std::cout << "Before:" << std::endl;
+			//for (unsigned int i = 0; i < _nComp + 1; ++i)
+			//{
+			//	for (unsigned int j = 0; j < _nComp + 1; ++j)
+			//		std::cout << mat.native(i, j) << " ";
+			//	std::cout << std::endl;
+			//}
+
+			/*if (_hasQuasiStationaryReactionBulk)
+			{
+				EigenMatrixTimesDenseMatrix(_MconvMoityBulk, mat);
+			}*/
+
+		}
+
+
+		/*
+		* @brief Extracts the system Jacobian from AD seed vectors
+		* @param [in] adRes Residual vector of AD datatypes with band compressed seed vectors
+		* @param [in] adDirOffset Number of AD directions used for non-Jacobian purposes (e.g., parameter sensitivities)
+		*/
+		void CSTRModel::extractJacobianFromAD(active const* const adRes, unsigned int adDirOffset)
 		{
-			IBindingModel* const binding = _binding[type];
-			if (!binding->hasDynamicReactions())
-			{
-				// Skip binding models without dynamic binding fluxes
-				globalIdx += _strideBound[type];
-				continue;
-			}
-
-			int const* const qsReaction = binding->reactionQuasiStationarity();
-			for (unsigned int idx = 0; idx < _strideBound[type]; ++idx, ++globalIdx)
-			{
-				// Skip quasi-stationary fluxes
-				if (qsReaction[idx])
-					continue;
-
-				mat.native(globalIdx, globalIdx) += alpha;
-			}
+			ad::extractDenseJacobianFromAd(adRes + _nComp, adDirOffset, _jac);
 		}
-	
-	// Volume: \dot{V} - F_{in} + F_{out} + F_{filter} == 0
-	mat.native(_nComp + _totalBound, _nComp + _totalBound) += alpha;
-
-	//std::cout << "Jacobian Derivative: " << std::endl;
-	//std::cout << "Before:" << std::endl;
-	//for (unsigned int i = 0; i < _nComp + 1; ++i)
-	//{
-	//	for (unsigned int j = 0; j < _nComp + 1; ++j)
-	//		std::cout << mat.native(i, j) << " ";
-	//	std::cout << std::endl;
-	//}
-
-	/*if (_hasQuasiStationaryReactionBulk)
-	{
-		EigenMatrixTimesDemseMatrix(_MconvMoityBulk2, mat);
-	}*/
-
-	std::cout << "Jacobian Derivative: " << std::endl;
-	//std::cout << "Old:" << std::endl;
-	for (unsigned int i = 0; i < _nComp + 1; ++i)
-	{
-		for (unsigned int j = 0; j < _nComp + 1; ++j)
-			std::cout << mat.native(i, j) << " ";
-		std::cout << std::endl;
-	}
-	
-}
-
-
-/*
-* @brief Extracts the system Jacobian from AD seed vectors
-* @param [in] adRes Residual vector of AD datatypes with band compressed seed vectors
-* @param [in] adDirOffset Number of AD directions used for non-Jacobian purposes (e.g., parameter sensitivities)
-*/
-void CSTRModel::extractJacobianFromAD(active const* const adRes, unsigned int adDirOffset)
-{
-	ad::extractDenseJacobianFromAd(adRes + _nComp, adDirOffset, _jac);
-}
 
 #ifdef CADET_CHECK_ANALYTIC_JACOBIAN
 
-/**
-	* @brief Compares the analytical Jacobian with a Jacobian derived by AD
-	* @details The analytical Jacobian is assumed to be stored in the dense matrix.
-	* @param [in] adRes Residual vector of AD datatypes with band compressed seed vectors
-	* @param [in] adDirOffset Number of AD directions used for non-Jacobian purposes (e.g., parameter sensitivities)
-	*/
-void CSTRModel::checkAnalyticJacobianAgainstAd(active const* const adRes, unsigned int adDirOffset) const
-{
-	const double diff = ad::compareDenseJacobianWithAd(adRes + _nComp, adDirOffset, _jac);
-	LOG(Debug) << "AD dir offset: " << adDirOffset << " diff: " << diff;
-}
+		/**
+			* @brief Compares the analytical Jacobian with a Jacobian derived by AD
+			* @details The analytical Jacobian is assumed to be stored in the dense matrix.
+			* @param [in] adRes Residual vector of AD datatypes with band compressed seed vectors
+			* @param [in] adDirOffset Number of AD directions used for non-Jacobian purposes (e.g., parameter sensitivities)
+			*/
+		void CSTRModel::checkAnalyticJacobianAgainstAd(active const* const adRes, unsigned int adDirOffset) const
+		{
+			const double diff = ad::compareDenseJacobianWithAd(adRes + _nComp, adDirOffset, _jac);
+			LOG(Debug) << "AD dir offset: " << adDirOffset << " diff: " << diff;
+		}
 
 #endif
 
 
-unsigned int CSTRModel::Exporter::numSolidPhaseDofs() const CADET_NOEXCEPT
-{
-	return _totalBound;
-}
+		unsigned int CSTRModel::Exporter::numSolidPhaseDofs() const CADET_NOEXCEPT
+		{
+			return _totalBound;
+		}
 
-int CSTRModel::Exporter::writeMobilePhase(double* buffer) const
-{
-	std::copy_n(_data + _nComp, _nComp, buffer);
-	return _nComp;
-}
+		int CSTRModel::Exporter::writeMobilePhase(double* buffer) const
+		{
+			std::copy_n(_data + _nComp, _nComp, buffer);
+			return _nComp;
+		}
 
-int CSTRModel::Exporter::writeSolidPhase(double* buffer) const
-{
-	if (_totalBound == 0)
-		return 0;
+		int CSTRModel::Exporter::writeSolidPhase(double* buffer) const
+		{
+			if (_totalBound == 0)
+				return 0;
 
-	std::copy_n(_data + 2 * _nComp, _totalBound, buffer);
-	return _totalBound;
-}
+			std::copy_n(_data + 2 * _nComp, _totalBound, buffer);
+			return _totalBound;
+		}
 
-int CSTRModel::Exporter::writeSolidPhase(unsigned int parType, double* buffer) const
-{
-	if (_totalBound == 0)
-		return 0;
+		int CSTRModel::Exporter::writeSolidPhase(unsigned int parType, double* buffer) const
+		{
+			if (_totalBound == 0)
+				return 0;
 
-	cadet_assert(parType < _nParType);
+			cadet_assert(parType < _nParType);
 
-	unsigned int offset = 0;
-	for (int i = 0; i < parType; ++i)
-		offset += _strideBound[i];
+			unsigned int offset = 0;
+			for (int i = 0; i < parType; ++i)
+				offset += _strideBound[i];
 
-	std::copy_n(_data + 2 * _nComp + offset, _strideBound[parType], buffer);
-	return _strideBound[parType];
-}
+			std::copy_n(_data + 2 * _nComp + offset, _strideBound[parType], buffer);
+			return _strideBound[parType];
+		}
 
-int CSTRModel::Exporter::writeVolume(double* buffer) const
-{
-	*buffer = _data[2 * _nComp + _totalBound];
-	return 1;
-}
+		int CSTRModel::Exporter::writeVolume(double* buffer) const
+		{
+			*buffer = _data[2 * _nComp + _totalBound];
+			return 1;
+		}
 
-int CSTRModel::Exporter::writeInlet(unsigned int port, double* buffer) const
-{
-	cadet_assert(port == 0);
-	std::copy_n(_data, _nComp, buffer);
-	return _nComp;
-}
+		int CSTRModel::Exporter::writeInlet(unsigned int port, double* buffer) const
+		{
+			cadet_assert(port == 0);
+			std::copy_n(_data, _nComp, buffer);
+			return _nComp;
+		}
 
-int CSTRModel::Exporter::writeInlet(double* buffer) const
-{
-	std::copy_n(_data, _nComp, buffer);
-	return _nComp;
-}
+		int CSTRModel::Exporter::writeInlet(double* buffer) const
+		{
+			std::copy_n(_data, _nComp, buffer);
+			return _nComp;
+		}
 
-int CSTRModel::Exporter::writeOutlet(unsigned int port, double* buffer) const
-{
-	cadet_assert(port == 0);
-	std::copy_n(_data + _nComp, _nComp, buffer);
-	return _nComp;
-}
+		int CSTRModel::Exporter::writeOutlet(unsigned int port, double* buffer) const
+		{
+			cadet_assert(port == 0);
+			std::copy_n(_data + _nComp, _nComp, buffer);
+			return _nComp;
+		}
 
-int CSTRModel::Exporter::writeOutlet(double* buffer) const
-{
-	std::copy_n(_data + _nComp, _nComp, buffer);
-	return _nComp;
-}
+		int CSTRModel::Exporter::writeOutlet(double* buffer) const
+		{
+			std::copy_n(_data + _nComp, _nComp, buffer);
+			return _nComp;
+		}
 
 
 
-void registerCSTRModel(std::unordered_map<std::string, std::function<IUnitOperation*(UnitOpIdx, IParameterProvider&)>>& models)
-{
-	models[CSTRModel::identifier()] = [](UnitOpIdx uoId, IParameterProvider&) { return new CSTRModel(uoId); };
-}
+		void registerCSTRModel(std::unordered_map<std::string, std::function<IUnitOperation* (UnitOpIdx, IParameterProvider&)>>& models)
+		{
+			models[CSTRModel::identifier()] = [](UnitOpIdx uoId, IParameterProvider&) { return new CSTRModel(uoId); };
+		}
 
-}  // namespace model
+	}  // namespace model
 
 }  // namespace cadet

--- a/src/libcadet/model/StirredTankModel.hpp
+++ b/src/libcadet/model/StirredTankModel.hpp
@@ -179,10 +179,7 @@ namespace cadet
 
 			IDynamicReactionModel* _dynReactionBulk; //!< Dynamic reactions in the bulk volume
 
-			Eigen::Matrix<active, Eigen::Dynamic, Eigen::Dynamic> _MconvMoityBulk; //!<  Matrix with conservation of moieties in the bulk volume
 			bool _hasQuasiStationaryReactionBulk; //!< Flag that determines whether there are quasi-stationary reactions in the bulk volume
-			std::vector<int> _QsCompBulk; //!< Indices of components that are conserved in the bulk volume
-			int _nConservedQuants;
 
 			class Exporter : public ISolutionExporter
 			{

--- a/src/libcadet/model/StirredTankModel.hpp
+++ b/src/libcadet/model/StirredTankModel.hpp
@@ -171,7 +171,9 @@ protected:
 
 	IDynamicReactionModel* _dynReactionBulk; //!< Dynamic reactions in the bulk volume
 
-	// active* _temp;
+	active* _temp;
+	double* _temp2;
+
 	Eigen::MatrixXd _MconvMoityBulk; //!<  Matrix with conservation of moieties in the bulk volume
 	std::vector<int> _qsReacBulk; //!< Indices of components that are not conserved in the bulk volume
 	std::vector<int> _QsCompBulk;

--- a/src/libcadet/model/StirredTankModel.hpp
+++ b/src/libcadet/model/StirredTankModel.hpp
@@ -30,6 +30,7 @@
 
 namespace cadet
 {
+	struct ColumnPosition;
 
 namespace model
 {
@@ -77,7 +78,9 @@ public:
 
 	virtual int residual(const SimulationTime& simTime, const ConstSimulationState& simState, double* const res, util::ThreadLocalStorage& threadLocalMem);
 	virtual int residual(const SimulationTime& simTime, const ConstSimulationState& simState, double* const res, const AdJacobianParams& adJac, util::ThreadLocalStorage& threadLocalMem, bool updateJacobian, bool paramSensitivity);
-
+	
+	template <typename StateType, typename ResidualType, typename ParamType, bool wantJac>
+	void applyConservedMoitiesBulk(double t, unsigned int secIdx, const ColumnPosition& colPos, StateType const* const y, double const* const yDot, ResidualType* const resC, LinearBufferAllocator tlmAlloc);
 	virtual int jacobian(const SimulationTime& simTime, const ConstSimulationState& simState, double* const res, const AdJacobianParams& adJac, util::ThreadLocalStorage& threadLocalMem);
 	virtual int residualWithJacobian(const SimulationTime& simTime, const ConstSimulationState& simState, double* const res, const AdJacobianParams& adJac, util::ThreadLocalStorage& threadLocalMem);
 	virtual int residualSensFwdAdOnly(const SimulationTime& simTime, const ConstSimulationState& simState, active* const adRes, util::ThreadLocalStorage& threadLocalMem);
@@ -172,15 +175,11 @@ protected:
 
 	IDynamicReactionModel* _dynReactionBulk; //!< Dynamic reactions in the bulk volume
 
-	active* _temp;
-	double* _temp2;
-
 	Eigen::MatrixXd _MconvMoityBulk; //!<  Matrix with conservation of moieties in the bulk volume
-	int const* _qsReactionBulk; //!< Indices of components that are not conserved in the bulk volume
+	int const* _qsReactionBulk; //!< Indices of reactions that are not conserved in the bulk volume
+	bool _hasQuasiStationaryReactionBulk; //!< Flag that determines whether there are quasi-stationary reactions in the bulk volume
 	std::vector<int> _QsCompBulk; //!< Indices of components that are conserved in the bulk volume
-	unsigned int _nqsReactionBulk;
-	int _nMoitiesBulk;
-	std::vector<std::bitset<3>> stateMap; // !< Bitset that tracks the properties of the state vector (dynamic, moities, algebraic)
+	std::vector<std::bitset<3>> _stateMap; // !< Bitset that tracks the properties of the state vector (dynamic, moities, algebraic)
 
 	class Exporter : public ISolutionExporter
 	{

--- a/src/libcadet/model/StirredTankModel.hpp
+++ b/src/libcadet/model/StirredTankModel.hpp
@@ -81,7 +81,7 @@ namespace cadet
 			virtual int residual(const SimulationTime& simTime, const ConstSimulationState& simState, double* const res, const AdJacobianParams& adJac, util::ThreadLocalStorage& threadLocalMem, bool updateJacobian, bool paramSensitivity);
 
 			template <typename ResidualType>
-			void EigenMatrixTimesDenseMatrix(Eigen::Matrix<ResidualType, Eigen::Dynamic, Eigen::Dynamic> A, linalg::DenseMatrix& B);
+			void EigenMatrixTimesDenseMatrix(const Eigen::Matrix<ResidualType, Eigen::Dynamic, Eigen::Dynamic>& A, linalg::DenseMatrix& B);
 
 			template <typename StateType, typename ResidualType, typename ParamType, bool wantJac>
 			void applyConservedMoitiesBulk(double t, unsigned int secIdx, const ColumnPosition& colPos, StateType const* const y, double const* const yDot, ResidualType* const resC, LinearBufferAllocator tlmAlloc);

--- a/src/libcadet/model/StirredTankModel.hpp
+++ b/src/libcadet/model/StirredTankModel.hpp
@@ -176,9 +176,9 @@ protected:
 	double* _temp2;
 
 	Eigen::MatrixXd _MconvMoityBulk; //!<  Matrix with conservation of moieties in the bulk volume
-	std::vector<int> _qsReacBulk; //!< Indices of components that are not conserved in the bulk volume
-	std::vector<int> _QsCompBulk;
-	unsigned int _nQsReacBulk;
+	int const* _qsReactionBulk; //!< Indices of components that are not conserved in the bulk volume
+	std::vector<int> _QsCompBulk; //!< Indices of components that are conserved in the bulk volume
+	unsigned int _nqsReactionBulk;
 	int _nMoitiesBulk;
 
 	class Exporter : public ISolutionExporter

--- a/src/libcadet/model/StirredTankModel.hpp
+++ b/src/libcadet/model/StirredTankModel.hpp
@@ -100,7 +100,6 @@ public:
 
 	virtual void leanConsistentInitialState(const SimulationTime& simTime, double* const vecStateY, const AdJacobianParams& adJac, double errorTol, util::ThreadLocalStorage& threadLocalMem);
 	virtual void leanConsistentInitialTimeDerivative(double time, double const* const vecStateY, double* const vecStateYdot, double* const res, util::ThreadLocalStorage& threadLocalMem);
-	virtual void leanConsistentInitialTimeDerivative(const SimulationTime& simTime, double const* const vecStateY, double* const vecStateYdot, double* const res, util::ThreadLocalStorage& threadLocalMem) {};
 
 	virtual void leanConsistentInitialSensitivity(const SimulationTime& simTime, const ConstSimulationState& simState,
 		std::vector<double*>& vecSensY, std::vector<double*>& vecSensYdot, active const* const adRes, util::ThreadLocalStorage& threadLocalMem);

--- a/src/libcadet/model/StirredTankModel.hpp
+++ b/src/libcadet/model/StirredTankModel.hpp
@@ -31,7 +31,7 @@
 
 namespace cadet
 {
-	struct ColumnPosition;
+struct ColumnPosition;
 
 namespace model
 {
@@ -183,7 +183,7 @@ protected:
 	IDynamicReactionModel* _dynReactionBulk; //!< Dynamic reactions in the bulk volume
 
 	Eigen::MatrixXd _MconvMoityBulk; //!<  Matrix with conservation of moieties in the bulk volume
-	Eigen::MatrixXd _MconvMoityBulk2; //!<  Matrix with conservation of moieties in the bulk volume
+	Eigen::Matrix<active, Eigen::Dynamic, Eigen::Dynamic> _MconvMoityBulk2; //!<  Matrix with conservation of moieties in the bulk volume
 	int const* _qsReactionBulk; //!< Indices of reactions that are not conserved in the bulk volume
 	bool _hasQuasiStationaryReactionBulk; //!< Flag that determines whether there are quasi-stationary reactions in the bulk volume
 	std::vector<int> _QsCompBulk; //!< Indices of components that are conserved in the bulk volume

--- a/src/libcadet/model/StirredTankModel.hpp
+++ b/src/libcadet/model/StirredTankModel.hpp
@@ -171,6 +171,13 @@ protected:
 
 	IDynamicReactionModel* _dynReactionBulk; //!< Dynamic reactions in the bulk volume
 
+	// active* _temp;
+	Eigen::MatrixXd _MconvMoityBulk; //!<  Matrix with conservation of moieties in the bulk volume
+	std::vector<int> _qsReacBulk; //!< Indices of components that are not conserved in the bulk volume
+	std::vector<int> _QsCompBulk;
+	unsigned int _nQsReacBulk;
+	unsigned int _nMoitiesBulk;
+
 	class Exporter : public ISolutionExporter
 	{
 	public:

--- a/src/libcadet/model/StirredTankModel.hpp
+++ b/src/libcadet/model/StirredTankModel.hpp
@@ -31,230 +31,224 @@
 
 namespace cadet
 {
-struct ColumnPosition;
+	struct ColumnPosition;
 
-namespace model
-{
+	namespace model
+	{
 
-/**
- * @brief Continuous stirred tank (reactor) model
- * @details This is a simple CSTR with variable porosity model with variable volume using the ``well mixed assumption''.
- * @f[\begin{align}
-	\frac{\mathrm{d}}{\mathrm{d} t}\left( V^l c_i \right) + V^s \sum_{j=1}^{N_{\text{bnd},i}} q_{i,j} &= F_{\text{in}} c_{\text{in},i} - F_{\text{out}} c_i \\
-	a \frac{\partial q_{i,j}}{\partial t} &= f_{\text{iso},i,j}(c, q) \\
-	\frac{\partial V^l}{\partial t} &= F_{\text{in}} - F_{\text{out}} - F_{\text{filter}}
-\end{align} @f]
- * The model can be used as a plain stir tank without any binding states.
- */
-class CSTRModel : public UnitOperationBase
-{
-public:
+		/**
+		 * @brief Continuous stirred tank (reactor) model
+		 * @details This is a simple CSTR with variable porosity model with variable volume using the ``well mixed assumption''.
+		 * @f[\begin{align}
+			\frac{\mathrm{d}}{\mathrm{d} t}\left( V^l c_i \right) + V^s \sum_{j=1}^{N_{\text{bnd},i}} q_{i,j} &= F_{\text{in}} c_{\text{in},i} - F_{\text{out}} c_i \\
+			a \frac{\partial q_{i,j}}{\partial t} &= f_{\text{iso},i,j}(c, q) \\
+			\frac{\partial V^l}{\partial t} &= F_{\text{in}} - F_{\text{out}} - F_{\text{filter}}
+		\end{align} @f]
+		 * The model can be used as a plain stir tank without any binding states.
+		 */
+		class CSTRModel : public UnitOperationBase
+		{
+		public:
 
-	CSTRModel(UnitOpIdx unitOpIdx);
-	virtual ~CSTRModel() CADET_NOEXCEPT;
+			CSTRModel(UnitOpIdx unitOpIdx);
+			virtual ~CSTRModel() CADET_NOEXCEPT;
 
-	virtual unsigned int numDofs() const CADET_NOEXCEPT;
-	virtual unsigned int numPureDofs() const CADET_NOEXCEPT;
-	virtual bool usesAD() const CADET_NOEXCEPT;
-	virtual unsigned int requiredADdirs() const CADET_NOEXCEPT;
+			virtual unsigned int numDofs() const CADET_NOEXCEPT;
+			virtual unsigned int numPureDofs() const CADET_NOEXCEPT;
+			virtual bool usesAD() const CADET_NOEXCEPT;
+			virtual unsigned int requiredADdirs() const CADET_NOEXCEPT;
 
-	virtual UnitOpIdx unitOperationId() const CADET_NOEXCEPT { return _unitOpIdx; }
-	virtual unsigned int numComponents() const CADET_NOEXCEPT { return _nComp; }
-	virtual void setFlowRates(active const* in, active const* out) CADET_NOEXCEPT;
-	virtual unsigned int numInletPorts() const CADET_NOEXCEPT { return 1; }
-	virtual unsigned int numOutletPorts() const CADET_NOEXCEPT { return 1; }
-	virtual bool canAccumulate() const CADET_NOEXCEPT { return true; }
+			virtual UnitOpIdx unitOperationId() const CADET_NOEXCEPT { return _unitOpIdx; }
+			virtual unsigned int numComponents() const CADET_NOEXCEPT { return _nComp; }
+			virtual void setFlowRates(active const* in, active const* out) CADET_NOEXCEPT;
+			virtual unsigned int numInletPorts() const CADET_NOEXCEPT { return 1; }
+			virtual unsigned int numOutletPorts() const CADET_NOEXCEPT { return 1; }
+			virtual bool canAccumulate() const CADET_NOEXCEPT { return true; }
 
-	static const char* identifier() { return "CSTR"; }
-	virtual const char* unitOperationName() const CADET_NOEXCEPT { return identifier(); }
+			static const char* identifier() { return "CSTR"; }
+			virtual const char* unitOperationName() const CADET_NOEXCEPT { return identifier(); }
 
-	virtual bool configureModelDiscretization(IParameterProvider& paramProvider, const IConfigHelper& helper);
-	virtual bool configure(IParameterProvider& paramProvider);
-	virtual void notifyDiscontinuousSectionTransition(double t, unsigned int secIdx, const ConstSimulationState& simState, const AdJacobianParams& adJac);
+			virtual bool configureModelDiscretization(IParameterProvider& paramProvider, const IConfigHelper& helper);
+			virtual bool configure(IParameterProvider& paramProvider);
+			virtual void notifyDiscontinuousSectionTransition(double t, unsigned int secIdx, const ConstSimulationState& simState, const AdJacobianParams& adJac);
 
-	virtual void useAnalyticJacobian(const bool analyticJac);
+			virtual void useAnalyticJacobian(const bool analyticJac);
 
-	virtual void reportSolution(ISolutionRecorder& recorder, double const* const solution) const;
-	virtual void reportSolutionStructure(ISolutionRecorder& recorder) const;
+			virtual void reportSolution(ISolutionRecorder& recorder, double const* const solution) const;
+			virtual void reportSolutionStructure(ISolutionRecorder& recorder) const;
 
-	virtual int residual(const SimulationTime& simTime, const ConstSimulationState& simState, double* const res, util::ThreadLocalStorage& threadLocalMem);
-	virtual int residual(const SimulationTime& simTime, const ConstSimulationState& simState, double* const res, const AdJacobianParams& adJac, util::ThreadLocalStorage& threadLocalMem, bool updateJacobian, bool paramSensitivity);
-	
-	template <typename ResidualType>
-	void EigenMatrixTimesDemseMatrix(Eigen::Matrix<ResidualType, Eigen::Dynamic, Eigen::Dynamic> A, linalg::DenseMatrix& B);
+			virtual int residual(const SimulationTime& simTime, const ConstSimulationState& simState, double* const res, util::ThreadLocalStorage& threadLocalMem);
+			virtual int residual(const SimulationTime& simTime, const ConstSimulationState& simState, double* const res, const AdJacobianParams& adJac, util::ThreadLocalStorage& threadLocalMem, bool updateJacobian, bool paramSensitivity);
 
-	template <typename StateType, typename ResidualType, typename ParamType, bool wantJac>
-	void applyConservedMoitiesBulk(double t, unsigned int secIdx, const ColumnPosition& colPos, StateType const* const y, double const* const yDot, ResidualType* const resC, LinearBufferAllocator tlmAlloc);
-	template <typename StateType, typename ResidualType, typename ParamType, bool wantJac>
-	void applyConservedMoitiesBulk2(double t, unsigned int secIdx, const ColumnPosition& colPos, StateType const* const y, double const* const yDot, ResidualType* const resC, LinearBufferAllocator tlmAlloc);
+			template <typename ResidualType>
+			void EigenMatrixTimesDenseMatrix(Eigen::Matrix<ResidualType, Eigen::Dynamic, Eigen::Dynamic> A, linalg::DenseMatrix& B);
 
-	virtual int jacobian(const SimulationTime& simTime, const ConstSimulationState& simState, double* const res, const AdJacobianParams& adJac, util::ThreadLocalStorage& threadLocalMem);
-	virtual int residualWithJacobian(const SimulationTime& simTime, const ConstSimulationState& simState, double* const res, const AdJacobianParams& adJac, util::ThreadLocalStorage& threadLocalMem);
-	virtual int residualSensFwdAdOnly(const SimulationTime& simTime, const ConstSimulationState& simState, active* const adRes, util::ThreadLocalStorage& threadLocalMem);
-	virtual int residualSensFwdWithJacobian(const SimulationTime& simTime, const ConstSimulationState& simState, const AdJacobianParams& adJac, util::ThreadLocalStorage& threadLocalMem);
+			template <typename StateType, typename ResidualType, typename ParamType, bool wantJac>
+			void applyConservedMoitiesBulk(double t, unsigned int secIdx, const ColumnPosition& colPos, StateType const* const y, double const* const yDot, ResidualType* const resC, LinearBufferAllocator tlmAlloc);
 
-	virtual int linearSolve(double t, double alpha, double tol, double* const rhs, double const* const weight,
-		const ConstSimulationState& simState);
+			virtual int jacobian(const SimulationTime& simTime, const ConstSimulationState& simState, double* const res, const AdJacobianParams& adJac, util::ThreadLocalStorage& threadLocalMem);
+			virtual int residualWithJacobian(const SimulationTime& simTime, const ConstSimulationState& simState, double* const res, const AdJacobianParams& adJac, util::ThreadLocalStorage& threadLocalMem);
+			virtual int residualSensFwdAdOnly(const SimulationTime& simTime, const ConstSimulationState& simState, active* const adRes, util::ThreadLocalStorage& threadLocalMem);
+			virtual int residualSensFwdWithJacobian(const SimulationTime& simTime, const ConstSimulationState& simState, const AdJacobianParams& adJac, util::ThreadLocalStorage& threadLocalMem);
 
-	virtual void prepareADvectors(const AdJacobianParams& adJac) const;
+			virtual int linearSolve(double t, double alpha, double tol, double* const rhs, double const* const weight,
+				const ConstSimulationState& simState);
 
-	virtual void applyInitialCondition(const SimulationState& simState) const;
-	virtual void readInitialCondition(IParameterProvider& paramProvider);
+			virtual void prepareADvectors(const AdJacobianParams& adJac) const;
 
-	virtual void consistentInitialState(const SimulationTime& simTime, double* const vecStateY, const AdJacobianParams& adJac, double errorTol, util::ThreadLocalStorage& threadLocalMem);
-	virtual void consistentInitialTimeDerivative(const SimulationTime& simTime, double const* vecStateY, double* const vecStateYdot, util::ThreadLocalStorage& threadLocalMem);
-	
-	virtual void initializeSensitivityStates(const std::vector<double*>& vecSensY) const;
-	virtual void consistentInitialSensitivity(const SimulationTime& simTime, const ConstSimulationState& simState,
-		std::vector<double*>& vecSensY, std::vector<double*>& vecSensYdot, active const* const adRes, util::ThreadLocalStorage& threadLocalMem);
+			virtual void applyInitialCondition(const SimulationState& simState) const;
+			virtual void readInitialCondition(IParameterProvider& paramProvider);
 
-	virtual void leanConsistentInitialState(const SimulationTime& simTime, double* const vecStateY, const AdJacobianParams& adJac, double errorTol, util::ThreadLocalStorage& threadLocalMem);
-	virtual void leanConsistentInitialTimeDerivative(double time, double const* const vecStateY, double* const vecStateYdot, double* const res, util::ThreadLocalStorage& threadLocalMem);
+			virtual void consistentInitialState(const SimulationTime& simTime, double* const vecStateY, const AdJacobianParams& adJac, double errorTol, util::ThreadLocalStorage& threadLocalMem);
+			virtual void consistentInitialTimeDerivative(const SimulationTime& simTime, double const* vecStateY, double* const vecStateYdot, util::ThreadLocalStorage& threadLocalMem);
+			virtual void initializeSensitivityStates(const std::vector<double*>& vecSensY) const;
+			virtual void consistentInitialSensitivity(const SimulationTime& simTime, const ConstSimulationState& simState,
+				std::vector<double*>& vecSensY, std::vector<double*>& vecSensYdot, active const* const adRes, util::ThreadLocalStorage& threadLocalMem);
 
-	virtual void leanConsistentInitialSensitivity(const SimulationTime& simTime, const ConstSimulationState& simState,
-		std::vector<double*>& vecSensY, std::vector<double*>& vecSensYdot, active const* const adRes, util::ThreadLocalStorage& threadLocalMem);
+			virtual void leanConsistentInitialState(const SimulationTime& simTime, double* const vecStateY, const AdJacobianParams& adJac, double errorTol, util::ThreadLocalStorage& threadLocalMem);
+			virtual void leanConsistentInitialTimeDerivative(double time, double const* const vecStateY, double* const vecStateYdot, double* const res, util::ThreadLocalStorage& threadLocalMem);
 
-	virtual void setExternalFunctions(IExternalFunction** extFuns, unsigned int size) { }
+			virtual void leanConsistentInitialSensitivity(const SimulationTime& simTime, const ConstSimulationState& simState,
+				std::vector<double*>& vecSensY, std::vector<double*>& vecSensYdot, active const* const adRes, util::ThreadLocalStorage& threadLocalMem);
 
-	virtual void multiplyWithJacobian(const SimulationTime& simTime, const ConstSimulationState& simState, double const* yS, double alpha, double beta, double* ret);
-	virtual void multiplyWithDerivativeJacobian(const SimulationTime& simTime, const ConstSimulationState& simState, double const* sDot, double* ret);
+			virtual void setExternalFunctions(IExternalFunction** extFuns, unsigned int size) { }
 
-	virtual bool hasInlet() const CADET_NOEXCEPT { return true; }
-	virtual bool hasOutlet() const CADET_NOEXCEPT { return true; }
+			virtual void multiplyWithJacobian(const SimulationTime& simTime, const ConstSimulationState& simState, double const* yS, double alpha, double beta, double* ret);
+			virtual void multiplyWithDerivativeJacobian(const SimulationTime& simTime, const ConstSimulationState& simState, double const* sDot, double* ret);
 
-	virtual unsigned int localOutletComponentIndex(unsigned int port) const CADET_NOEXCEPT { return _nComp; }
-	virtual unsigned int localOutletComponentStride(unsigned int port) const CADET_NOEXCEPT { return 1; }
-	virtual unsigned int localInletComponentIndex(unsigned int port) const CADET_NOEXCEPT { return 0; }
-	virtual unsigned int localInletComponentStride(unsigned int port) const CADET_NOEXCEPT { return 1; }
+			virtual bool hasInlet() const CADET_NOEXCEPT { return true; }
+			virtual bool hasOutlet() const CADET_NOEXCEPT { return true; }
 
-	virtual void setSectionTimes(double const* secTimes, bool const* secContinuity, unsigned int nSections);
+			virtual unsigned int localOutletComponentIndex(unsigned int port) const CADET_NOEXCEPT { return _nComp; }
+			virtual unsigned int localOutletComponentStride(unsigned int port) const CADET_NOEXCEPT { return 1; }
+			virtual unsigned int localInletComponentIndex(unsigned int port) const CADET_NOEXCEPT { return 0; }
+			virtual unsigned int localInletComponentStride(unsigned int port) const CADET_NOEXCEPT { return 1; }
 
-	virtual void expandErrorTol(double const* errorSpec, unsigned int errorSpecSize, double* expandOut) { }
+			virtual void setSectionTimes(double const* secTimes, bool const* secContinuity, unsigned int nSections);
 
-	virtual unsigned int threadLocalMemorySize() const CADET_NOEXCEPT;
+			virtual void expandErrorTol(double const* errorSpec, unsigned int errorSpecSize, double* expandOut) { }
+
+			virtual unsigned int threadLocalMemorySize() const CADET_NOEXCEPT;
 
 #ifdef CADET_BENCHMARK_MODE
-	virtual std::vector<double> benchmarkTimings() const { return std::vector<double>(0); }
-	virtual char const* const* benchmarkDescriptions() const { return nullptr; }
+			virtual std::vector<double> benchmarkTimings() const { return std::vector<double>(0); }
+			virtual char const* const* benchmarkDescriptions() const { return nullptr; }
 #endif
 
-	inline const std::vector<active>& flowRateFilter() const { return _flowRateFilter; }
-	inline std::vector<active>& flowRateFilter() { return _flowRateFilter; }
-	inline void flowRateFilter(const std::vector<active>& frf) { _flowRateFilter = frf; }
-	inline void setFlowRates(double in, double out) CADET_NOEXCEPT { _flowRateIn = in; _flowRateOut = out; }
+			inline const std::vector<active>& flowRateFilter() const { return _flowRateFilter; }
+			inline std::vector<active>& flowRateFilter() { return _flowRateFilter; }
+			inline void flowRateFilter(const std::vector<active>& frf) { _flowRateFilter = frf; }
+			inline void setFlowRates(double in, double out) CADET_NOEXCEPT { _flowRateIn = in; _flowRateOut = out; }
 
-protected:
+		protected:
 
-	template <typename StateType, typename ResidualType, typename ParamType, bool wantJac>
-	int residualImpl(double t, unsigned int secIdx, StateType const* const y, double const* const yDot, ResidualType* const res, LinearBufferAllocator threadLocalMem);
+			template <typename StateType, typename ResidualType, typename ParamType, bool wantJac>
+			int residualImpl(double t, unsigned int secIdx, StateType const* const y, double const* const yDot, ResidualType* const res, LinearBufferAllocator threadLocalMem);
 
-	template <typename MatrixType>
-	void addTimeDerivativeJacobian(double t, double alpha, const ConstSimulationState& simState, MatrixType& mat);
+			template <typename MatrixType>
+			void addTimeDerivativeJacobian(double t, double alpha, const ConstSimulationState& simState, MatrixType& mat);
 
-	void extractJacobianFromAD(active const* const adRes, unsigned int adDirOffset);
+			void extractJacobianFromAD(active const* const adRes, unsigned int adDirOffset);
 #ifdef CADET_CHECK_ANALYTIC_JACOBIAN
-	void checkAnalyticJacobianAgainstAd(active const* const adRes, unsigned int adDirOffset) const;
+			void checkAnalyticJacobianAgainstAd(active const* const adRes, unsigned int adDirOffset) const;
 #endif
 
-	unsigned int _nComp; //!< Number of components
-	unsigned int _nParType; //!< Number of particle types
-	unsigned int* _nBound; //!< Array with number of bound states for each component in each particle type
-	unsigned int* _boundOffset; //!< Array with offset to the first bound state of each component in the solid phase for each particle type
-	unsigned int* _strideBound; //!< Total number of bound states per particle type
-	unsigned int* _offsetParType; //!< Offset to bound states of a particle type in solid phase
-	unsigned int _totalBound; //!< Total number of all bound states in all particle types
+			unsigned int _nComp; //!< Number of components
+			unsigned int _nParType; //!< Number of particle types
+			unsigned int* _nBound; //!< Array with number of bound states for each component in each particle type
+			unsigned int* _boundOffset; //!< Array with offset to the first bound state of each component in the solid phase for each particle type
+			unsigned int* _strideBound; //!< Total number of bound states per particle type
+			unsigned int* _offsetParType; //!< Offset to bound states of a particle type in solid phase
+			unsigned int _totalBound; //!< Total number of all bound states in all particle types
 
-	active _constSolidVolume; //!< Solid volume \f$ V^s \f$
-	active _flowRateIn; //!< Volumetric flow rate of incoming stream
-	active _flowRateOut; //!< Volumetric flow rate of drawn outgoing stream
-	active _curFlowRateFilter; //!< Current volumetric flow rate of liquid outtake stream for this section
-	unsigned int _curSecIdx; //!< Current section index
-	std::vector<active> _flowRateFilter; //!< Volumetric flow rate of liquid outtake stream
-	std::vector<active> _parTypeVolFrac; //!< Volume fraction of each particle type
+			active _constSolidVolume; //!< Solid volume \f$ V^s \f$
+			active _flowRateIn; //!< Volumetric flow rate of incoming stream
+			active _flowRateOut; //!< Volumetric flow rate of drawn outgoing stream
+			active _curFlowRateFilter; //!< Current volumetric flow rate of liquid outtake stream for this section
+			unsigned int _curSecIdx; //!< Current section index
+			std::vector<active> _flowRateFilter; //!< Volumetric flow rate of liquid outtake stream
+			std::vector<active> _parTypeVolFrac; //!< Volume fraction of each particle type
 
-	bool _analyticJac; //!< Flag that determines whether analytic or AD Jacobian is used
-	linalg::DenseMatrix _jac; //!< Jacobian
-	linalg::DenseMatrix _jacFact; //!< Factorized Jacobian
-	bool _factorizeJac; //!< Flag that tracks whether the Jacobian needs to be factorized
+			bool _analyticJac; //!< Flag that determines whether analytic or AD Jacobian is used
+			linalg::DenseMatrix _jac; //!< Jacobian
+			linalg::DenseMatrix _jacFact; //!< Factorized Jacobian
+			bool _factorizeJac; //!< Flag that tracks whether the Jacobian needs to be factorized
 
-	std::vector<active> _initConditions; //!< Initial conditions, ordering: Liquid phase concentration, solid phase concentration, liquid volume
-	std::vector<double> _initConditionsDot; //!< Initial conditions for time derivative
+			std::vector<active> _initConditions; //!< Initial conditions, ordering: Liquid phase concentration, solid phase concentration, liquid volume
+			std::vector<double> _initConditionsDot; //!< Initial conditions for time derivative
 
-	IDynamicReactionModel* _dynReactionBulk; //!< Dynamic reactions in the bulk volume
+			IDynamicReactionModel* _dynReactionBulk; //!< Dynamic reactions in the bulk volume
 
-	Eigen::MatrixXd _MconvMoityBulk; //!<  Matrix with conservation of moieties in the bulk volume
-	Eigen::Matrix<active, Eigen::Dynamic, Eigen::Dynamic> _MconvMoityBulk2; //!<  Matrix with conservation of moieties in the bulk volume
-	int const* _qsReactionBulk; //!< Indices of reactions that are not conserved in the bulk volume
-	bool _hasQuasiStationaryReactionBulk; //!< Flag that determines whether there are quasi-stationary reactions in the bulk volume
-	std::vector<int> _QsCompBulk; //!< Indices of components that are conserved in the bulk volume
-	int _nConservedQuants;
-	std::vector<std::bitset<3>> _stateMap; // !< Bitset that tracks the properties of the state vector (dynamic, moities, algebraic)
+			Eigen::Matrix<active, Eigen::Dynamic, Eigen::Dynamic> _MconvMoityBulk; //!<  Matrix with conservation of moieties in the bulk volume
+			bool _hasQuasiStationaryReactionBulk; //!< Flag that determines whether there are quasi-stationary reactions in the bulk volume
+			std::vector<int> _QsCompBulk; //!< Indices of components that are conserved in the bulk volume
+			int _nConservedQuants;
 
-	class Exporter : public ISolutionExporter
-	{
-	public:
+			class Exporter : public ISolutionExporter
+			{
+			public:
 
-		Exporter(unsigned int nComp, unsigned int nParType, unsigned int const* nBound, unsigned int const* strideBound, unsigned int const* boundOffset, unsigned int totalBound, double const* data)
-			: _data(data), _nComp(nComp), _nParType(nParType), _nBound(nBound), _strideBound(strideBound), _boundOffset(boundOffset), _totalBound(totalBound) { }
+				Exporter(unsigned int nComp, unsigned int nParType, unsigned int const* nBound, unsigned int const* strideBound, unsigned int const* boundOffset, unsigned int totalBound, double const* data)
+					: _data(data), _nComp(nComp), _nParType(nParType), _nBound(nBound), _strideBound(strideBound), _boundOffset(boundOffset), _totalBound(totalBound) { }
 
-		virtual bool hasParticleFlux() const CADET_NOEXCEPT { return false; }
-		virtual bool hasParticleMobilePhase() const CADET_NOEXCEPT { return false; }
-		virtual bool hasSolidPhase() const CADET_NOEXCEPT { return _totalBound > 0; }
-		virtual bool hasVolume() const CADET_NOEXCEPT { return true; }
-		virtual bool isParticleLumped() const CADET_NOEXCEPT { return true; }
-		virtual bool hasPrimaryExtent() const CADET_NOEXCEPT { return false; }
+				virtual bool hasParticleFlux() const CADET_NOEXCEPT { return false; }
+				virtual bool hasParticleMobilePhase() const CADET_NOEXCEPT { return false; }
+				virtual bool hasSolidPhase() const CADET_NOEXCEPT { return _totalBound > 0; }
+				virtual bool hasVolume() const CADET_NOEXCEPT { return true; }
+				virtual bool isParticleLumped() const CADET_NOEXCEPT { return true; }
+				virtual bool hasPrimaryExtent() const CADET_NOEXCEPT { return false; }
 
-		virtual unsigned int numComponents() const CADET_NOEXCEPT { return _nComp; }
-		virtual unsigned int numPrimaryCoordinates() const CADET_NOEXCEPT { return 1; }
-		virtual unsigned int numSecondaryCoordinates() const CADET_NOEXCEPT { return 0; }
-		virtual unsigned int numInletPorts() const CADET_NOEXCEPT { return 1; }
-		virtual unsigned int numOutletPorts() const CADET_NOEXCEPT { return 1; }
-		virtual unsigned int numParticleTypes() const CADET_NOEXCEPT { return _nParType; }
-		virtual unsigned int numParticleShells(unsigned int parType) const CADET_NOEXCEPT { return 0; }
-		virtual unsigned int numBoundStates(unsigned int parType) const CADET_NOEXCEPT { return _strideBound[parType]; }
-		virtual unsigned int numMobilePhaseDofs() const CADET_NOEXCEPT { return _nComp; }
-		virtual unsigned int numParticleMobilePhaseDofs() const CADET_NOEXCEPT { return 0; }
-		virtual unsigned int numParticleMobilePhaseDofs(unsigned int parType) const CADET_NOEXCEPT { return 0; }
-		virtual unsigned int numSolidPhaseDofs() const CADET_NOEXCEPT;
-		virtual unsigned int numSolidPhaseDofs(unsigned int parType) const CADET_NOEXCEPT { return _strideBound[parType]; }
-		virtual unsigned int numParticleFluxDofs() const CADET_NOEXCEPT { return 0; }
-		virtual unsigned int numVolumeDofs() const CADET_NOEXCEPT { return 1; }
+				virtual unsigned int numComponents() const CADET_NOEXCEPT { return _nComp; }
+				virtual unsigned int numPrimaryCoordinates() const CADET_NOEXCEPT { return 1; }
+				virtual unsigned int numSecondaryCoordinates() const CADET_NOEXCEPT { return 0; }
+				virtual unsigned int numInletPorts() const CADET_NOEXCEPT { return 1; }
+				virtual unsigned int numOutletPorts() const CADET_NOEXCEPT { return 1; }
+				virtual unsigned int numParticleTypes() const CADET_NOEXCEPT { return _nParType; }
+				virtual unsigned int numParticleShells(unsigned int parType) const CADET_NOEXCEPT { return 0; }
+				virtual unsigned int numBoundStates(unsigned int parType) const CADET_NOEXCEPT { return _strideBound[parType]; }
+				virtual unsigned int numMobilePhaseDofs() const CADET_NOEXCEPT { return _nComp; }
+				virtual unsigned int numParticleMobilePhaseDofs() const CADET_NOEXCEPT { return 0; }
+				virtual unsigned int numParticleMobilePhaseDofs(unsigned int parType) const CADET_NOEXCEPT { return 0; }
+				virtual unsigned int numSolidPhaseDofs() const CADET_NOEXCEPT;
+				virtual unsigned int numSolidPhaseDofs(unsigned int parType) const CADET_NOEXCEPT { return _strideBound[parType]; }
+				virtual unsigned int numParticleFluxDofs() const CADET_NOEXCEPT { return 0; }
+				virtual unsigned int numVolumeDofs() const CADET_NOEXCEPT { return 1; }
 
-		virtual int writeMobilePhase(double* buffer) const;
-		virtual int writeSolidPhase(double* buffer) const;
-		virtual int writeSolidPhase(unsigned int parType, double* buffer) const;
-		virtual int writeParticleMobilePhase(double* buffer) const { return 0; }
-		virtual int writeParticleMobilePhase(unsigned int parType, double* buffer) const { return 0; }
-		virtual int writeParticleFlux(double* buffer) const { return 0; }
-		virtual int writeParticleFlux(unsigned int parType, double* buffer) const { return 0; }
-		virtual int writeVolume(double* buffer) const;
-		virtual int writeInlet(unsigned int port, double* buffer) const;
-		virtual int writeInlet(double* buffer) const;
-		virtual int writeOutlet(unsigned int port, double* buffer) const;
-		virtual int writeOutlet(double* buffer) const;
+				virtual int writeMobilePhase(double* buffer) const;
+				virtual int writeSolidPhase(double* buffer) const;
+				virtual int writeSolidPhase(unsigned int parType, double* buffer) const;
+				virtual int writeParticleMobilePhase(double* buffer) const { return 0; }
+				virtual int writeParticleMobilePhase(unsigned int parType, double* buffer) const { return 0; }
+				virtual int writeParticleFlux(double* buffer) const { return 0; }
+				virtual int writeParticleFlux(unsigned int parType, double* buffer) const { return 0; }
+				virtual int writeVolume(double* buffer) const;
+				virtual int writeInlet(unsigned int port, double* buffer) const;
+				virtual int writeInlet(double* buffer) const;
+				virtual int writeOutlet(unsigned int port, double* buffer) const;
+				virtual int writeOutlet(double* buffer) const;
 
-		virtual double const* solidPhase(unsigned int parType) const { return _data + 2 * _nComp; }
+				virtual double const* solidPhase(unsigned int parType) const { return _data + 2 * _nComp; }
 
-		virtual int writePrimaryCoordinates(double* coords) const
-		{
-			coords[0] = 0.0;
-			return 1;
-		}
-		virtual int writeSecondaryCoordinates(double* coords) const { return 0; }
-		virtual int writeParticleCoordinates(unsigned int parType, double* coords) const { return 0; }
+				virtual int writePrimaryCoordinates(double* coords) const
+				{
+					coords[0] = 0.0;
+					return 1;
+				}
+				virtual int writeSecondaryCoordinates(double* coords) const { return 0; }
+				virtual int writeParticleCoordinates(unsigned int parType, double* coords) const { return 0; }
 
-	protected:
-		double const* const _data;
-		unsigned int _nComp;
-		unsigned int _nParType;
-		unsigned int const* _nBound;
-		unsigned int const* _strideBound;
-		unsigned int const* _boundOffset;
-		unsigned int _totalBound;
-	};
-};
+			protected:
+				double const* const _data;
+				unsigned int _nComp;
+				unsigned int _nParType;
+				unsigned int const* _nBound;
+				unsigned int const* _strideBound;
+				unsigned int const* _boundOffset;
+				unsigned int _totalBound;
+			};
+		};
 
-} // namespace model
+	} // namespace model
 } // namespace cadet
 
 #endif  // LIBCADET_CSTR_HPP_

--- a/src/libcadet/model/StirredTankModel.hpp
+++ b/src/libcadet/model/StirredTankModel.hpp
@@ -27,6 +27,7 @@
 #include <bitset>
 #include <array>
 #include <vector>
+#include <Eigen/Dense>
 
 namespace cadet
 {
@@ -79,6 +80,9 @@ public:
 	virtual int residual(const SimulationTime& simTime, const ConstSimulationState& simState, double* const res, util::ThreadLocalStorage& threadLocalMem);
 	virtual int residual(const SimulationTime& simTime, const ConstSimulationState& simState, double* const res, const AdJacobianParams& adJac, util::ThreadLocalStorage& threadLocalMem, bool updateJacobian, bool paramSensitivity);
 	
+	template <typename ResidualType>
+	void EigenMatrixTimesDemseMatrix(Eigen::Matrix<ResidualType, Eigen::Dynamic, Eigen::Dynamic> A, linalg::DenseMatrix& B);
+
 	template <typename StateType, typename ResidualType, typename ParamType, bool wantJac>
 	void applyConservedMoitiesBulk(double t, unsigned int secIdx, const ColumnPosition& colPos, StateType const* const y, double const* const yDot, ResidualType* const resC, LinearBufferAllocator tlmAlloc);
 	template <typename StateType, typename ResidualType, typename ParamType, bool wantJac>
@@ -179,9 +183,11 @@ protected:
 	IDynamicReactionModel* _dynReactionBulk; //!< Dynamic reactions in the bulk volume
 
 	Eigen::MatrixXd _MconvMoityBulk; //!<  Matrix with conservation of moieties in the bulk volume
+	Eigen::MatrixXd _MconvMoityBulk2; //!<  Matrix with conservation of moieties in the bulk volume
 	int const* _qsReactionBulk; //!< Indices of reactions that are not conserved in the bulk volume
 	bool _hasQuasiStationaryReactionBulk; //!< Flag that determines whether there are quasi-stationary reactions in the bulk volume
 	std::vector<int> _QsCompBulk; //!< Indices of components that are conserved in the bulk volume
+	int _nConservedQuants;
 	std::vector<std::bitset<3>> _stateMap; // !< Bitset that tracks the properties of the state vector (dynamic, moities, algebraic)
 
 	class Exporter : public ISolutionExporter

--- a/src/libcadet/model/StirredTankModel.hpp
+++ b/src/libcadet/model/StirredTankModel.hpp
@@ -24,7 +24,7 @@
 #include "linalg/DenseMatrix.hpp"
 #include "model/ModelUtils.hpp"
 #include "Memory.hpp"
-
+#include <bitset>
 #include <array>
 #include <vector>
 
@@ -180,6 +180,7 @@ protected:
 	std::vector<int> _QsCompBulk; //!< Indices of components that are conserved in the bulk volume
 	unsigned int _nqsReactionBulk;
 	int _nMoitiesBulk;
+	std::vector<std::bitset<3>> stateMap; // !< Bitset that tracks the properties of the state vector (dynamic, moities, algebraic)
 
 	class Exporter : public ISolutionExporter
 	{

--- a/src/libcadet/model/StirredTankModel.hpp
+++ b/src/libcadet/model/StirredTankModel.hpp
@@ -99,8 +99,9 @@ public:
 		std::vector<double*>& vecSensY, std::vector<double*>& vecSensYdot, active const* const adRes, util::ThreadLocalStorage& threadLocalMem);
 
 	virtual void leanConsistentInitialState(const SimulationTime& simTime, double* const vecStateY, const AdJacobianParams& adJac, double errorTol, util::ThreadLocalStorage& threadLocalMem);
-	virtual void leanConsistentInitialTimeDerivative(double t, double const* const vecStateY, double* const vecStateYdot, double* const res, util::ThreadLocalStorage& threadLocalMem);
-	
+	virtual void leanConsistentInitialTimeDerivative(double time, double const* const vecStateY, double* const vecStateYdot, double* const res, util::ThreadLocalStorage& threadLocalMem);
+	virtual void leanConsistentInitialTimeDerivative(const SimulationTime& simTime, double const* const vecStateY, double* const vecStateYdot, double* const res, util::ThreadLocalStorage& threadLocalMem) {};
+
 	virtual void leanConsistentInitialSensitivity(const SimulationTime& simTime, const ConstSimulationState& simState,
 		std::vector<double*>& vecSensY, std::vector<double*>& vecSensYdot, active const* const adRes, util::ThreadLocalStorage& threadLocalMem);
 
@@ -158,6 +159,7 @@ protected:
 	active _flowRateIn; //!< Volumetric flow rate of incoming stream
 	active _flowRateOut; //!< Volumetric flow rate of drawn outgoing stream
 	active _curFlowRateFilter; //!< Current volumetric flow rate of liquid outtake stream for this section
+	unsigned int _curSecIdx; //!< Current section index
 	std::vector<active> _flowRateFilter; //!< Volumetric flow rate of liquid outtake stream
 	std::vector<active> _parTypeVolFrac; //!< Volume fraction of each particle type
 
@@ -178,7 +180,7 @@ protected:
 	std::vector<int> _qsReacBulk; //!< Indices of components that are not conserved in the bulk volume
 	std::vector<int> _QsCompBulk;
 	unsigned int _nQsReacBulk;
-	unsigned int _nMoitiesBulk;
+	int _nMoitiesBulk;
 
 	class Exporter : public ISolutionExporter
 	{

--- a/src/libcadet/model/StirredTankModel.hpp
+++ b/src/libcadet/model/StirredTankModel.hpp
@@ -81,6 +81,9 @@ public:
 	
 	template <typename StateType, typename ResidualType, typename ParamType, bool wantJac>
 	void applyConservedMoitiesBulk(double t, unsigned int secIdx, const ColumnPosition& colPos, StateType const* const y, double const* const yDot, ResidualType* const resC, LinearBufferAllocator tlmAlloc);
+	template <typename StateType, typename ResidualType, typename ParamType, bool wantJac>
+	void applyConservedMoitiesBulk2(double t, unsigned int secIdx, const ColumnPosition& colPos, StateType const* const y, double const* const yDot, ResidualType* const resC, LinearBufferAllocator tlmAlloc);
+
 	virtual int jacobian(const SimulationTime& simTime, const ConstSimulationState& simState, double* const res, const AdJacobianParams& adJac, util::ThreadLocalStorage& threadLocalMem);
 	virtual int residualWithJacobian(const SimulationTime& simTime, const ConstSimulationState& simState, double* const res, const AdJacobianParams& adJac, util::ThreadLocalStorage& threadLocalMem);
 	virtual int residualSensFwdAdOnly(const SimulationTime& simTime, const ConstSimulationState& simState, active* const adRes, util::ThreadLocalStorage& threadLocalMem);

--- a/src/libcadet/model/UnitOperation.hpp
+++ b/src/libcadet/model/UnitOperation.hpp
@@ -498,8 +498,6 @@ public:
 	 * @param [in] res On entry, residual without taking time derivatives into account. The data is overwritten during execution of the function.
 	 */
 	virtual void leanConsistentInitialTimeDerivative(double t, double const* const vecStateY, double* const vecStateYdot, double* const res, util::ThreadLocalStorage& threadLocalMem) = 0;
-	virtual void leanConsistentInitialTimeDerivative(const SimulationTime& simTime, double const* const vecStateY, double* const vecStateYdot, double* const res, util::ThreadLocalStorage& threadLocalMem) = 0;
-
 	/**
 	 * @brief Computes consistent initial conditions for all sensitivity subsystems
 	 * @details Given the DAE \f[ F(t, y, \dot{y}, p) = 0, \f] the corresponding (linear) forward sensitivity

--- a/src/libcadet/model/UnitOperation.hpp
+++ b/src/libcadet/model/UnitOperation.hpp
@@ -498,6 +498,7 @@ public:
 	 * @param [in] res On entry, residual without taking time derivatives into account. The data is overwritten during execution of the function.
 	 */
 	virtual void leanConsistentInitialTimeDerivative(double t, double const* const vecStateY, double* const vecStateYdot, double* const res, util::ThreadLocalStorage& threadLocalMem) = 0;
+	virtual void leanConsistentInitialTimeDerivative(const SimulationTime& simTime, double const* const vecStateY, double* const vecStateYdot, double* const res, util::ThreadLocalStorage& threadLocalMem) = 0;
 
 	/**
 	 * @brief Computes consistent initial conditions for all sensitivity subsystems

--- a/src/libcadet/model/parts/ConvectionDispersionOperator.hpp
+++ b/src/libcadet/model/parts/ConvectionDispersionOperator.hpp
@@ -44,6 +44,7 @@ namespace model
 {
 
 class IParameterParameterDependence;
+class IDynamicReactionModel;
 
 namespace parts
 {
@@ -115,6 +116,8 @@ public:
 	bool setSensitiveParameter(std::unordered_set<active*>& sensParams, const ParameterId& pId, unsigned int adDirection, double adValue);
 	bool setSensitiveParameterValue(const std::unordered_set<active*>& sensParams, const ParameterId& id, double value);
 
+	inline void setDynamicReactionBulk(IDynamicReactionModel* dynReactionBulk) CADET_NOEXCEPT;
+
 protected:
 
 	template <typename StateType, typename ResidualType, typename ParamType, typename RowIteratorType, bool wantJac, bool wantRes = true>
@@ -142,6 +145,8 @@ protected:
 
 	IParameterParameterDependence* _dispersionDep;
 
+	IDynamicReactionModel* _dynReactionBulk; //!< Dynamic reactions in the bulk volume
+	bool _hasQuasiStationaryReactions;
 	// Indexer functionality
 
 	// Strides
@@ -336,6 +341,9 @@ public:
 	{
 		return _baseOp.setSensitiveParameterValue(sensParams, id, value);
 	}
+
+	inline void setDynamicReactionBulk(IDynamicReactionModel* dynReactionBulk) CADET_NOEXCEPT {};
+
 
 protected:
 

--- a/src/libcadet/model/reaction/CrystallizationReaction.cpp
+++ b/src/libcadet/model/reaction/CrystallizationReaction.cpp
@@ -208,7 +208,6 @@ namespace cadet
 				Eigen::Map<Eigen::Vector<ResidualType, Eigen::Dynamic>> fluxes, LinearBufferAllocator workSpace){return 0;}
 
 			virtual int const* reactionQuasiStationarity() const CADET_NOEXCEPT { return nullptr; }
-			virtual void timeDerivativeQuasiStationaryReaction(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double* dReacDt, LinearBufferAllocator workSpace){ }
 			virtual bool configure(IParameterProvider& paramProvider, UnitOpIdx unitOpIdx, ParticleTypeIdx parTypeIdx)
 			{
 				readScalarParameterOrArray(_bins, paramProvider, "CRY_BINS", 1);

--- a/src/libcadet/model/reaction/CrystallizationReaction.cpp
+++ b/src/libcadet/model/reaction/CrystallizationReaction.cpp
@@ -348,7 +348,7 @@ namespace cadet
 			virtual unsigned int numReactionsCombined() const CADET_NOEXCEPT { return 1; }
 			virtual unsigned int numReactionQuasiStationary() const CADET_NOEXCEPT { return 0; }
 			template <typename ResidualType>
-			void fillConservedMoietiesBulk21(Eigen::Matrix<ResidualType, Eigen::Dynamic, Eigen::Dynamic>& M, std::vector<int>& QsCompBulk) {}
+			void fillConservedMoietiesBulk21(Eigen::Matrix<ResidualType, Eigen::Dynamic, Eigen::Dynamic>& M, int& QsCompBulk) {}
 
 			CADET_DYNAMICREACTIONMODEL_BOILERPLATE
 

--- a/src/libcadet/model/reaction/CrystallizationReaction.cpp
+++ b/src/libcadet/model/reaction/CrystallizationReaction.cpp
@@ -197,19 +197,20 @@ namespace cadet
 
 			virtual bool requiresConfiguration() const CADET_NOEXCEPT { return true; }
 			virtual bool usesParamProviderInDiscretizationConfig() const CADET_NOEXCEPT { return false; }
-			void fillConservedMoietiesBulk(Eigen::MatrixXd& M, std::vector<int>& QSReaction, std::vector<int>& QSComponent) { }
-			bool hasQuasiStationaryReactionsLiquid() { return false; }
+			void fillConservedMoietiesBulk(Eigen::MatrixXd& M, std::vector<int>& QSReaction, std::vector<int>& QSComponent) {}
 
 			template <typename RowIterator>
-			void jacobianQuasiSteadyLiquidImpl(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double factor, const RowIterator& jac, LinearBufferAllocator workSpace) const { }
-			
+			void jacobianQuasiSteadyLiquidImpl(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction,  const RowIterator& jac, LinearBufferAllocator workSpace) const { }
+
 			virtual int quasiStationaryFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, active const* y,
-				double* fluxes, std::vector<int> mapQSReac, LinearBufferAllocator workSpace) { return 0; }
-
+				Eigen::Map<Eigen::VectorXd> fluxes, std::vector<int> mapQSReac, LinearBufferAllocator workSpace) {
+				return 0;
+			}
 			virtual int quasiStationaryFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,
-				double* fluxes, std::vector<int> mapQSReac, LinearBufferAllocator workSpace) { return 0; }
-
-			
+				Eigen::Map<Eigen::VectorXd> fluxes, std::vector<int> mapQSReac, LinearBufferAllocator workSpace) {
+				return 0;
+			}
+			virtual void timeDerivativeQuasiStationaryReaction(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double* dReacDt, LinearBufferAllocator workSpace){ }
 			virtual bool configure(IParameterProvider& paramProvider, UnitOpIdx unitOpIdx, ParticleTypeIdx parTypeIdx)
 			{
 				readScalarParameterOrArray(_bins, paramProvider, "CRY_BINS", 1);

--- a/src/libcadet/model/reaction/CrystallizationReaction.cpp
+++ b/src/libcadet/model/reaction/CrystallizationReaction.cpp
@@ -199,8 +199,17 @@ namespace cadet
 			virtual bool usesParamProviderInDiscretizationConfig() const CADET_NOEXCEPT { return false; }
 			void fillConservedMoietiesBulk(Eigen::MatrixXd& M, std::vector<int>& QSReaction, std::vector<int>& QSComponent) { }
 			bool hasQuasiStationaryReactionsLiquid() { return false; }
+
+			template <typename RowIterator>
+			void jacobianQuasiSteadyLiquidImpl(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double factor, const RowIterator& jac, LinearBufferAllocator workSpace) const { }
+			
+			virtual int quasiStationaryFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, active const* y,
+				double* fluxes, std::vector<int> mapQSReac, LinearBufferAllocator workSpace) { return 0; }
+
 			virtual int quasiStationaryFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,
-				active* fluxes, std::vector<int>& mapQSReac, LinearBufferAllocator workSpace) const { return 0; }
+				double* fluxes, std::vector<int> mapQSReac, LinearBufferAllocator workSpace) { return 0; }
+
+			
 			virtual bool configure(IParameterProvider& paramProvider, UnitOpIdx unitOpIdx, ParticleTypeIdx parTypeIdx)
 			{
 				readScalarParameterOrArray(_bins, paramProvider, "CRY_BINS", 1);

--- a/src/libcadet/model/reaction/CrystallizationReaction.cpp
+++ b/src/libcadet/model/reaction/CrystallizationReaction.cpp
@@ -202,6 +202,9 @@ namespace cadet
 			template <typename RowIterator>
 			void jacobianQuasiSteadyLiquidImpl(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction,  const RowIterator& jac, LinearBufferAllocator workSpace) const { }
 
+			template <typename RowIterator>
+			void jacobianSingleFluxImpl(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction, const RowIterator& jac, LinearBufferAllocator workSpace) const { }
+
 			virtual int quasiStationaryFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, active const* y,
 				Eigen::Map<Eigen::VectorXd> fluxes, std::vector<int> mapQSReac, LinearBufferAllocator workSpace) {
 				return 0;

--- a/src/libcadet/model/reaction/CrystallizationReaction.cpp
+++ b/src/libcadet/model/reaction/CrystallizationReaction.cpp
@@ -198,14 +198,14 @@ namespace cadet
 			virtual bool requiresConfiguration() const CADET_NOEXCEPT { return true; }
 			virtual bool usesParamProviderInDiscretizationConfig() const CADET_NOEXCEPT { return false; }
 			template <typename RowIterator>
-			void jacobianQuasiSteadyLiquidImpl(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction,  const RowIterator& jac, LinearBufferAllocator workSpace) const { }
+			void jacobianQuasiStationaryBulkImpl(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction,  const RowIterator& jac, LinearBufferAllocator workSpace) const { }
 
 			template <typename RowIterator>
 			void jacobianSingleFluxImpl(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction, const RowIterator& jac, LinearBufferAllocator workSpace) const { }
 
 			template<typename StateType, typename ResidualType>
 			int quasiStationaryFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, StateType const* y,
-				Eigen::Map<Eigen::Vector<ResidualType, Eigen::Dynamic>> fluxes, int const* mapQSReac, LinearBufferAllocator workSpace){return 0;}
+				Eigen::Map<Eigen::Vector<ResidualType, Eigen::Dynamic>> fluxes, LinearBufferAllocator workSpace){return 0;}
 
 			virtual int const* reactionQuasiStationarity() const CADET_NOEXCEPT { return nullptr; }
 			virtual void timeDerivativeQuasiStationaryReaction(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double* dReacDt, LinearBufferAllocator workSpace){ }
@@ -347,8 +347,8 @@ namespace cadet
 			virtual unsigned int numReactionsLiquid() const CADET_NOEXCEPT { return 1; }
 			virtual unsigned int numReactionsCombined() const CADET_NOEXCEPT { return 1; }
 			virtual unsigned int numReactionQuasiStationary() const CADET_NOEXCEPT { return 0; }
-			template <typename ResidualType>
-			void fillConservedMoietiesBulk21(Eigen::Matrix<ResidualType, Eigen::Dynamic, Eigen::Dynamic>& M, int& QsCompBulk) {}
+			template<typename ResidualType>
+			void ConservedMoietiesBulk(Eigen::Matrix<ResidualType, Eigen::Dynamic, Eigen::Dynamic>& M, int& conservedState, std::vector<int>& QsCompBulk) {}
 
 			CADET_DYNAMICREACTIONMODEL_BOILERPLATE
 

--- a/src/libcadet/model/reaction/CrystallizationReaction.cpp
+++ b/src/libcadet/model/reaction/CrystallizationReaction.cpp
@@ -346,6 +346,9 @@ namespace cadet
 
 			virtual unsigned int numReactionsLiquid() const CADET_NOEXCEPT { return 1; }
 			virtual unsigned int numReactionsCombined() const CADET_NOEXCEPT { return 1; }
+			virtual unsigned int numReactionQuasiStationary() const CADET_NOEXCEPT { return 0; }
+			template <typename ResidualType>
+			void fillConservedMoietiesBulk21(Eigen::Matrix<ResidualType, Eigen::Dynamic, Eigen::Dynamic>& M, std::vector<int>& QsCompBulk) {}
 
 			CADET_DYNAMICREACTIONMODEL_BOILERPLATE
 

--- a/src/libcadet/model/reaction/CrystallizationReaction.cpp
+++ b/src/libcadet/model/reaction/CrystallizationReaction.cpp
@@ -197,22 +197,16 @@ namespace cadet
 
 			virtual bool requiresConfiguration() const CADET_NOEXCEPT { return true; }
 			virtual bool usesParamProviderInDiscretizationConfig() const CADET_NOEXCEPT { return false; }
-			void fillConservedMoietiesBulk(Eigen::MatrixXd& M, unsigned int& QSReaction, std::vector<int>& QSComponent) {}
-
 			template <typename RowIterator>
 			void jacobianQuasiSteadyLiquidImpl(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction,  const RowIterator& jac, LinearBufferAllocator workSpace) const { }
 
 			template <typename RowIterator>
 			void jacobianSingleFluxImpl(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction, const RowIterator& jac, LinearBufferAllocator workSpace) const { }
 
-			virtual int quasiStationaryFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, active const* y,
-				Eigen::Map<Eigen::VectorXd> fluxes, int const* mapQSReac, LinearBufferAllocator workSpace) {
-				return 0;
-			}
-			virtual int quasiStationaryFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,
-				Eigen::Map<Eigen::VectorXd> fluxes, int const* mapQSReac, LinearBufferAllocator workSpace) {
-				return 0;
-			}
+			template<typename StateType, typename ResidualType>
+			int quasiStationaryFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, StateType const* y,
+				Eigen::Map<Eigen::Vector<ResidualType, Eigen::Dynamic>> fluxes, int const* mapQSReac, LinearBufferAllocator workSpace){return 0;}
+
 			virtual int const* reactionQuasiStationarity() const CADET_NOEXCEPT { return nullptr; }
 			virtual void timeDerivativeQuasiStationaryReaction(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double* dReacDt, LinearBufferAllocator workSpace){ }
 			virtual bool configure(IParameterProvider& paramProvider, UnitOpIdx unitOpIdx, ParticleTypeIdx parTypeIdx)

--- a/src/libcadet/model/reaction/CrystallizationReaction.cpp
+++ b/src/libcadet/model/reaction/CrystallizationReaction.cpp
@@ -197,7 +197,7 @@ namespace cadet
 
 			virtual bool requiresConfiguration() const CADET_NOEXCEPT { return true; }
 			virtual bool usesParamProviderInDiscretizationConfig() const CADET_NOEXCEPT { return false; }
-			void fillConservedMoietiesBulk(Eigen::MatrixXd& M, std::vector<int>& QSReaction, std::vector<int>& QSComponent) {}
+			void fillConservedMoietiesBulk(Eigen::MatrixXd& M, unsigned int& QSReaction, std::vector<int>& QSComponent) {}
 
 			template <typename RowIterator>
 			void jacobianQuasiSteadyLiquidImpl(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction,  const RowIterator& jac, LinearBufferAllocator workSpace) const { }
@@ -206,13 +206,14 @@ namespace cadet
 			void jacobianSingleFluxImpl(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction, const RowIterator& jac, LinearBufferAllocator workSpace) const { }
 
 			virtual int quasiStationaryFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, active const* y,
-				Eigen::Map<Eigen::VectorXd> fluxes, std::vector<int> mapQSReac, LinearBufferAllocator workSpace) {
+				Eigen::Map<Eigen::VectorXd> fluxes, int const* mapQSReac, LinearBufferAllocator workSpace) {
 				return 0;
 			}
 			virtual int quasiStationaryFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,
-				Eigen::Map<Eigen::VectorXd> fluxes, std::vector<int> mapQSReac, LinearBufferAllocator workSpace) {
+				Eigen::Map<Eigen::VectorXd> fluxes, int const* mapQSReac, LinearBufferAllocator workSpace) {
 				return 0;
 			}
+			virtual int const* reactionQuasiStationarity() const CADET_NOEXCEPT { return nullptr; }
 			virtual void timeDerivativeQuasiStationaryReaction(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double* dReacDt, LinearBufferAllocator workSpace){ }
 			virtual bool configure(IParameterProvider& paramProvider, UnitOpIdx unitOpIdx, ParticleTypeIdx parTypeIdx)
 			{

--- a/src/libcadet/model/reaction/CrystallizationReaction.cpp
+++ b/src/libcadet/model/reaction/CrystallizationReaction.cpp
@@ -197,7 +197,10 @@ namespace cadet
 
 			virtual bool requiresConfiguration() const CADET_NOEXCEPT { return true; }
 			virtual bool usesParamProviderInDiscretizationConfig() const CADET_NOEXCEPT { return false; }
-
+			void fillConservedMoietiesBulk(Eigen::MatrixXd& M, std::vector<int>& QSReaction, std::vector<int>& QSComponent) { }
+			bool hasQuasiStationaryReactionsLiquid() { return false; }
+			virtual int quasiStationaryFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,
+				active* fluxes, std::vector<int>& mapQSReac, LinearBufferAllocator workSpace) const { return 0; }
 			virtual bool configure(IParameterProvider& paramProvider, UnitOpIdx unitOpIdx, ParticleTypeIdx parTypeIdx)
 			{
 				readScalarParameterOrArray(_bins, paramProvider, "CRY_BINS", 1);

--- a/src/libcadet/model/reaction/DummyReaction.cpp
+++ b/src/libcadet/model/reaction/DummyReaction.cpp
@@ -130,7 +130,7 @@ public:
 	virtual unsigned int numReactionsCombined() const CADET_NOEXCEPT { return 0; }
 	virtual unsigned int numReactionQuasiStationary() const CADET_NOEXCEPT { return 0; }
 	template <typename ResidualType>
-	void fillConservedMoietiesBulk21(Eigen::Matrix<ResidualType, Eigen::Dynamic, Eigen::Dynamic>& M, std::vector<int>& QsCompBulk) {}
+	void fillConservedMoietiesBulk21(Eigen::Matrix<ResidualType, Eigen::Dynamic, Eigen::Dynamic>& M, int& QsCompBulk) {}
 protected:
 };
 

--- a/src/libcadet/model/reaction/DummyReaction.cpp
+++ b/src/libcadet/model/reaction/DummyReaction.cpp
@@ -87,7 +87,7 @@ public:
 	virtual void analyticJacobianLiquidSingleFluxAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction, linalg::BandedSparseRowIterator jac, LinearBufferAllocator workSpace)  const { }
 
 	virtual void timeDerivativeQuasiStationaryReaction(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double* dReacDt, LinearBufferAllocator workSpace) { }
-
+	virtual int const* reactionQuasiStationarity() const CADET_NOEXCEPT { return nullptr; }
 	#ifdef ENABLE_DG
 	virtual void analyticJacobianLiquidAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double factor, linalg::BandedEigenSparseRowIterator jac, LinearBufferAllocator workSpace) const { }
 	#endif
@@ -111,14 +111,14 @@ public:
 	virtual unsigned int numReactionsLiquid() const CADET_NOEXCEPT { return 0; }
 	virtual unsigned int numReactionsCombined() const CADET_NOEXCEPT { return 0; }
 	
-	void fillConservedMoietiesBulk(Eigen::MatrixXd& M, std::vector<int>& QSReaction, std::vector<int>& QSComponent) {}
+	void fillConservedMoietiesBulk(Eigen::MatrixXd& M, unsigned int & QSReaction, std::vector<int>& QSComponent) {}
 	bool hasQuasiStationaryReactionsLiquid() { return false;}
 	
 	virtual int quasiStationaryFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, active const* y,
-		Eigen::Map<Eigen::VectorXd> fluxes, std::vector<int> mapQSReac, LinearBufferAllocator workSpace) { return 0; }
+		Eigen::Map<Eigen::VectorXd> fluxes, int const* mapQSReac, LinearBufferAllocator workSpace) { return 0; }
 
 	virtual int quasiStationaryFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,
-		Eigen::Map<Eigen::VectorXd> fluxes, std::vector<int> mapQSReac, LinearBufferAllocator workSpace) { return 0; }
+		Eigen::Map<Eigen::VectorXd> fluxes, int const* mapQSReac, LinearBufferAllocator workSpace) { return 0; }
 
 protected:
 };

--- a/src/libcadet/model/reaction/DummyReaction.cpp
+++ b/src/libcadet/model/reaction/DummyReaction.cpp
@@ -78,9 +78,9 @@ public:
 	virtual void analyticJacobianLiquidAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double factor, linalg::DenseBandedRowIterator jac, LinearBufferAllocator workSpace) const { }
 	virtual void analyticJacobianLiquidAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double factor, linalg::BandedSparseRowIterator jac, LinearBufferAllocator workSpace) const { }
 	
-	virtual void analyticQuasiSteadyJacobianLiquid(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction, linalg::BandMatrix::RowIterator jac, LinearBufferAllocator workSpace) const { }
-	virtual void analyticQuasiSteadyJacobianLiquid(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction, linalg::DenseBandedRowIterator jac, LinearBufferAllocator workSpace) const { }
-	virtual void analyticQuasiSteadyJacobianLiquid(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction, linalg::BandedSparseRowIterator jac, LinearBufferAllocator workSpace) const { }
+	virtual void analyticJacobianQuasiStationaryReaction(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction, linalg::BandMatrix::RowIterator jac, LinearBufferAllocator workSpace) const { }
+	virtual void analyticJacobianQuasiStationaryReaction(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction, linalg::DenseBandedRowIterator jac, LinearBufferAllocator workSpace) const { }
+	virtual void analyticJacobianQuasiStationaryReaction(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction, linalg::BandedSparseRowIterator jac, LinearBufferAllocator workSpace) const { }
 	
 	virtual void analyticJacobianLiquidSingleFluxAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction, linalg::BandMatrix::RowIterator jac, LinearBufferAllocator workSpace)  const { }
 	virtual void analyticJacobianLiquidSingleFluxAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction, linalg::DenseBandedRowIterator jac, LinearBufferAllocator workSpace)  const { }
@@ -107,18 +107,27 @@ public:
 	#ifdef ENABLE_DG
 	virtual void analyticJacobianCombinedAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* yLiquid, double const* ySolid, double factor, linalg::BandedEigenSparseRowIterator jacLiquid, linalg::DenseBandedRowIterator jacSolid, LinearBufferAllocator workSpace) const { }
 	#endif
+	virtual int computeQuasiStationaryReactionFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, active const* y,
+		Eigen::Map<Eigen::Vector<active, Eigen::Dynamic>> fluxes, int const* mapQSReac, LinearBufferAllocator workSpace) {
+		return 0;
+	}
+	virtual int computeQuasiStationaryReactionFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,
+		Eigen::Map<Eigen::Vector<active, Eigen::Dynamic>> fluxes, int const* mapQSReac, LinearBufferAllocator workSpace) {
+		return 0;
+	}
+
+	virtual int computeQuasiStationaryReactionFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, active const* y,
+		Eigen::Map<Eigen::Vector<double, Eigen::Dynamic>> fluxes, int const* mapQSReac, LinearBufferAllocator workSpace) {
+		return 0;
+	}
+
+	virtual int computeQuasiStationaryReactionFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,
+		Eigen::Map<Eigen::Vector<double, Eigen::Dynamic>> fluxes, int const* mapQSReac, LinearBufferAllocator workSpace) {
+		return 0;
+	}
 
 	virtual unsigned int numReactionsLiquid() const CADET_NOEXCEPT { return 0; }
 	virtual unsigned int numReactionsCombined() const CADET_NOEXCEPT { return 0; }
-	
-	void fillConservedMoietiesBulk(Eigen::MatrixXd& M, unsigned int & QSReaction, std::vector<int>& QSComponent) {}
-	bool hasQuasiStationaryReactionsLiquid() { return false;}
-	
-	virtual int quasiStationaryFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, active const* y,
-		Eigen::Map<Eigen::VectorXd> fluxes, int const* mapQSReac, LinearBufferAllocator workSpace) { return 0; }
-
-	virtual int quasiStationaryFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,
-		Eigen::Map<Eigen::VectorXd> fluxes, int const* mapQSReac, LinearBufferAllocator workSpace) { return 0; }
 
 protected:
 };

--- a/src/libcadet/model/reaction/DummyReaction.cpp
+++ b/src/libcadet/model/reaction/DummyReaction.cpp
@@ -82,7 +82,6 @@ public:
 	virtual void analyticJacobianQuasiStationaryReaction(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction, linalg::DenseBandedRowIterator jac, LinearBufferAllocator workSpace) const { }
 	virtual void analyticJacobianQuasiStationaryReaction(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction, linalg::BandedSparseRowIterator jac, LinearBufferAllocator workSpace) const { }
 	
-	virtual void timeDerivativeQuasiStationaryReaction(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double* dReacDt, LinearBufferAllocator workSpace) { }
 	virtual int const* reactionQuasiStationarity() const CADET_NOEXCEPT { return nullptr; }
 	#ifdef ENABLE_DG
 	virtual void analyticJacobianLiquidAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double factor, linalg::BandedEigenSparseRowIterator jac, LinearBufferAllocator workSpace) const { }

--- a/src/libcadet/model/reaction/DummyReaction.cpp
+++ b/src/libcadet/model/reaction/DummyReaction.cpp
@@ -77,6 +77,11 @@ public:
 	virtual void analyticJacobianLiquidAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double factor, linalg::BandMatrix::RowIterator jac, LinearBufferAllocator workSpace) const { }
 	virtual void analyticJacobianLiquidAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double factor, linalg::DenseBandedRowIterator jac, LinearBufferAllocator workSpace) const { }
 	virtual void analyticJacobianLiquidAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double factor, linalg::BandedSparseRowIterator jac, LinearBufferAllocator workSpace) const { }
+	
+	virtual void analyticQuasiSteadyJacobianLiquid(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double factor, linalg::BandMatrix::RowIterator jac, LinearBufferAllocator workSpace) const { }
+	virtual void analyticQuasiSteadyJacobianLiquid(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double factor, linalg::DenseBandedRowIterator jac, LinearBufferAllocator workSpace) const { }
+	virtual void analyticQuasiSteadyJacobianLiquid(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double factor, linalg::BandedSparseRowIterator jac, LinearBufferAllocator workSpace) const { }
+	
 	#ifdef ENABLE_DG
 	virtual void analyticJacobianLiquidAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double factor, linalg::BandedEigenSparseRowIterator jac, LinearBufferAllocator workSpace) const { }
 	#endif
@@ -103,8 +108,11 @@ public:
 	void fillConservedMoietiesBulk(Eigen::MatrixXd& M, std::vector<int>& QSReaction, std::vector<int>& QSComponent) {}
 	bool hasQuasiStationaryReactionsLiquid() { return false;}
 	
+	virtual int quasiStationaryFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, active const* y,
+		Eigen::Map<Eigen::VectorXd> fluxes, std::vector<int> mapQSReac, LinearBufferAllocator workSpace) { return 0; }
+
 	virtual int quasiStationaryFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,
-		active* fluxes, std::vector<int>& mapQSReac, LinearBufferAllocator workSpace) const {return 0;}
+		Eigen::Map<Eigen::VectorXd> fluxes, std::vector<int> mapQSReac, LinearBufferAllocator workSpace) { return 0; }
 
 protected:
 };

--- a/src/libcadet/model/reaction/DummyReaction.cpp
+++ b/src/libcadet/model/reaction/DummyReaction.cpp
@@ -78,10 +78,12 @@ public:
 	virtual void analyticJacobianLiquidAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double factor, linalg::DenseBandedRowIterator jac, LinearBufferAllocator workSpace) const { }
 	virtual void analyticJacobianLiquidAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double factor, linalg::BandedSparseRowIterator jac, LinearBufferAllocator workSpace) const { }
 	
-	virtual void analyticQuasiSteadyJacobianLiquid(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double factor, linalg::BandMatrix::RowIterator jac, LinearBufferAllocator workSpace) const { }
-	virtual void analyticQuasiSteadyJacobianLiquid(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double factor, linalg::DenseBandedRowIterator jac, LinearBufferAllocator workSpace) const { }
-	virtual void analyticQuasiSteadyJacobianLiquid(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double factor, linalg::BandedSparseRowIterator jac, LinearBufferAllocator workSpace) const { }
+	virtual void analyticQuasiSteadyJacobianLiquid(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction, linalg::BandMatrix::RowIterator jac, LinearBufferAllocator workSpace) const { }
+	virtual void analyticQuasiSteadyJacobianLiquid(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction, linalg::DenseBandedRowIterator jac, LinearBufferAllocator workSpace) const { }
+	virtual void analyticQuasiSteadyJacobianLiquid(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction, linalg::BandedSparseRowIterator jac, LinearBufferAllocator workSpace) const { }
 	
+	virtual void timeDerivativeQuasiStationaryReaction(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double* dReacDt, LinearBufferAllocator workSpace) { }
+
 	#ifdef ENABLE_DG
 	virtual void analyticJacobianLiquidAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double factor, linalg::BandedEigenSparseRowIterator jac, LinearBufferAllocator workSpace) const { }
 	#endif

--- a/src/libcadet/model/reaction/DummyReaction.cpp
+++ b/src/libcadet/model/reaction/DummyReaction.cpp
@@ -82,10 +82,6 @@ public:
 	virtual void analyticJacobianQuasiStationaryReaction(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction, linalg::DenseBandedRowIterator jac, LinearBufferAllocator workSpace) const { }
 	virtual void analyticJacobianQuasiStationaryReaction(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction, linalg::BandedSparseRowIterator jac, LinearBufferAllocator workSpace) const { }
 	
-	virtual void analyticJacobianLiquidSingleFluxAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction, linalg::BandMatrix::RowIterator jac, LinearBufferAllocator workSpace)  const { }
-	virtual void analyticJacobianLiquidSingleFluxAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction, linalg::DenseBandedRowIterator jac, LinearBufferAllocator workSpace)  const { }
-	virtual void analyticJacobianLiquidSingleFluxAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction, linalg::BandedSparseRowIterator jac, LinearBufferAllocator workSpace)  const { }
-
 	virtual void timeDerivativeQuasiStationaryReaction(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double* dReacDt, LinearBufferAllocator workSpace) { }
 	virtual int const* reactionQuasiStationarity() const CADET_NOEXCEPT { return nullptr; }
 	#ifdef ENABLE_DG
@@ -108,21 +104,21 @@ public:
 	virtual void analyticJacobianCombinedAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* yLiquid, double const* ySolid, double factor, linalg::BandedEigenSparseRowIterator jacLiquid, linalg::DenseBandedRowIterator jacSolid, LinearBufferAllocator workSpace) const { }
 	#endif
 	virtual int computeQuasiStationaryReactionFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, active const* y,
-		Eigen::Map<Eigen::Vector<active, Eigen::Dynamic>> fluxes, int const* mapQSReac, LinearBufferAllocator workSpace) {
+		Eigen::Map<Eigen::Vector<active, Eigen::Dynamic>> fluxes, LinearBufferAllocator workSpace) {
 		return 0;
 	}
 	virtual int computeQuasiStationaryReactionFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,
-		Eigen::Map<Eigen::Vector<active, Eigen::Dynamic>> fluxes, int const* mapQSReac, LinearBufferAllocator workSpace) {
+		Eigen::Map<Eigen::Vector<active, Eigen::Dynamic>> fluxes,  LinearBufferAllocator workSpace) {
 		return 0;
 	}
 
 	virtual int computeQuasiStationaryReactionFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, active const* y,
-		Eigen::Map<Eigen::Vector<double, Eigen::Dynamic>> fluxes, int const* mapQSReac, LinearBufferAllocator workSpace) {
+		Eigen::Map<Eigen::Vector<double, Eigen::Dynamic>> fluxes, LinearBufferAllocator workSpace) {
 		return 0;
 	}
 
 	virtual int computeQuasiStationaryReactionFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,
-		Eigen::Map<Eigen::Vector<double, Eigen::Dynamic>> fluxes, int const* mapQSReac, LinearBufferAllocator workSpace) {
+		Eigen::Map<Eigen::Vector<double, Eigen::Dynamic>> fluxes, LinearBufferAllocator workSpace) {
 		return 0;
 	}
 

--- a/src/libcadet/model/reaction/DummyReaction.cpp
+++ b/src/libcadet/model/reaction/DummyReaction.cpp
@@ -99,6 +99,12 @@ public:
 
 	virtual unsigned int numReactionsLiquid() const CADET_NOEXCEPT { return 0; }
 	virtual unsigned int numReactionsCombined() const CADET_NOEXCEPT { return 0; }
+	
+	void fillConservedMoietiesBulk(Eigen::MatrixXd& M, std::vector<int>& QSReaction, std::vector<int>& QSComponent) {}
+	bool hasQuasiStationaryReactionsLiquid() { return false;}
+	
+	virtual int quasiStationaryFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,
+		active* fluxes, std::vector<int>& mapQSReac, LinearBufferAllocator workSpace) const {return 0;}
 
 protected:
 };

--- a/src/libcadet/model/reaction/DummyReaction.cpp
+++ b/src/libcadet/model/reaction/DummyReaction.cpp
@@ -128,7 +128,9 @@ public:
 
 	virtual unsigned int numReactionsLiquid() const CADET_NOEXCEPT { return 0; }
 	virtual unsigned int numReactionsCombined() const CADET_NOEXCEPT { return 0; }
-
+	virtual unsigned int numReactionQuasiStationary() const CADET_NOEXCEPT { return 0; }
+	template <typename ResidualType>
+	void fillConservedMoietiesBulk21(Eigen::Matrix<ResidualType, Eigen::Dynamic, Eigen::Dynamic>& M, std::vector<int>& QsCompBulk) {}
 protected:
 };
 

--- a/src/libcadet/model/reaction/DummyReaction.cpp
+++ b/src/libcadet/model/reaction/DummyReaction.cpp
@@ -82,6 +82,10 @@ public:
 	virtual void analyticQuasiSteadyJacobianLiquid(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction, linalg::DenseBandedRowIterator jac, LinearBufferAllocator workSpace) const { }
 	virtual void analyticQuasiSteadyJacobianLiquid(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction, linalg::BandedSparseRowIterator jac, LinearBufferAllocator workSpace) const { }
 	
+	virtual void analyticJacobianLiquidSingleFluxAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction, linalg::BandMatrix::RowIterator jac, LinearBufferAllocator workSpace)  const { }
+	virtual void analyticJacobianLiquidSingleFluxAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction, linalg::DenseBandedRowIterator jac, LinearBufferAllocator workSpace)  const { }
+	virtual void analyticJacobianLiquidSingleFluxAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction, linalg::BandedSparseRowIterator jac, LinearBufferAllocator workSpace)  const { }
+
 	virtual void timeDerivativeQuasiStationaryReaction(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double* dReacDt, LinearBufferAllocator workSpace) { }
 
 	#ifdef ENABLE_DG

--- a/src/libcadet/model/reaction/DummyReaction.cpp
+++ b/src/libcadet/model/reaction/DummyReaction.cpp
@@ -129,8 +129,8 @@ public:
 	virtual unsigned int numReactionsLiquid() const CADET_NOEXCEPT { return 0; }
 	virtual unsigned int numReactionsCombined() const CADET_NOEXCEPT { return 0; }
 	virtual unsigned int numReactionQuasiStationary() const CADET_NOEXCEPT { return 0; }
-	template <typename ResidualType>
-	void fillConservedMoietiesBulk21(Eigen::Matrix<ResidualType, Eigen::Dynamic, Eigen::Dynamic>& M, int& QsCompBulk) {}
+	template<typename ResidualType>
+	void ConservedMoietiesBulk(Eigen::Matrix<ResidualType, Eigen::Dynamic, Eigen::Dynamic>& M, int& conservedState, std::vector<int>& QsCompBulk) {}
 protected:
 };
 

--- a/src/libcadet/model/reaction/MassActionLawReaction.cpp
+++ b/src/libcadet/model/reaction/MassActionLawReaction.cpp
@@ -57,1124 +57,1272 @@
 namespace cadet
 {
 
-namespace model
-{
-
-inline const char* MassActionLawParamHandler::identifier() CADET_NOEXCEPT { return "MASS_ACTION_LAW"; }
-
-inline bool MassActionLawParamHandler::validateConfig(unsigned int nReactions, unsigned int nComp, unsigned int const* nBoundStates)
-{
-	return true;
-}
-
-inline const char* ExtMassActionLawParamHandler::identifier() CADET_NOEXCEPT { return "EXT_MASS_ACTION_LAW"; }
-
-inline bool ExtMassActionLawParamHandler::validateConfig(unsigned int nReactions, unsigned int nComp, unsigned int const* nBoundStates)
-{
-	return true;
-}
-
-
-namespace
-{
-	/**
-	 * @brief Registers a matrix-valued parameter (row-major storage) with bound states as rows
-	 * @details The matrix-valued parameter has as many rows as there are bound states in the system.
-	 * @param [in,out] parameters Parameter map
-	 * @param [in] unitOpIdx Unit operation id
-	 * @param [in] parTypeIdx Particle type index
-	 * @param [in] paramName Name of the parameter
-	 * @param [in] mat Matrix to register
-	 * @param [in] nComp Number of components
-	 * @param [in] boundOffset Array with offsets to bound states of a specific component
-	 */
-	inline void registerBoundStateRowMatrix(std::unordered_map<ParameterId, active*>& parameters, UnitOpIdx unitOpIdx, ParticleTypeIdx parTypeIdx, const std::string& paramName, cadet::linalg::ActiveDenseMatrix& mat,
-		unsigned int nComp, unsigned int const* boundOffset)
+	namespace model
 	{
-		const cadet::StringHash hashName = cadet::hashStringRuntime(paramName);
-		cadet::registerParam2DArray(parameters, mat.data(), mat.elements(), [=](bool multi, unsigned int row, unsigned int col)
-			{
-				const unsigned int comp = std::lower_bound(boundOffset, boundOffset + nComp, row) - boundOffset;
-				const unsigned int bnd = row - boundOffset[comp];
-				return cadet::makeParamId(hashName, unitOpIdx, comp, parTypeIdx, bnd, col, cadet::SectionIndep);
-			},
-			mat.columns()
-		);
-	}
 
-	/**
-	 * @brief Registers a matrix-valued parameter (row-major storage) with components as rows
-	 * @details The matrix-valued parameter has as many rows as there are components in the system.
-	 * @param [in,out] parameters Parameter map
-	 * @param [in] unitOpIdx Unit operation id
-	 * @param [in] parTypeIdx Particle type index
-	 * @param [in] paramName Name of the parameter
-	 * @param [in] mat Matrix to register
-	 */
-	inline void registerCompRowMatrix(std::unordered_map<ParameterId, active*>& parameters, UnitOpIdx unitOpIdx, ParticleTypeIdx parTypeIdx, const std::string& paramName, cadet::linalg::ActiveDenseMatrix& mat)
-	{
-		const cadet::StringHash hashName = cadet::hashStringRuntime(paramName);
-		cadet::registerParam2DArray(parameters, mat.data(), mat.elements(), [=](bool multi, unsigned int row, unsigned int col)
-			{
-				return cadet::makeParamId(hashName, unitOpIdx, row, parTypeIdx, cadet::BoundStateIndep, col, cadet::SectionIndep);
-			},
-			mat.columns()
-		);
-	}
+		inline const char* MassActionLawParamHandler::identifier() CADET_NOEXCEPT { return "MASS_ACTION_LAW"; }
 
-	/**
-	 * @brief Reads reaction rate exponents and registers them
-	 * @details Reads a matrix-valued parameter into the given pre-allocated matrix and registers the
-	 *          parameters in the map. If @p boundOffset is @c nullptr, the matrix has as many columns
-	 *          as there are components. Otherwise, the matrix has as many columns as there are bound states.
-	 * @param [in] paramProvider Parameter provider
-	 * @param [in,out] parameters Parameter map
-	 * @param [in] unitOpIdx Unit operation id
-	 * @param [in] parTypeIdx Particle type index
-	 * @param [in] paramName Name of the parameter
-	 * @param [out] mat Matrix that holds the values (pre-allocated)
-	 * @param [in] nComp Number of components
-	 * @param [in] boundOffset Array with offsets to bound states of a specific component, or @c nullptr
-	 */
-	inline void readAndRegisterExponents(cadet::IParameterProvider& paramProvider, std::unordered_map<ParameterId, active*>& parameters, UnitOpIdx unitOpIdx, ParticleTypeIdx parTypeIdx,
-		const std::string& paramName, cadet::linalg::ActiveDenseMatrix& mat, unsigned int nComp, unsigned int const* boundOffset)
-	{
-		if (paramProvider.exists(paramName))
+		inline bool MassActionLawParamHandler::validateConfig(unsigned int nReactions, unsigned int nComp, unsigned int const* nBoundStates)
 		{
-			const std::vector<double> s = paramProvider.getDoubleArray(paramName);
-			if (static_cast<int>(s.size()) != mat.elements())
-				throw InvalidParameterException("Expected " + paramName + " to be of size " + std::to_string(mat.elements()) + "");
-
-			std::copy(s.begin(), s.end(), mat.data());
-		}
-		else
-			mat.setAll(0.0);
-
-		if (boundOffset)
-			registerBoundStateRowMatrix(parameters, unitOpIdx, parTypeIdx, paramName, mat, nComp, boundOffset);
-		else
-			registerCompRowMatrix(parameters, unitOpIdx, parTypeIdx, paramName, mat);
-	}
-
-	/**
-	 * @brief Calculate gradient of reaction rate (flux) in liquid phase
-	 * @param [out] fluxGrad Array that holds the gradient of the reaction rate
-	 * @param [in] r Index of the reaction
-	 * @param [in] nComp Number of components
-	 * @param [in] rate Rate constant
-	 * @param [in] exponents Matrix with exponents in the rate law
-	 * @param [in] y Array of concentrations
-	 */
-	inline void fluxGradLiquid(double* fluxGrad, unsigned int r, unsigned int nComp, double rate, const cadet::linalg::ActiveDenseMatrix& exponents, double const* y)
-	{
-		for (unsigned int c = 0; c < nComp; ++c)
-		{
-			if (cadet_unlikely(exponents.native(c, r) != 0.0))
-				fluxGrad[c] = rate;
-			else
-				fluxGrad[c] = 0.0;
-		}
-
-		// Calculate gradient
-		for (unsigned int c = 0; c < nComp; ++c)
-		{
-			if (cadet_unlikely(exponents.native(c, r) != 0.0))
-			{
-				const double exponentValue = static_cast<double>(exponents.native(c, r));
-				const double v = pow(y[c], exponentValue);
-				for (unsigned int j = 0; j < c; ++j)
-					fluxGrad[j] *= v;
-
-				fluxGrad[c] *= exponentValue * pow(y[c], exponentValue - 1.0);
-
-				for (unsigned int j = c + 1; j < nComp; ++j)
-					fluxGrad[j] *= v;
-
-			}
-		}
-	}
-
-	/**
-	 * @brief Calculate gradient of reaction rate (flux) in liquid-solid phase cell
-	 * @param [out] fluxGrad Array that holds the gradient of the reaction rate
-	 * @param [in] r Index of the reaction
-	 * @param [in] nComp Number of components
-	 * @param [in] nTotalBoundStates Total number of bound states
-	 * @param [in] rate Rate constant
-	 * @param [in] expLiquid Matrix with exponents of the liquid phase concentrations in the rate law
-	 * @param [in] expSolid Matrix with exponents of the solid phase concentrations in the rate law
-	 * @param [in] yLiquid Array of liquid phase concentrations (points to first component of liquid phase concentrations)
-	 * @param [in] ySolid Array of solid phase concentrations (points to first component of solid phase concentrations)
-	 */
-	inline void fluxGradCombined(double* fluxGrad, unsigned int r, unsigned int nComp, unsigned int nTotalBoundStates, double rate,
-		const cadet::linalg::ActiveDenseMatrix& expLiquid, const cadet::linalg::ActiveDenseMatrix& expSolid, double const* yLiquid, double const* ySolid)
-	{
-		for (unsigned int c = 0; c < nComp; ++c)
-		{
-			if (cadet_unlikely(expLiquid.native(c, r) != 0.0))
-				fluxGrad[c] = rate;
-			else
-				fluxGrad[c] = 0.0;
-		}
-
-		for (unsigned int c = 0; c < nTotalBoundStates; ++c)
-		{
-			if (cadet_unlikely(expSolid.native(c, r) != 0.0))
-				fluxGrad[nComp + c] = rate;
-			else
-				fluxGrad[nComp + c] = 0.0;
-		}
-
-		// Calculate gradient
-		for (unsigned int c = 0; c < nComp; ++c)
-		{
-			if (cadet_unlikely(expLiquid.native(c, r) != 0.0))
-			{
-				const double exponentValue = static_cast<double>(expLiquid.native(c, r));
-				const double v = pow(yLiquid[c], exponentValue);
-				for (unsigned int j = 0; j < c; ++j)
-					fluxGrad[j] *= v;
-
-				fluxGrad[c] *= exponentValue * pow(yLiquid[c], exponentValue - 1.0);
-
-				for (unsigned int j = c + 1; j < nComp + nTotalBoundStates; ++j)
-					fluxGrad[j] *= v;
-
-			}
-		}
-
-		for (unsigned int c = 0; c < nTotalBoundStates; ++c)
-		{
-			if (cadet_unlikely(expSolid.native(c, r) != 0.0))
-			{
-				const double exponentValue = static_cast<double>(expSolid.native(c, r));
-				const double v = pow(ySolid[c], exponentValue);
-				for (unsigned int j = 0; j < nComp + c; ++j)
-					fluxGrad[j] *= v;
-
-				fluxGrad[nComp + c] *= exponentValue * pow(ySolid[c], exponentValue - 1.0);
-
-				for (unsigned int j = c + 1; j < nTotalBoundStates; ++j)
-					fluxGrad[nComp + j] *= v;
-
-			}
-		}
-	}
-
-	template <typename num_t>
-	inline num_t rateConstantOrZero(const num_t& rate, unsigned int idxReaction, const cadet::linalg::ActiveDenseMatrix& exponents, unsigned int nComp)
-	{
-		for (unsigned int c = 0; c < nComp; ++c)
-		{
-			if (cadet_unlikely(exponents.native(c, idxReaction) != 0.0))
-				return rate;
-		}
-		return 0.0;
-	}
-
-	template <typename num_t>
-	inline num_t rateConstantOrZero(const num_t& rate, unsigned int idxReaction, const cadet::linalg::ActiveDenseMatrix& expLiquid, const cadet::linalg::ActiveDenseMatrix& expSolid, unsigned int nComp, unsigned int nTotalBoundStates)
-	{
-		for (unsigned int c = 0; c < nComp; ++c)
-		{
-			if (cadet_unlikely(expLiquid.native(c, idxReaction) != 0.0))
-				return rate;
-		}
-		for (unsigned int c = 0; c < nTotalBoundStates; ++c)
-		{
-			if (cadet_unlikely(expSolid.native(c, idxReaction) != 0.0))
-				return rate;
-		}
-		return 0.0;
-	}
-}
-
-/**
- * @brief Defines the multi component Langmuir binding model
- * @details Implements the Langmuir adsorption model: \f[ \begin{align} 
- *              \frac{\mathrm{d}q_i}{\mathrm{d}t} &= k_{a,i} c_{p,i} q_{\text{max},i} \left( 1 - \sum_j \frac{q_j}{q_{\text{max},j}} \right) - k_{d,i} q_i
- *          \end{align} \f]
- *          Multiple bound states are not supported. 
- *          Components without bound state (i.e., non-binding components) are supported.
- *          
- *          See @cite Langmuir1916.
- * @tparam ParamHandler_t Type that can add support for external function dependence
- */
-template <class ParamHandler_t>
-class MassActionLawReactionBase : public DynamicReactionModelBase
-{
-public:
-
-	MassActionLawReactionBase() { }
-	virtual ~MassActionLawReactionBase() CADET_NOEXCEPT { }
-
-	static const char* identifier() { return ParamHandler_t::identifier(); }
-	virtual const char* name() const CADET_NOEXCEPT { return ParamHandler_t::identifier(); }
-
-	virtual void setExternalFunctions(IExternalFunction** extFuns, unsigned int size) { _paramHandler.setExternalFunctions(extFuns, size); }
-	virtual bool dependsOnTime() const CADET_NOEXCEPT { return ParamHandler_t::dependsOnTime(); }
-	virtual bool requiresWorkspace() const CADET_NOEXCEPT { return true; }
-	virtual bool hasDynamicReactions() const CADET_NOEXCEPT { return true; }
-
-	virtual unsigned int workspaceSize(unsigned int nComp, unsigned int totalNumBoundStates, unsigned int const* nBoundStates) const CADET_NOEXCEPT
-	{
-		return _paramHandler.cacheSize(maxNumReactions(), nComp, totalNumBoundStates) + std::max(maxNumReactions() * sizeof(active), 2 * (_nComp + totalNumBoundStates) * sizeof(double)) + 2*maxNumReactions();
-	}
-	
-	virtual int const* reactionQuasiStationarity() const CADET_NOEXCEPT { return _reactionQuasiStationarity.data(); }
-	virtual bool hasQuasiStationaryReactionsBulk() const CADET_NOEXCEPT
-	{
-		return std::any_of(_reactionQuasiStationarity.begin(), _reactionQuasiStationarity.end(), [](int i) -> bool { return i; });
-	}
-
-	virtual bool configureModelDiscretization(IParameterProvider& paramProvider, unsigned int nComp, unsigned int const* nBound, unsigned int const* boundOffset)
-	{
-		DynamicReactionModelBase::configureModelDiscretization(paramProvider, nComp, nBound, boundOffset);
-
-		if (paramProvider.exists("MAL_STOICHIOMETRY_BULK"))
-		{
-			const std::size_t numElements = paramProvider.numElements("MAL_STOICHIOMETRY_BULK");
-			if (numElements % nComp != 0)
-				throw InvalidParameterException("Size of field MAL_STOICHIOMETRY_BULK must be a positive multiple of NCOMP (" + std::to_string(nComp) + ")");
-
-			const unsigned int nReactions = numElements / nComp;
-
-			_stoichiometryBulk.resize(nComp, nReactions);
-			_expBulkFwd.resize(nComp, nReactions);
-			_expBulkBwd.resize(nComp, nReactions);
-
-			
-			if (paramProvider.exists("IS_KINETIC"))
-			{	// default is kinetic binding
-				_reactionQuasiStationarity.resize(_stoichiometryBulk.columns(), false);
-
-				if (paramProvider.isArray("IS_KINETIC")) {
-					const std::vector<int> kinetikFlag = paramProvider.getIntArray("IS_KINETIC");
-					if (kinetikFlag.size() == 1)
-					{	// Set all reactions to kinetic binding if IS_KINETIC is a single value
-						std::fill(_reactionQuasiStationarity.begin(), _reactionQuasiStationarity.end(), !static_cast<bool>(kinetikFlag[0]));
-					}
-					else if (kinetikFlag.size() < _reactionQuasiStationarity.size())
-					{
-						throw InvalidParameterException("IS_KINETIC has to have at least " + std::to_string(_reactionQuasiStationarity.size()) + " elements");
-					}
-					else
-					{	// Set reactions to kinetic or quasi statrionary according to IS_KINETIC array
-						std::transform(kinetikFlag.begin(), kinetikFlag.begin() + _reactionQuasiStationarity.size(), _reactionQuasiStationarity.begin(), [](int val) { return !static_cast<bool>(val); });
-					}
-				}
-				else
-				{	 // Set all reactions to kinetic or quasi statrionary if IS_KINETIC is not an array
-					const bool kineticBinding = paramProvider.getInt("IS_KINETIC");
-					std::fill(_reactionQuasiStationarity.begin(), _reactionQuasiStationarity.end(), !kineticBinding);
-				}
-
-				_quasiStationaryReactionIndices.clear();
-				for(int r = 0; r < _stoichiometryBulk.columns(); ++r)
-				{
-					if(_reactionQuasiStationarity[r])
-					{
-						_quasiStationaryReactionIndices.push_back(r);
-					}
-				}
-			}
-		}
-
-
-		if (!nBound || !boundOffset)
 			return true;
+		}
 
-		if (paramProvider.exists("MAL_STOICHIOMETRY_LIQUID"))
+		inline const char* ExtMassActionLawParamHandler::identifier() CADET_NOEXCEPT { return "EXT_MASS_ACTION_LAW"; }
+
+		inline bool ExtMassActionLawParamHandler::validateConfig(unsigned int nReactions, unsigned int nComp, unsigned int const* nBoundStates)
 		{
-			const std::size_t numElements = paramProvider.numElements("MAL_STOICHIOMETRY_LIQUID");
-			if (numElements % nComp != 0)
-				throw InvalidParameterException("Size of field MAL_STOICHIOMETRY_LIQUID must be a positive multiple of NCOMP (" + std::to_string(nComp) + ")");
-
-			const unsigned int nReactions = numElements / nComp;
-
-			_stoichiometryLiquid.resize(nComp, nReactions);
-			_expLiquidFwd.resize(nComp, nReactions);
-			_expLiquidBwd.resize(nComp, nReactions);
-
-			_expLiquidFwdSolid.resize(_nTotalBoundStates, nReactions);
-			_expLiquidBwdSolid.resize(_nTotalBoundStates, nReactions);
-		}
-
-		if (paramProvider.exists("MAL_STOICHIOMETRY_SOLID") && (_nTotalBoundStates > 0))
-		{
-			const std::size_t numElements = paramProvider.numElements("MAL_STOICHIOMETRY_SOLID");
-			if (numElements % _nTotalBoundStates != 0)
-				throw InvalidParameterException("Size of field MAL_STOICHIOMETRY_SOLID must be a positive multiple of NTOTALBND (" + std::to_string(_nTotalBoundStates) + ")");
-
-			const unsigned int nReactions = numElements / _nTotalBoundStates;
-
-			_stoichiometrySolid.resize(_nTotalBoundStates, nReactions);
-			_expSolidFwd.resize(_nTotalBoundStates, nReactions);
-			_expSolidBwd.resize(_nTotalBoundStates, nReactions);
-
-			_expSolidFwdLiquid.resize(nComp, nReactions);
-			_expSolidBwdLiquid.resize(nComp, nReactions);
-		}
-
-
-		return true;
-	}
-
-	/**
-     * @brief Calculates conservation relations for quasi-stationary reactions in bulk phase
-     * @details For quasi-stationary reactions, this method identifies conservation laws by
-     *          finding the left null space of the stoichiometry matrix for the quasi-stationary
-     *          reactions. The method populates matrix M with the conservation relations and 
-     *          marks components participating in quasi-stationary reactions in componentsInQssReactions.
-     *
-     * @param [in,out] conservationMatrix Matrix to be filled with conservation relations
-     * @param [in,out] numConservationLaws Number of independent conservation laws found
-     * @param [in,out] componentsInQssReactions Vector marking components that participate in quasi-stationary reactions (1 if active, 0 otherwise)
-     * @tparam ResidualType Type used for the residual calculations
-     */
-	template<typename ResidualType>
-	void ConservedMoietiesBulk(Eigen::Matrix<ResidualType, Eigen::Dynamic, Eigen::Dynamic>& conservationMatrix, int& numConservationLaws, std::vector<int>& componentsInQssReactions)
-	{		
-		// Count the number of quasi-stationary reactions
-		int numQuasiStationaryReactions = std::count(_reactionQuasiStationarity.begin(), _reactionQuasiStationarity.end(), true);
-		std::fill(componentsInQssReactions.begin(), componentsInQssReactions.end(), 0);
-
-		if (numQuasiStationaryReactions == 0)
-		{	
-			numConservationLaws = 0;
-			return;
-		}
-		// Create quasiStationaryStoichiometry matrix with stoichiometry of quasi-stationary reactions
-		Eigen::MatrixXd quasiStationaryStoichiometry(_stoichiometryBulk.rows(), numQuasiStationaryReactions);
-
-		int reactionIndex = 0;
-		for (int j = 0; j < _stoichiometryBulk.columns(); j++)
-		{
-			if (_reactionQuasiStationarity[j] == 0)
-				continue;
-
-			for (int i = 0; i < _stoichiometryBulk.rows(); ++i)
-			{
-				quasiStationaryStoichiometry(i, reactionIndex) = static_cast<double>(_stoichiometryBulk.native(i, j));
-			}
-			reactionIndex++;
-		}
-
-		// Count active components and mark them in componentsInQssReactions
-		std::vector<int> quasiStationaryCompIdx;
-		quasiStationaryCompIdx.reserve(_nComp);
-
-		std::vector<int> notQuasiStationaryCompIdx;
-		notQuasiStationaryCompIdx.reserve(_nComp);
-
-		if(componentsInQssReactions.size() != _nComp)
-		{
-			throw InvalidParameterException("Calculating conserved Moities: Vector for marking components in quasi stationary reactions must have size equal to number of components");
-		}
-		
-		for (int i = 0; i < quasiStationaryStoichiometry.rows(); ++i)
-		{
-			bool isActive = (quasiStationaryStoichiometry.row(i).norm() >= 1e-15);
-			componentsInQssReactions[i] = isActive ? 1 : 0;
-			if (isActive)
-			{
-				quasiStationaryCompIdx.push_back(i);
-			}
-			else
-			{
-				notQuasiStationaryCompIdx.push_back(i);
-			}
-		}
-
-		// Create compressed matrix of only active rows
-		const int nActiveComponents = quasiStationaryCompIdx.size();
-		if (nActiveComponents == 0)
-		{
-			throw InvalidParameterException(
-				"Calculating conserved Moities: No components participate in quasi-stationary reactions. "
-				"Check your stoichiometry matrix."
-			);
-		}
-
-		// Extract active rows to compressed matrix
-		Eigen::MatrixXd compactStoichiometry(nActiveComponents, numQuasiStationaryReactions);
-		for (int i = 0; i < nActiveComponents; ++i)
-		{
-			compactStoichiometry.row(i) = quasiStationaryStoichiometry.row(quasiStationaryCompIdx[i]);
-		}
-
-		// Check matrix rank
-		int rank = compactStoichiometry.fullPivLu().rank();
-		if (rank != numQuasiStationaryReactions)
-		{
-			throw InvalidParameterException(
-				"Calculating conserved moieties: The stoichiometric matrix for quasi-stationary reactions "
-				"has rank " + std::to_string(rank) + " but " + std::to_string(numQuasiStationaryReactions) +
-				" reactions. This indicates redundant reactions or conservation laws, which are "
-				"not supported in combination with quasi-stationary reactions yet."
-			);
-		}
-
-		// Calculate null space of stoichiometry for conservation relations with LU decomposition
-		// This corresponds to the left null space of the stoichiometry matrix
-		Eigen::MatrixXd conservationRelations  = compactStoichiometry.transpose().fullPivLu().kernel().transpose();
-		numConservationLaws = conservationRelations .rows();
-		
-		
-		// Create final matrix conservationMatrix with proper dimensions
-		// acording to componentsInQssReactions: 0 -> not conserved 1-> conserved (either dynamic or not)
-		int idx = 0;
-		int nonActiveIdx = 0;
-		conservationMatrix = Eigen::Matrix<ResidualType, Eigen::Dynamic, Eigen::Dynamic>::Zero(_nComp, _nComp);
-		for (int i = 0; i < _nComp; ++i)
-		{
-			if (componentsInQssReactions[i] == 0) // dynamic but not active
-			{
-				conservationMatrix(i, notQuasiStationaryCompIdx[nonActiveIdx]) = static_cast<ResidualType>(1.0);
-				nonActiveIdx++;
-			}
-			else if (idx < conservationRelations.rows())
-			{
-				int activeIdx = 0;
-				for (int j = 0; j < conservationRelations.cols(); ++j)
-				{
-					conservationMatrix(i, quasiStationaryCompIdx[activeIdx]) = static_cast<ResidualType>(conservationRelations(idx, j));
-					activeIdx++;
-				}
-				idx++;
-			}
-		}
-
-	}
-
-	virtual unsigned int numReactionsLiquid() const CADET_NOEXCEPT { return _stoichiometryBulk.columns(); }
-	virtual unsigned int numReactionsCombined() const CADET_NOEXCEPT { return _stoichiometryLiquid.columns() + _stoichiometrySolid.columns(); }
-	virtual unsigned int numReactionQuasiStationary() const CADET_NOEXCEPT { return  std::count(_reactionQuasiStationarity.begin(), _reactionQuasiStationarity.end(), true); }
-
-	CADET_DYNAMICREACTIONMODEL_BOILERPLATE
-
-protected:
-	ParamHandler_t _paramHandler; //!< Handles parameters and their dependence on external functions
-
-	linalg::ActiveDenseMatrix _stoichiometryBulk;
-	linalg::ActiveDenseMatrix _expBulkFwd;
-	linalg::ActiveDenseMatrix _expBulkBwd;
-
-	linalg::ActiveDenseMatrix _stoichiometryLiquid;
-	linalg::ActiveDenseMatrix _expLiquidFwd;
-	linalg::ActiveDenseMatrix _expLiquidBwd;
-	linalg::ActiveDenseMatrix _expLiquidFwdSolid;
-	linalg::ActiveDenseMatrix _expLiquidBwdSolid;
-
-	linalg::ActiveDenseMatrix _stoichiometrySolid;
-	linalg::ActiveDenseMatrix _expSolidFwd;
-	linalg::ActiveDenseMatrix _expSolidBwd;
-	linalg::ActiveDenseMatrix _expSolidFwdLiquid;
-	linalg::ActiveDenseMatrix _expSolidBwdLiquid;
-
-	std::vector<int> _reactionQuasiStationarity; 
-	std::vector<int> _quasiStationaryReactionIndices;
-
-
-	inline int maxNumReactions() const CADET_NOEXCEPT { return std::max(std::max(_stoichiometryBulk.columns(), _stoichiometryLiquid.columns()), _stoichiometrySolid.columns()); }
-
-	virtual bool configureImpl(IParameterProvider& paramProvider, UnitOpIdx unitOpIdx, ParticleTypeIdx parTypeIdx)
-	{
-		_paramHandler.configure(paramProvider, maxNumReactions(), _nComp, _nBoundStates);
-		_paramHandler.registerParameters(_parameters, unitOpIdx, parTypeIdx, _nComp, _nBoundStates);
-
-		if ((_stoichiometryBulk.columns() > 0) && ((static_cast<int>(_paramHandler.kFwdBulk().size()) < _stoichiometryBulk.columns()) || (static_cast<int>(_paramHandler.kBwdBulk().size()) < _stoichiometryBulk.columns())))
-			throw InvalidParameterException("MAL_KFWD_BULK and MAL_KBWD_BULK have to have the same size (number of reactions)");
-
-		if ((_stoichiometryLiquid.columns() > 0) && ((static_cast<int>(_paramHandler.kFwdLiquid().size()) < _stoichiometryLiquid.columns()) || (static_cast<int>(_paramHandler.kBwdLiquid().size()) < _stoichiometryLiquid.columns())))
-			throw InvalidParameterException("MAL_KFWD_LIQUID and MAL_KBWD_LIQUID have to have the same size (number of reactions)");
-
-		if ((_stoichiometrySolid.columns() > 0) && ((static_cast<int>(_paramHandler.kFwdSolid().size()) < _stoichiometrySolid.columns()) || (static_cast<int>(_paramHandler.kBwdSolid().size()) < _stoichiometrySolid.columns())))
-			throw InvalidParameterException("MAL_KFWD_SOLID and MAL_KBWD_SOLID have to have the same size (number of reactions)");
-
-		if (paramProvider.exists("MAL_STOICHIOMETRY_BULK"))
-		{
-			const std::vector<double> s = paramProvider.getDoubleArray("MAL_STOICHIOMETRY_BULK");
-
-			if (static_cast<int>(s.size()) != _stoichiometryBulk.elements())
-				throw InvalidParameterException("MAL_STOICHIOMETRY_BULK has changed size (number of reactions changed)");
-
-			std::copy(s.begin(), s.end(), _stoichiometryBulk.data());
-		}
-		registerCompRowMatrix(_parameters, unitOpIdx, parTypeIdx, "MAL_STOICHIOMETRY_BULK", _stoichiometryBulk);
-
-		if (paramProvider.exists("MAL_EXPONENTS_BULK_FWD"))
-		{
-			const std::vector<double> s = paramProvider.getDoubleArray("MAL_EXPONENTS_BULK_FWD");
-			if (static_cast<int>(s.size()) != _stoichiometryBulk.elements())
-				throw InvalidParameterException("Expected MAL_EXPONENTS_BULK_FWD and MAL_STOICHIOMETRY_BULK to be of the same size (" + std::to_string(_stoichiometryBulk.elements()) + ")");
-
-			std::copy(s.begin(), s.end(), _expBulkFwd.data());
-		}
-		else
-		{
-			// Obtain default values from stoichiometry
-			std::transform(_stoichiometryBulk.data(), _stoichiometryBulk.data() + _stoichiometryBulk.elements(), _expBulkFwd.data(), [](const active& v) { return std::max(0.0, -static_cast<double>(v)); });
-		}
-		registerCompRowMatrix(_parameters, unitOpIdx, parTypeIdx, "MAL_EXPONENTS_BULK_FWD", _expBulkFwd);
-
-		if (paramProvider.exists("MAL_EXPONENTS_BULK_BWD"))
-		{
-			const std::vector<double> s = paramProvider.getDoubleArray("MAL_EXPONENTS_BULK_BWD");
-			if (static_cast<int>(s.size()) != _stoichiometryBulk.elements())
-				throw InvalidParameterException("Expected MAL_EXPONENTS_BULK_BWD and MAL_STOICHIOMETRY_BULK to be of the same size (" + std::to_string(_stoichiometryBulk.elements()) + ")");
-
-			std::copy(s.begin(), s.end(), _expBulkBwd.data());
-		}
-		else
-		{
-			// Obtain default values from stoichiometry
-			std::transform(_stoichiometryBulk.data(), _stoichiometryBulk.data() + _stoichiometryBulk.elements(), _expBulkBwd.data(), [](const active& v) { return std::max(0.0, static_cast<double>(v)); });
-		}
-		registerCompRowMatrix(_parameters, unitOpIdx, parTypeIdx, "MAL_EXPONENTS_BULK_BWD", _expBulkBwd);
-
-
-		if (paramProvider.exists("MAL_STOICHIOMETRY_LIQUID"))
-		{
-			const std::vector<double> s = paramProvider.getDoubleArray("MAL_STOICHIOMETRY_LIQUID");
-
-			if (static_cast<int>(s.size()) != _stoichiometryLiquid.elements())
-				throw InvalidParameterException("MAL_STOICHIOMETRY_LIQUID has changed size (number of reactions changed)");
-
-			std::copy(s.begin(), s.end(), _stoichiometryLiquid.data());
-		}
-		registerCompRowMatrix(_parameters, unitOpIdx, parTypeIdx, "MAL_STOICHIOMETRY_LIQUID", _stoichiometryLiquid);
-
-		if (paramProvider.exists("MAL_EXPONENTS_LIQUID_FWD"))
-		{
-			const std::vector<double> s = paramProvider.getDoubleArray("MAL_EXPONENTS_LIQUID_FWD");
-			if (static_cast<int>(s.size()) != _stoichiometryLiquid.elements())
-				throw InvalidParameterException("Expected MAL_EXPONENTS_LIQUID_FWD and MAL_STOICHIOMETRY_LIQUID to be of the same size (" + std::to_string(_stoichiometryLiquid.elements()) + ")");
-
-			std::copy(s.begin(), s.end(), _expLiquidFwd.data());
-		}
-		else
-		{
-			// Obtain default values from stoichiometry
-			std::transform(_stoichiometryLiquid.data(), _stoichiometryLiquid.data() + _stoichiometryLiquid.elements(), _expLiquidFwd.data(), [](const active& v) { return std::max(0.0, -static_cast<double>(v)); });
-		}
-		registerCompRowMatrix(_parameters, unitOpIdx, parTypeIdx, "MAL_EXPONENTS_LIQUID_FWD", _expLiquidFwd);
-
-		if (paramProvider.exists("MAL_EXPONENTS_LIQUID_BWD"))
-		{
-			const std::vector<double> s = paramProvider.getDoubleArray("MAL_EXPONENTS_LIQUID_BWD");
-			if (static_cast<int>(s.size()) != _stoichiometryLiquid.elements())
-				throw InvalidParameterException("Expected MAL_EXPONENTS_LIQUID_BWD and MAL_STOICHIOMETRY_LIQUID to be of the same size (" + std::to_string(_stoichiometryLiquid.elements()) + ")");
-
-			std::copy(s.begin(), s.end(), _expLiquidBwd.data());
-		}
-		else
-		{
-			// Obtain default values from stoichiometry
-			std::transform(_stoichiometryLiquid.data(), _stoichiometryLiquid.data() + _stoichiometryLiquid.elements(), _expLiquidBwd.data(), [](const active& v) { return std::max(0.0, static_cast<double>(v)); });
-		}
-		registerCompRowMatrix(_parameters, unitOpIdx, parTypeIdx, "MAL_EXPONENTS_LIQUID_BWD", _expLiquidBwd);
-
-		if (!_nBoundStates || !_boundOffset)
 			return true;
-
-		readAndRegisterExponents(paramProvider, _parameters, unitOpIdx, parTypeIdx, "MAL_EXPONENTS_LIQUID_FWD_MODSOLID", _expLiquidFwdSolid, _nComp, _boundOffset);
-		readAndRegisterExponents(paramProvider, _parameters, unitOpIdx, parTypeIdx, "MAL_EXPONENTS_LIQUID_BWD_MODSOLID", _expLiquidBwdSolid, _nComp, _boundOffset);
-
-
-		if (paramProvider.exists("MAL_STOICHIOMETRY_SOLID"))
-		{
-			const std::vector<double> s = paramProvider.getDoubleArray("MAL_STOICHIOMETRY_SOLID");
-
-			if (static_cast<int>(s.size()) != _stoichiometrySolid.elements())
-				throw InvalidParameterException("MAL_STOICHIOMETRY_SOLID has changed size (number of reactions changed)");
-
-			std::copy(s.begin(), s.end(), _stoichiometrySolid.data());
 		}
-		registerBoundStateRowMatrix(_parameters, unitOpIdx, parTypeIdx, "MAL_STOICHIOMETRY_SOLID", _stoichiometrySolid, _nComp, _boundOffset);
 
-		if (paramProvider.exists("MAL_EXPONENTS_SOLID_FWD"))
+
+		namespace
 		{
-			const std::vector<double> s = paramProvider.getDoubleArray("MAL_EXPONENTS_SOLID_FWD");
-			if (static_cast<int>(s.size()) != _stoichiometrySolid.elements())
-				throw InvalidParameterException("Expected MAL_EXPONENTS_SOLID_FWD and MAL_STOICHIOMETRY_SOLID to be of the same size (" + std::to_string(_stoichiometrySolid.elements()) + ")");
-
-			std::copy(s.begin(), s.end(), _expSolidFwd.data());
-		}
-		else
-		{
-			// Obtain default values from stoichiometry
-			std::transform(_stoichiometrySolid.data(), _stoichiometrySolid.data() + _stoichiometrySolid.elements(), _expSolidFwd.data(), [](const active& v) { return std::max(0.0, -static_cast<double>(v)); });
-		}
-		registerBoundStateRowMatrix(_parameters, unitOpIdx, parTypeIdx, "MAL_EXPONENTS_SOLID_FWD", _expSolidFwd, _nComp, _boundOffset);
-
-		if (paramProvider.exists("MAL_EXPONENTS_SOLID_BWD"))
-		{
-			const std::vector<double> s = paramProvider.getDoubleArray("MAL_EXPONENTS_SOLID_BWD");
-			if (static_cast<int>(s.size()) != _stoichiometrySolid.elements())
-				throw InvalidParameterException("Expected MAL_EXPONENTS_SOLID_BWD and MAL_STOICHIOMETRY_SOLID to be of the same size (" + std::to_string(_stoichiometrySolid.elements()) + ")");
-
-			std::copy(s.begin(), s.end(), _expSolidBwd.data());
-		}
-		else
-		{
-			// Obtain default values from stoichiometry
-			std::transform(_stoichiometrySolid.data(), _stoichiometrySolid.data() + _stoichiometrySolid.elements(), _expSolidBwd.data(), [](const active& v) { return std::max(0.0, static_cast<double>(v)); });
-		}
-		registerBoundStateRowMatrix(_parameters, unitOpIdx, parTypeIdx, "MAL_EXPONENTS_SOLID_BWD", _expSolidBwd, _nComp, _boundOffset);
-
-		readAndRegisterExponents(paramProvider, _parameters, unitOpIdx, parTypeIdx, "MAL_EXPONENTS_SOLID_FWD_MODLIQUID", _expSolidFwdLiquid, _nComp, nullptr);
-		readAndRegisterExponents(paramProvider, _parameters, unitOpIdx, parTypeIdx, "MAL_EXPONENTS_SOLID_BWD_MODLIQUID", _expSolidBwdLiquid, _nComp, nullptr);
-
-		return true;
-	}
-	/**
-	 * @brief Calculates the net reaction rate for a single reaction
-	 * @details Computes the difference between forward and backward reaction rates 
-	 *          based on mass action kinetics: rate = k * prod(c_i^n_i)
-	 *          where c_i are component concentrations and n_i are reaction orders
-	 *
-	 * @param [in] reactionIdx Index of the reaction in the stoichiometry matrix
-	 * @param [in] c Array of component concentrations
-	 * @param [in] kFwdBulk_r Forward rate constant
-	 * @param [in] kBwdBulk_r Backward rate constant
-	 * @return Net reaction rate (forward - backward)
-	 * @tparam StateType Type of state variables (concentrations)
-	 * @tparam ResidualType Type of the result
-	 */
-	template <typename StateType, typename ResidualType>
-	ResidualType calculateReactionRate(int reactionIdx, StateType const* c, double kFwdBulk_r, double kBwdBulk_r)
-	{	
-		constexpr double CONCENTRATION_THRESHOLD = 1e-15;
-		
-		int r = reactionIdx;
-		ResidualType fwd = rateConstantOrZero(kFwdBulk_r, r, _expBulkFwd, _nComp);
-		for (int comp = 0; comp < _nComp; ++comp)
-		{
-			if (_expBulkFwd.native(comp, r) != 0.0)
+			/**
+			 * @brief Registers a matrix-valued parameter (row-major storage) with bound states as rows
+			 * @details The matrix-valued parameter has as many rows as there are bound states in the system.
+			 * @param [in,out] parameters Parameter map
+			 * @param [in] unitOpIdx Unit operation id
+			 * @param [in] parTypeIdx Particle type index
+			 * @param [in] paramName Name of the parameter
+			 * @param [in] mat Matrix to register
+			 * @param [in] nComp Number of components
+			 * @param [in] boundOffset Array with offsets to bound states of a specific component
+			 */
+			inline void registerBoundStateRowMatrix(std::unordered_map<ParameterId, active*>& parameters, UnitOpIdx unitOpIdx, ParticleTypeIdx parTypeIdx, const std::string& paramName, cadet::linalg::ActiveDenseMatrix& mat,
+				unsigned int nComp, unsigned int const* boundOffset)
 			{
-				const double concentration = static_cast<double>(c[comp]);
-				if (concentration > CONCENTRATION_THRESHOLD)
+				const cadet::StringHash hashName = cadet::hashStringRuntime(paramName);
+				cadet::registerParam2DArray(parameters, mat.data(), mat.elements(), [=](bool multi, unsigned int row, unsigned int col)
+					{
+						const unsigned int comp = std::lower_bound(boundOffset, boundOffset + nComp, row) - boundOffset;
+						const unsigned int bnd = row - boundOffset[comp];
+						return cadet::makeParamId(hashName, unitOpIdx, comp, parTypeIdx, bnd, col, cadet::SectionIndep);
+					},
+					mat.columns()
+				);
+			}
+
+			/**
+			 * @brief Registers a matrix-valued parameter (row-major storage) with components as rows
+			 * @details The matrix-valued parameter has as many rows as there are components in the system.
+			 * @param [in,out] parameters Parameter map
+			 * @param [in] unitOpIdx Unit operation id
+			 * @param [in] parTypeIdx Particle type index
+			 * @param [in] paramName Name of the parameter
+			 * @param [in] mat Matrix to register
+			 */
+			inline void registerCompRowMatrix(std::unordered_map<ParameterId, active*>& parameters, UnitOpIdx unitOpIdx, ParticleTypeIdx parTypeIdx, const std::string& paramName, cadet::linalg::ActiveDenseMatrix& mat)
+			{
+				const cadet::StringHash hashName = cadet::hashStringRuntime(paramName);
+				cadet::registerParam2DArray(parameters, mat.data(), mat.elements(), [=](bool multi, unsigned int row, unsigned int col)
+					{
+						return cadet::makeParamId(hashName, unitOpIdx, row, parTypeIdx, cadet::BoundStateIndep, col, cadet::SectionIndep);
+					},
+					mat.columns()
+				);
+			}
+
+			/**
+			 * @brief Reads reaction rate exponents and registers them
+			 * @details Reads a matrix-valued parameter into the given pre-allocated matrix and registers the
+			 *          parameters in the map. If @p boundOffset is @c nullptr, the matrix has as many columns
+			 *          as there are components. Otherwise, the matrix has as many columns as there are bound states.
+			 * @param [in] paramProvider Parameter provider
+			 * @param [in,out] parameters Parameter map
+			 * @param [in] unitOpIdx Unit operation id
+			 * @param [in] parTypeIdx Particle type index
+			 * @param [in] paramName Name of the parameter
+			 * @param [out] mat Matrix that holds the values (pre-allocated)
+			 * @param [in] nComp Number of components
+			 * @param [in] boundOffset Array with offsets to bound states of a specific component, or @c nullptr
+			 */
+			inline void readAndRegisterExponents(cadet::IParameterProvider& paramProvider, std::unordered_map<ParameterId, active*>& parameters, UnitOpIdx unitOpIdx, ParticleTypeIdx parTypeIdx,
+				const std::string& paramName, cadet::linalg::ActiveDenseMatrix& mat, unsigned int nComp, unsigned int const* boundOffset)
+			{
+				if (paramProvider.exists(paramName))
 				{
-					fwd *= pow(static_cast<typename DoubleActiveDemoter<ResidualType, active>::type>(c[comp]),
-						static_cast<typename DoubleActiveDemoter<ResidualType, active>::type>(_expBulkFwd.native(comp, r)));
+					const std::vector<double> s = paramProvider.getDoubleArray(paramName);
+					if (static_cast<int>(s.size()) != mat.elements())
+						throw InvalidParameterException("Expected " + paramName + " to be of size " + std::to_string(mat.elements()) + "");
+
+					std::copy(s.begin(), s.end(), mat.data());
 				}
 				else
-				{	
-					fwd *= 0.0;
-					break;
+					mat.setAll(0.0);
+
+				if (boundOffset)
+					registerBoundStateRowMatrix(parameters, unitOpIdx, parTypeIdx, paramName, mat, nComp, boundOffset);
+				else
+					registerCompRowMatrix(parameters, unitOpIdx, parTypeIdx, paramName, mat);
+			}
+
+			/**
+			 * @brief Calculate gradient of reaction rate (flux) in liquid phase
+			 * @param [out] fluxGrad Array that holds the gradient of the reaction rate
+			 * @param [in] r Index of the reaction
+			 * @param [in] nComp Number of components
+			 * @param [in] rate Rate constant
+			 * @param [in] exponents Matrix with exponents in the rate law
+			 * @param [in] y Array of concentrations
+			 */
+			inline void fluxGradLiquid(double* fluxGrad, unsigned int r, unsigned int nComp, double rate, const cadet::linalg::ActiveDenseMatrix& exponents, double const* y)
+			{
+				for (unsigned int c = 0; c < nComp; ++c)
+				{
+					if (cadet_unlikely(exponents.native(c, r) != 0.0))
+						fluxGrad[c] = rate;
+					else
+						fluxGrad[c] = 0.0;
+				}
+
+				// Calculate gradient
+				for (unsigned int c = 0; c < nComp; ++c)
+				{
+					if (cadet_unlikely(exponents.native(c, r) != 0.0))
+					{
+						const double exponentValue = static_cast<double>(exponents.native(c, r));
+						const double v = pow(y[c], exponentValue);
+						for (unsigned int j = 0; j < c; ++j)
+							fluxGrad[j] *= v;
+
+						fluxGrad[c] *= exponentValue * pow(y[c], exponentValue - 1.0);
+
+						for (unsigned int j = c + 1; j < nComp; ++j)
+							fluxGrad[j] *= v;
+
+					}
 				}
 			}
-		}
- 
-		ResidualType bwd = rateConstantOrZero(kBwdBulk_r, r, _expBulkBwd, _nComp);
-		for (int comp = 0; comp < _nComp; ++comp)
-		{
-			if (_expBulkBwd.native(comp, r) != 0.0)
+
+			/**
+			 * @brief Calculate gradient of reaction rate (flux) in liquid-solid phase cell
+			 * @param [out] fluxGrad Array that holds the gradient of the reaction rate
+			 * @param [in] r Index of the reaction
+			 * @param [in] nComp Number of components
+			 * @param [in] nTotalBoundStates Total number of bound states
+			 * @param [in] rate Rate constant
+			 * @param [in] expLiquid Matrix with exponents of the liquid phase concentrations in the rate law
+			 * @param [in] expSolid Matrix with exponents of the solid phase concentrations in the rate law
+			 * @param [in] yLiquid Array of liquid phase concentrations (points to first component of liquid phase concentrations)
+			 * @param [in] ySolid Array of solid phase concentrations (points to first component of solid phase concentrations)
+			 */
+			inline void fluxGradCombined(double* fluxGrad, unsigned int r, unsigned int nComp, unsigned int nTotalBoundStates, double rate,
+				const cadet::linalg::ActiveDenseMatrix& expLiquid, const cadet::linalg::ActiveDenseMatrix& expSolid, double const* yLiquid, double const* ySolid)
 			{
-				const double concentration = static_cast<double>(c[comp]);
-				if (concentration > CONCENTRATION_THRESHOLD) 
+				for (unsigned int c = 0; c < nComp; ++c)
 				{
-					bwd *= pow(static_cast<typename DoubleActiveDemoter<ResidualType, active>::type>(c[comp]),
-						static_cast<typename DoubleActiveDemoter<ResidualType, active>::type>(_expBulkBwd.native(comp, r)));
+					if (cadet_unlikely(expLiquid.native(c, r) != 0.0))
+						fluxGrad[c] = rate;
+					else
+						fluxGrad[c] = 0.0;
+				}
+
+				for (unsigned int c = 0; c < nTotalBoundStates; ++c)
+				{
+					if (cadet_unlikely(expSolid.native(c, r) != 0.0))
+						fluxGrad[nComp + c] = rate;
+					else
+						fluxGrad[nComp + c] = 0.0;
+				}
+
+				// Calculate gradient
+				for (unsigned int c = 0; c < nComp; ++c)
+				{
+					if (cadet_unlikely(expLiquid.native(c, r) != 0.0))
+					{
+						const double exponentValue = static_cast<double>(expLiquid.native(c, r));
+						const double v = pow(yLiquid[c], exponentValue);
+						for (unsigned int j = 0; j < c; ++j)
+							fluxGrad[j] *= v;
+
+						fluxGrad[c] *= exponentValue * pow(yLiquid[c], exponentValue - 1.0);
+
+						for (unsigned int j = c + 1; j < nComp + nTotalBoundStates; ++j)
+							fluxGrad[j] *= v;
+
+					}
+				}
+
+				for (unsigned int c = 0; c < nTotalBoundStates; ++c)
+				{
+					if (cadet_unlikely(expSolid.native(c, r) != 0.0))
+					{
+						const double exponentValue = static_cast<double>(expSolid.native(c, r));
+						const double v = pow(ySolid[c], exponentValue);
+						for (unsigned int j = 0; j < nComp + c; ++j)
+							fluxGrad[j] *= v;
+
+						fluxGrad[nComp + c] *= exponentValue * pow(ySolid[c], exponentValue - 1.0);
+
+						for (unsigned int j = c + 1; j < nTotalBoundStates; ++j)
+							fluxGrad[nComp + j] *= v;
+
+					}
+				}
+			}
+
+			template <typename num_t>
+			inline num_t rateConstantOrZero(const num_t& rate, unsigned int idxReaction, const cadet::linalg::ActiveDenseMatrix& exponents, unsigned int nComp)
+			{
+				for (unsigned int c = 0; c < nComp; ++c)
+				{
+					if (cadet_unlikely(exponents.native(c, idxReaction) != 0.0))
+						return rate;
+				}
+				return 0.0;
+			}
+
+			template <typename num_t>
+			inline num_t rateConstantOrZero(const num_t& rate, unsigned int idxReaction, const cadet::linalg::ActiveDenseMatrix& expLiquid, const cadet::linalg::ActiveDenseMatrix& expSolid, unsigned int nComp, unsigned int nTotalBoundStates)
+			{
+				for (unsigned int c = 0; c < nComp; ++c)
+				{
+					if (cadet_unlikely(expLiquid.native(c, idxReaction) != 0.0))
+						return rate;
+				}
+				for (unsigned int c = 0; c < nTotalBoundStates; ++c)
+				{
+					if (cadet_unlikely(expSolid.native(c, idxReaction) != 0.0))
+						return rate;
+				}
+				return 0.0;
+			}
+		}
+
+		/**
+		 * @brief Defines the multi component Langmuir binding model
+		 * @details Implements the Langmuir adsorption model: \f[ \begin{align}
+		 *              \frac{\mathrm{d}q_i}{\mathrm{d}t} &= k_{a,i} c_{p,i} q_{\text{max},i} \left( 1 - \sum_j \frac{q_j}{q_{\text{max},j}} \right) - k_{d,i} q_i
+		 *          \end{align} \f]
+		 *          Multiple bound states are not supported.
+		 *          Components without bound state (i.e., non-binding components) are supported.
+		 *
+		 *          See @cite Langmuir1916.
+		 * @tparam ParamHandler_t Type that can add support for external function dependence
+		 */
+		template <class ParamHandler_t>
+		class MassActionLawReactionBase : public DynamicReactionModelBase
+		{
+		public:
+
+			MassActionLawReactionBase() { }
+			virtual ~MassActionLawReactionBase() CADET_NOEXCEPT { }
+
+			static const char* identifier() { return ParamHandler_t::identifier(); }
+			virtual const char* name() const CADET_NOEXCEPT { return ParamHandler_t::identifier(); }
+
+			virtual void setExternalFunctions(IExternalFunction** extFuns, unsigned int size) { _paramHandler.setExternalFunctions(extFuns, size); }
+			virtual bool dependsOnTime() const CADET_NOEXCEPT { return ParamHandler_t::dependsOnTime(); }
+			virtual bool requiresWorkspace() const CADET_NOEXCEPT { return true; }
+			virtual bool hasDynamicReactions() const CADET_NOEXCEPT { return true; }
+
+			virtual unsigned int workspaceSize(unsigned int nComp, unsigned int totalNumBoundStates, unsigned int const* nBoundStates) const CADET_NOEXCEPT
+			{
+				return _paramHandler.cacheSize(maxNumReactions(), nComp, totalNumBoundStates) + std::max(maxNumReactions() * sizeof(active), 2 * (_nComp + totalNumBoundStates) * sizeof(double)) + 2 * maxNumReactions();
+			}
+
+			virtual int const* reactionQuasiStationarity() const CADET_NOEXCEPT { return _reactionQuasiStationarity.data(); }
+			virtual bool hasQuasiStationaryReactionsBulk() const CADET_NOEXCEPT
+			{
+				return std::any_of(_reactionQuasiStationarity.begin(), _reactionQuasiStationarity.end(), [](int i) -> bool { return i; });
+			}
+
+			virtual bool configureModelDiscretization(IParameterProvider& paramProvider, unsigned int nComp, unsigned int const* nBound, unsigned int const* boundOffset)
+			{
+				DynamicReactionModelBase::configureModelDiscretization(paramProvider, nComp, nBound, boundOffset);
+
+				if (paramProvider.exists("MAL_STOICHIOMETRY_BULK"))
+				{
+					const std::size_t numElements = paramProvider.numElements("MAL_STOICHIOMETRY_BULK");
+					if (numElements % nComp != 0)
+						throw InvalidParameterException("Size of field MAL_STOICHIOMETRY_BULK must be a positive multiple of NCOMP (" + std::to_string(nComp) + ")");
+
+					const unsigned int nReactions = numElements / nComp;
+
+					_stoichiometryBulk.resize(nComp, nReactions);
+					_expBulkFwd.resize(nComp, nReactions);
+					_expBulkBwd.resize(nComp, nReactions);
+					_MconvMoityBulk.resize(nComp, nComp);
+					_quasiStationaryComponentBulkMap.resize(nComp);
+
+
+					if (paramProvider.exists("IS_KINETIC"))
+					{	// default is kinetic binding
+						_reactionQuasiStationarity.resize(_stoichiometryBulk.columns(), false);
+
+						if (paramProvider.isArray("IS_KINETIC")) {
+
+							const std::vector<int> kinetikFlag = paramProvider.getIntArray("IS_KINETIC");
+							if (kinetikFlag.size() == 1)
+							{	// Set all reactions to kinetic binding if IS_KINETIC is a single value
+								std::fill(_reactionQuasiStationarity.begin(), _reactionQuasiStationarity.end(), !static_cast<bool>(kinetikFlag[0]));
+							}
+							else if (kinetikFlag.size() < _reactionQuasiStationarity.size())
+							{
+								throw InvalidParameterException("IS_KINETIC has to have at least " + std::to_string(_reactionQuasiStationarity.size()) + " elements");
+							}
+							else
+							{	// Set reactions to kinetic or quasi statrionary according to IS_KINETIC array
+								std::transform(kinetikFlag.begin(), kinetikFlag.begin() + _reactionQuasiStationarity.size(), _reactionQuasiStationarity.begin(), [](int val) { return !static_cast<bool>(val); });
+							}
+						}
+						else
+						{	 // Set all reactions to kinetic or quasi statrionary if IS_KINETIC is not an array
+							const bool kineticBinding = paramProvider.getInt("IS_KINETIC");
+							std::fill(_reactionQuasiStationarity.begin(), _reactionQuasiStationarity.end(), !kineticBinding);
+						}
+
+						_quasiStationaryReactionIndices.clear();
+						for (int r = 0; r < _stoichiometryBulk.columns(); ++r)
+						{
+							if (_reactionQuasiStationarity[r])
+							{
+								_quasiStationaryReactionIndices.push_back(r);
+							}
+						}
+					}
+				}
+
+
+				if (!nBound || !boundOffset)
+					return true;
+
+				if (paramProvider.exists("MAL_STOICHIOMETRY_LIQUID"))
+				{
+					const std::size_t numElements = paramProvider.numElements("MAL_STOICHIOMETRY_LIQUID");
+					if (numElements % nComp != 0)
+						throw InvalidParameterException("Size of field MAL_STOICHIOMETRY_LIQUID must be a positive multiple of NCOMP (" + std::to_string(nComp) + ")");
+
+					const unsigned int nReactions = numElements / nComp;
+
+					_stoichiometryLiquid.resize(nComp, nReactions);
+					_expLiquidFwd.resize(nComp, nReactions);
+					_expLiquidBwd.resize(nComp, nReactions);
+
+					_expLiquidFwdSolid.resize(_nTotalBoundStates, nReactions);
+					_expLiquidBwdSolid.resize(_nTotalBoundStates, nReactions);
+				}
+
+				if (paramProvider.exists("MAL_STOICHIOMETRY_SOLID") && (_nTotalBoundStates > 0))
+				{
+					const std::size_t numElements = paramProvider.numElements("MAL_STOICHIOMETRY_SOLID");
+					if (numElements % _nTotalBoundStates != 0)
+						throw InvalidParameterException("Size of field MAL_STOICHIOMETRY_SOLID must be a positive multiple of NTOTALBND (" + std::to_string(_nTotalBoundStates) + ")");
+
+					const unsigned int nReactions = numElements / _nTotalBoundStates;
+
+					_stoichiometrySolid.resize(_nTotalBoundStates, nReactions);
+					_expSolidFwd.resize(_nTotalBoundStates, nReactions);
+					_expSolidBwd.resize(_nTotalBoundStates, nReactions);
+
+					_expSolidFwdLiquid.resize(nComp, nReactions);
+					_expSolidBwdLiquid.resize(nComp, nReactions);
+				}
+
+
+				return true;
+			}
+
+
+
+			virtual unsigned int numReactionsLiquid() const CADET_NOEXCEPT { return _stoichiometryBulk.columns(); }
+			virtual unsigned int numReactionsCombined() const CADET_NOEXCEPT { return _stoichiometryLiquid.columns() + _stoichiometrySolid.columns(); }
+
+			virtual unsigned int numReactionQuasiStationary() const
+			{
+				return  std::count(_reactionQuasiStationarity.begin(), _reactionQuasiStationarity.end(), true);
+			}
+
+			auto numConservedMoities() const CADET_NOEXCEPT -> unsigned int override { return _nConservedQuants; }
+
+			auto configureConservedMoity() -> bool override
+			{
+				CalcConservedMoietiesBulk();
+				return true;
+			}
+			auto matrixMoietiesBulk() -> Eigen::Matrix<active, Eigen::Dynamic, Eigen::Dynamic> override
+			{
+				return _MconvMoityBulk;
+			}
+
+			auto quasiStationaryComponentMap() const -> std::vector<int> override
+			{
+				return _quasiStationaryComponentBulkMap;
+			}
+
+
+
+			CADET_DYNAMICREACTIONMODEL_BOILERPLATE
+
+		protected:
+			ParamHandler_t _paramHandler; //!< Handles parameters and their dependence on external functions
+
+			linalg::ActiveDenseMatrix _stoichiometryBulk;
+			linalg::ActiveDenseMatrix _expBulkFwd;
+			linalg::ActiveDenseMatrix _expBulkBwd;
+
+			linalg::ActiveDenseMatrix _stoichiometryLiquid;
+			linalg::ActiveDenseMatrix _expLiquidFwd;
+			linalg::ActiveDenseMatrix _expLiquidBwd;
+			linalg::ActiveDenseMatrix _expLiquidFwdSolid;
+			linalg::ActiveDenseMatrix _expLiquidBwdSolid;
+
+			linalg::ActiveDenseMatrix _stoichiometrySolid;
+			linalg::ActiveDenseMatrix _expSolidFwd;
+			linalg::ActiveDenseMatrix _expSolidBwd;
+			linalg::ActiveDenseMatrix _expSolidFwdLiquid;
+			linalg::ActiveDenseMatrix _expSolidBwdLiquid;
+
+			//todo add these to workspace
+			std::vector<int> _reactionQuasiStationarity;
+			std::vector<int> _quasiStationaryReactionIndices;
+			std::vector<int> _quasiStationaryComponentBulkIndices; //!< Indices of components that are conserved in the bulk volume
+			std::vector<int> _quasiStationaryComponentBulkMap;
+
+
+			Eigen::Matrix<active, Eigen::Dynamic, Eigen::Dynamic> _MconvMoityBulk; //!<  Matrix with conservation of moieties in the bulk volume
+			unsigned int _nConservedQuants;
+
+
+			inline int maxNumReactions() const CADET_NOEXCEPT { return std::max(std::max(_stoichiometryBulk.columns(), _stoichiometryLiquid.columns()), _stoichiometrySolid.columns()); }
+
+			virtual bool configureImpl(IParameterProvider& paramProvider, UnitOpIdx unitOpIdx, ParticleTypeIdx parTypeIdx)
+			{
+				_paramHandler.configure(paramProvider, maxNumReactions(), _nComp, _nBoundStates);
+				_paramHandler.registerParameters(_parameters, unitOpIdx, parTypeIdx, _nComp, _nBoundStates);
+
+				if ((_stoichiometryBulk.columns() > 0) && ((static_cast<int>(_paramHandler.kFwdBulk().size()) < _stoichiometryBulk.columns()) || (static_cast<int>(_paramHandler.kBwdBulk().size()) < _stoichiometryBulk.columns())))
+					throw InvalidParameterException("MAL_KFWD_BULK and MAL_KBWD_BULK have to have the same size (number of reactions)");
+
+				if ((_stoichiometryLiquid.columns() > 0) && ((static_cast<int>(_paramHandler.kFwdLiquid().size()) < _stoichiometryLiquid.columns()) || (static_cast<int>(_paramHandler.kBwdLiquid().size()) < _stoichiometryLiquid.columns())))
+					throw InvalidParameterException("MAL_KFWD_LIQUID and MAL_KBWD_LIQUID have to have the same size (number of reactions)");
+
+				if ((_stoichiometrySolid.columns() > 0) && ((static_cast<int>(_paramHandler.kFwdSolid().size()) < _stoichiometrySolid.columns()) || (static_cast<int>(_paramHandler.kBwdSolid().size()) < _stoichiometrySolid.columns())))
+					throw InvalidParameterException("MAL_KFWD_SOLID and MAL_KBWD_SOLID have to have the same size (number of reactions)");
+
+				if (paramProvider.exists("MAL_STOICHIOMETRY_BULK"))
+				{
+					const std::vector<double> s = paramProvider.getDoubleArray("MAL_STOICHIOMETRY_BULK");
+
+					if (static_cast<int>(s.size()) != _stoichiometryBulk.elements())
+						throw InvalidParameterException("MAL_STOICHIOMETRY_BULK has changed size (number of reactions changed)");
+
+					std::copy(s.begin(), s.end(), _stoichiometryBulk.data());
+				}
+				registerCompRowMatrix(_parameters, unitOpIdx, parTypeIdx, "MAL_STOICHIOMETRY_BULK", _stoichiometryBulk);
+
+				if (paramProvider.exists("MAL_EXPONENTS_BULK_FWD"))
+				{
+					const std::vector<double> s = paramProvider.getDoubleArray("MAL_EXPONENTS_BULK_FWD");
+					if (static_cast<int>(s.size()) != _stoichiometryBulk.elements())
+						throw InvalidParameterException("Expected MAL_EXPONENTS_BULK_FWD and MAL_STOICHIOMETRY_BULK to be of the same size (" + std::to_string(_stoichiometryBulk.elements()) + ")");
+
+					std::copy(s.begin(), s.end(), _expBulkFwd.data());
 				}
 				else
 				{
-					bwd *= 0.0;
-					break;
+					// Obtain default values from stoichiometry
+					std::transform(_stoichiometryBulk.data(), _stoichiometryBulk.data() + _stoichiometryBulk.elements(), _expBulkFwd.data(), [](const active& v) { return std::max(0.0, -static_cast<double>(v)); });
 				}
-			}
-		}
-		return fwd - bwd;
-	}
+				registerCompRowMatrix(_parameters, unitOpIdx, parTypeIdx, "MAL_EXPONENTS_BULK_FWD", _expBulkFwd);
 
-	/**
- * @brief Calculates fluxes for quasi-stationary reactions
- * @details Computes reaction rates for all quasi-stationary reactions
- *          using mass action kinetics formulation
- *
- * @param [in] t Current time point
- * @param [in] secIdx Current section index
- * @param [in] colPos Column position information
- * @param [in] c Array of component concentrations
- * @param [out] fluxes Vector to store calculated fluxes
- * @param [in] workSpace Workspace for temporary data
- * @return Error code (0 if successful)
- * @tparam StateType Type of state variables (concentrations)
- * @tparam ResidualType Type of the result
- */
-	template<typename StateType, typename ResidualType>
-	int quasiStationaryFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, StateType const* c,
-		Eigen::Map<Eigen::Vector<ResidualType, Eigen::Dynamic>> fluxes, LinearBufferAllocator workSpace)
-	{
-		typename ParamHandler_t::ParamsHandle const p = _paramHandler.update(t, secIdx, colPos, _nComp, _nBoundStates, workSpace);
-		const int numQuasiStationaryReactions = std::count(_reactionQuasiStationarity.begin(), _reactionQuasiStationarity.end(), true);
-		if(numQuasiStationaryReactions == 0)
-			return 0;
-
-		for (int qsr = 0; qsr < numQuasiStationaryReactions; ++qsr)
-		{
-			int r = _quasiStationaryReactionIndices[qsr];
-			double kFwdBulk_r = static_cast<double>(p->kFwdBulk[r]);
-			double kBwdBulk_r = static_cast<double>(p->kBwdBulk[r]);
-
-			fluxes[qsr] = calculateReactionRate<StateType, ResidualType>(r, c, kFwdBulk_r, kBwdBulk_r);
-
-		}
-		return 0;
-	}
-
-	template <typename StateType, typename ResidualType, typename ParamType, typename FactorType>
-	int residualLiquidImpl(double t, unsigned int secIdx, const ColumnPosition& colPos,
-		StateType const* y, ResidualType* res, const FactorType& factor, LinearBufferAllocator workSpace) const
-	{
-		typename ParamHandler_t::ParamsHandle const p = _paramHandler.update(t, secIdx, colPos, _nComp, _nBoundStates, workSpace);
-
-		// Calculate fluxes
-		typedef typename DoubleActivePromoter<StateType, ParamType>::type flux_t;
-		BufferedArray<flux_t> fluxes = workSpace.array<flux_t>(maxNumReactions());
-		for (int r = 0; r < _stoichiometryBulk.columns(); ++r)
-		{
-			flux_t fwd = rateConstantOrZero(static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(p->kFwdBulk[r]), r, _expBulkFwd, _nComp);
-			for (int c = 0; c < _nComp; ++c)
-			{
-				if (_expBulkFwd.native(c, r) != 0.0)
+				if (paramProvider.exists("MAL_EXPONENTS_BULK_BWD"))
 				{
-					if (static_cast<double>(y[c]) > 0.0)
-						fwd *= pow(static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(y[c]),
-							static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(_expBulkFwd.native(c, r)));
-					else
+					const std::vector<double> s = paramProvider.getDoubleArray("MAL_EXPONENTS_BULK_BWD");
+					if (static_cast<int>(s.size()) != _stoichiometryBulk.elements())
+						throw InvalidParameterException("Expected MAL_EXPONENTS_BULK_BWD and MAL_STOICHIOMETRY_BULK to be of the same size (" + std::to_string(_stoichiometryBulk.elements()) + ")");
+
+					std::copy(s.begin(), s.end(), _expBulkBwd.data());
+				}
+				else
+				{
+					// Obtain default values from stoichiometry
+					std::transform(_stoichiometryBulk.data(), _stoichiometryBulk.data() + _stoichiometryBulk.elements(), _expBulkBwd.data(), [](const active& v) { return std::max(0.0, static_cast<double>(v)); });
+				}
+				registerCompRowMatrix(_parameters, unitOpIdx, parTypeIdx, "MAL_EXPONENTS_BULK_BWD", _expBulkBwd);
+
+
+				if (paramProvider.exists("MAL_STOICHIOMETRY_LIQUID"))
+				{
+					const std::vector<double> s = paramProvider.getDoubleArray("MAL_STOICHIOMETRY_LIQUID");
+
+					if (static_cast<int>(s.size()) != _stoichiometryLiquid.elements())
+						throw InvalidParameterException("MAL_STOICHIOMETRY_LIQUID has changed size (number of reactions changed)");
+
+					std::copy(s.begin(), s.end(), _stoichiometryLiquid.data());
+				}
+				registerCompRowMatrix(_parameters, unitOpIdx, parTypeIdx, "MAL_STOICHIOMETRY_LIQUID", _stoichiometryLiquid);
+
+				if (paramProvider.exists("MAL_EXPONENTS_LIQUID_FWD"))
+				{
+					const std::vector<double> s = paramProvider.getDoubleArray("MAL_EXPONENTS_LIQUID_FWD");
+					if (static_cast<int>(s.size()) != _stoichiometryLiquid.elements())
+						throw InvalidParameterException("Expected MAL_EXPONENTS_LIQUID_FWD and MAL_STOICHIOMETRY_LIQUID to be of the same size (" + std::to_string(_stoichiometryLiquid.elements()) + ")");
+
+					std::copy(s.begin(), s.end(), _expLiquidFwd.data());
+				}
+				else
+				{
+					// Obtain default values from stoichiometry
+					std::transform(_stoichiometryLiquid.data(), _stoichiometryLiquid.data() + _stoichiometryLiquid.elements(), _expLiquidFwd.data(), [](const active& v) { return std::max(0.0, -static_cast<double>(v)); });
+				}
+				registerCompRowMatrix(_parameters, unitOpIdx, parTypeIdx, "MAL_EXPONENTS_LIQUID_FWD", _expLiquidFwd);
+
+				if (paramProvider.exists("MAL_EXPONENTS_LIQUID_BWD"))
+				{
+					const std::vector<double> s = paramProvider.getDoubleArray("MAL_EXPONENTS_LIQUID_BWD");
+					if (static_cast<int>(s.size()) != _stoichiometryLiquid.elements())
+						throw InvalidParameterException("Expected MAL_EXPONENTS_LIQUID_BWD and MAL_STOICHIOMETRY_LIQUID to be of the same size (" + std::to_string(_stoichiometryLiquid.elements()) + ")");
+
+					std::copy(s.begin(), s.end(), _expLiquidBwd.data());
+				}
+				else
+				{
+					// Obtain default values from stoichiometry
+					std::transform(_stoichiometryLiquid.data(), _stoichiometryLiquid.data() + _stoichiometryLiquid.elements(), _expLiquidBwd.data(), [](const active& v) { return std::max(0.0, static_cast<double>(v)); });
+				}
+				registerCompRowMatrix(_parameters, unitOpIdx, parTypeIdx, "MAL_EXPONENTS_LIQUID_BWD", _expLiquidBwd);
+
+				if (!_nBoundStates || !_boundOffset)
+					return true;
+
+				readAndRegisterExponents(paramProvider, _parameters, unitOpIdx, parTypeIdx, "MAL_EXPONENTS_LIQUID_FWD_MODSOLID", _expLiquidFwdSolid, _nComp, _boundOffset);
+				readAndRegisterExponents(paramProvider, _parameters, unitOpIdx, parTypeIdx, "MAL_EXPONENTS_LIQUID_BWD_MODSOLID", _expLiquidBwdSolid, _nComp, _boundOffset);
+
+
+				if (paramProvider.exists("MAL_STOICHIOMETRY_SOLID"))
+				{
+					const std::vector<double> s = paramProvider.getDoubleArray("MAL_STOICHIOMETRY_SOLID");
+
+					if (static_cast<int>(s.size()) != _stoichiometrySolid.elements())
+						throw InvalidParameterException("MAL_STOICHIOMETRY_SOLID has changed size (number of reactions changed)");
+
+					std::copy(s.begin(), s.end(), _stoichiometrySolid.data());
+				}
+				registerBoundStateRowMatrix(_parameters, unitOpIdx, parTypeIdx, "MAL_STOICHIOMETRY_SOLID", _stoichiometrySolid, _nComp, _boundOffset);
+
+				if (paramProvider.exists("MAL_EXPONENTS_SOLID_FWD"))
+				{
+					const std::vector<double> s = paramProvider.getDoubleArray("MAL_EXPONENTS_SOLID_FWD");
+					if (static_cast<int>(s.size()) != _stoichiometrySolid.elements())
+						throw InvalidParameterException("Expected MAL_EXPONENTS_SOLID_FWD and MAL_STOICHIOMETRY_SOLID to be of the same size (" + std::to_string(_stoichiometrySolid.elements()) + ")");
+
+					std::copy(s.begin(), s.end(), _expSolidFwd.data());
+				}
+				else
+				{
+					// Obtain default values from stoichiometry
+					std::transform(_stoichiometrySolid.data(), _stoichiometrySolid.data() + _stoichiometrySolid.elements(), _expSolidFwd.data(), [](const active& v) { return std::max(0.0, -static_cast<double>(v)); });
+				}
+				registerBoundStateRowMatrix(_parameters, unitOpIdx, parTypeIdx, "MAL_EXPONENTS_SOLID_FWD", _expSolidFwd, _nComp, _boundOffset);
+
+				if (paramProvider.exists("MAL_EXPONENTS_SOLID_BWD"))
+				{
+					const std::vector<double> s = paramProvider.getDoubleArray("MAL_EXPONENTS_SOLID_BWD");
+					if (static_cast<int>(s.size()) != _stoichiometrySolid.elements())
+						throw InvalidParameterException("Expected MAL_EXPONENTS_SOLID_BWD and MAL_STOICHIOMETRY_SOLID to be of the same size (" + std::to_string(_stoichiometrySolid.elements()) + ")");
+
+					std::copy(s.begin(), s.end(), _expSolidBwd.data());
+				}
+				else
+				{
+					// Obtain default values from stoichiometry
+					std::transform(_stoichiometrySolid.data(), _stoichiometrySolid.data() + _stoichiometrySolid.elements(), _expSolidBwd.data(), [](const active& v) { return std::max(0.0, static_cast<double>(v)); });
+				}
+				registerBoundStateRowMatrix(_parameters, unitOpIdx, parTypeIdx, "MAL_EXPONENTS_SOLID_BWD", _expSolidBwd, _nComp, _boundOffset);
+
+				readAndRegisterExponents(paramProvider, _parameters, unitOpIdx, parTypeIdx, "MAL_EXPONENTS_SOLID_FWD_MODLIQUID", _expSolidFwdLiquid, _nComp, nullptr);
+				readAndRegisterExponents(paramProvider, _parameters, unitOpIdx, parTypeIdx, "MAL_EXPONENTS_SOLID_BWD_MODLIQUID", _expSolidBwdLiquid, _nComp, nullptr);
+
+				return true;
+			}
+			/**
+			 * @brief Calculates the net reaction rate for a single reaction
+			 * @details Computes the difference between forward and backward reaction rates
+			 *          based on mass action kinetics: rate = k * prod(c_i^n_i)
+			 *          where c_i are component concentrations and n_i are reaction orders
+			 *
+			 * @param [in] reactionIdx Index of the reaction in the stoichiometry matrix
+			 * @param [in] c Array of component concentrations
+			 * @param [in] kFwdBulk_r Forward rate constant
+			 * @param [in] kBwdBulk_r Backward rate constant
+			 * @return Net reaction rate (forward - backward)
+			 * @tparam StateType Type of state variables (concentrations)
+			 * @tparam ResidualType Type of the result
+			 */
+			template <typename StateType, typename ResidualType>
+			ResidualType calculateReactionRate(int reactionIdx, StateType const* c, double kFwdBulk_r, double kBwdBulk_r)
+			{
+				constexpr double CONCENTRATION_THRESHOLD = 1e-15;
+
+				int r = reactionIdx;
+				ResidualType fwd = rateConstantOrZero(kFwdBulk_r, r, _expBulkFwd, _nComp);
+				for (int comp = 0; comp < _nComp; ++comp)
+				{
+					if (_expBulkFwd.native(comp, r) != 0.0)
 					{
-						fwd *= 0.0;
-						break;
+						const double concentration = static_cast<double>(c[comp]);
+						if (concentration > CONCENTRATION_THRESHOLD)
+						{
+							fwd *= pow(static_cast<typename DoubleActiveDemoter<ResidualType, active>::type>(c[comp]),
+								static_cast<typename DoubleActiveDemoter<ResidualType, active>::type>(_expBulkFwd.native(comp, r)));
+						}
+						else
+						{
+							fwd *= 0.0;
+							break;
+						}
+					}
+				}
+
+				ResidualType bwd = rateConstantOrZero(kBwdBulk_r, r, _expBulkBwd, _nComp);
+				for (int comp = 0; comp < _nComp; ++comp)
+				{
+					if (_expBulkBwd.native(comp, r) != 0.0)
+					{
+						const double concentration = static_cast<double>(c[comp]);
+						if (concentration > CONCENTRATION_THRESHOLD)
+						{
+							bwd *= pow(static_cast<typename DoubleActiveDemoter<ResidualType, active>::type>(c[comp]),
+								static_cast<typename DoubleActiveDemoter<ResidualType, active>::type>(_expBulkBwd.native(comp, r)));
+						}
+						else
+						{
+							bwd *= 0.0;
+							break;
+						}
+					}
+				}
+				return fwd - bwd;
+			}
+
+			/**
+		 * @brief Calculates fluxes for quasi-stationary reactions
+		 * @details Computes reaction rates for all quasi-stationary reactions
+		 *          using mass action kinetics formulation
+		 *
+		 * @param [in] t Current time point
+		 * @param [in] secIdx Current section index
+		 * @param [in] colPos Column position information
+		 * @param [in] c Array of component concentrations
+		 * @param [out] fluxes Vector to store calculated fluxes
+		 * @param [in] workSpace Workspace for temporary data
+		 * @return Error code (0 if successful)
+		 * @tparam StateType Type of state variables (concentrations)
+		 * @tparam ResidualType Type of the result
+		 */
+			template<typename StateType, typename ResidualType>
+			int quasiStationaryFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, StateType const* c,
+				Eigen::Map<Eigen::Vector<ResidualType, Eigen::Dynamic>> fluxes, LinearBufferAllocator workSpace)
+			{
+				typename ParamHandler_t::ParamsHandle const p = _paramHandler.update(t, secIdx, colPos, _nComp, _nBoundStates, workSpace);
+				const int numQuasiStationaryReactions = std::count(_reactionQuasiStationarity.begin(), _reactionQuasiStationarity.end(), true);
+				if (numQuasiStationaryReactions == 0)
+					return 0;
+
+				for (int qsr = 0; qsr < numQuasiStationaryReactions; ++qsr)
+				{
+					int r = _quasiStationaryReactionIndices[qsr];
+					double kFwdBulk_r = static_cast<double>(p->kFwdBulk[r]);
+					double kBwdBulk_r = static_cast<double>(p->kBwdBulk[r]);
+
+					fluxes[qsr] = calculateReactionRate<StateType, ResidualType>(r, c, kFwdBulk_r, kBwdBulk_r);
+
+				}
+				return 0;
+			}
+
+			template <typename StateType, typename ResidualType, typename ParamType, typename FactorType>
+			int residualLiquidImpl(double t, unsigned int secIdx, const ColumnPosition& colPos,
+				StateType const* y, ResidualType* res, const FactorType& factor, LinearBufferAllocator workSpace) const
+			{
+				typename ParamHandler_t::ParamsHandle const p = _paramHandler.update(t, secIdx, colPos, _nComp, _nBoundStates, workSpace);
+
+				// Calculate fluxes
+				typedef typename DoubleActivePromoter<StateType, ParamType>::type flux_t;
+				BufferedArray<flux_t> fluxes = workSpace.array<flux_t>(maxNumReactions());
+				for (int r = 0; r < _stoichiometryBulk.columns(); ++r)
+				{
+					flux_t fwd = rateConstantOrZero(static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(p->kFwdBulk[r]), r, _expBulkFwd, _nComp);
+					for (int c = 0; c < _nComp; ++c)
+					{
+						if (_expBulkFwd.native(c, r) != 0.0)
+						{
+							if (static_cast<double>(y[c]) > 0.0)
+								fwd *= pow(static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(y[c]),
+									static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(_expBulkFwd.native(c, r)));
+							else
+							{
+								fwd *= 0.0;
+								break;
+							}
+						}
+					}
+
+					flux_t bwd = rateConstantOrZero(static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(p->kBwdBulk[r]), r, _expBulkBwd, _nComp);
+					for (int c = 0; c < _nComp; ++c)
+					{
+						if (_expBulkBwd.native(c, r) != 0.0)
+						{
+							if (static_cast<double>(y[c]) > 0.0)
+								bwd *= pow(static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(y[c]),
+									static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(_expBulkBwd.native(c, r)));
+							else
+							{
+								bwd *= 0.0;
+								break;
+							}
+						}
+					}
+
+					fluxes[r] = fwd - bwd;
+				}
+
+				// Add reaction terms to residual
+				_stoichiometryBulk.multiplyVector(static_cast<flux_t*>(fluxes), factor, res);
+
+				return 0;
+			}
+
+			template <typename StateType, typename ResidualType, typename ParamType>
+			int residualCombinedImpl(double t, unsigned int secIdx, const ColumnPosition& colPos,
+				StateType const* yLiquid, StateType const* ySolid, ResidualType* resLiquid, ResidualType* resSolid, double factor, LinearBufferAllocator workSpace) const
+			{
+				typename ParamHandler_t::ParamsHandle const p = _paramHandler.update(t, secIdx, colPos, _nComp, _nBoundStates, workSpace);
+
+				// Calculate fluxes in liquid phase
+				typedef typename DoubleActivePromoter<StateType, ParamType>::type flux_t;
+				BufferedArray<flux_t> fluxes = workSpace.array<flux_t>(maxNumReactions());
+				for (int r = 0; r < _stoichiometryLiquid.columns(); ++r)
+				{
+					flux_t fwd = rateConstantOrZero(static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(p->kFwdLiquid[r]), r, _expLiquidFwd, _expLiquidFwdSolid, _nComp, _nTotalBoundStates);
+					for (int c = 0; c < _nComp; ++c)
+					{
+						if (_expLiquidFwd.native(c, r) != 0.0)
+						{
+							if (static_cast<double>(yLiquid[c]) > 0.0)
+								fwd *= pow(static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(yLiquid[c]),
+									static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(_expLiquidFwd.native(c, r)));
+							else
+							{
+								fwd *= 0.0;
+								break;
+							}
+						}
+					}
+					for (int c = 0; c < _nTotalBoundStates; ++c)
+					{
+						if (_expLiquidFwdSolid.native(c, r) != 0.0)
+						{
+							if (static_cast<double>(ySolid[c]) > 0.0)
+								fwd *= pow(static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(ySolid[c]),
+									static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(_expLiquidFwdSolid.native(c, r)));
+							else
+							{
+								fwd *= 0.0;
+								break;
+							}
+						}
+					}
+
+					flux_t bwd = rateConstantOrZero(static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(p->kBwdLiquid[r]), r, _expLiquidBwd, _expLiquidBwdSolid, _nComp, _nTotalBoundStates);
+					for (int c = 0; c < _nComp; ++c)
+					{
+						if (_expLiquidBwd.native(c, r) != 0.0)
+						{
+							if (static_cast<double>(yLiquid[c]) > 0.0)
+								bwd *= pow(static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(yLiquid[c]),
+									static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(_expLiquidBwd.native(c, r)));
+							else
+							{
+								bwd *= 0.0;
+								break;
+							}
+						}
+					}
+					for (int c = 0; c < _nTotalBoundStates; ++c)
+					{
+						if (_expLiquidBwdSolid.native(c, r) != 0.0)
+						{
+							if (static_cast<double>(ySolid[c]) > 0.0)
+								bwd *= pow(static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(ySolid[c]),
+									static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(_expLiquidBwdSolid.native(c, r)));
+							else
+							{
+								bwd *= 0.0;
+								break;
+							}
+						}
+					}
+
+					fluxes[r] = fwd - bwd;
+				}
+
+				// Add reaction terms to liquid phase residual
+				_stoichiometryLiquid.multiplyVector(static_cast<flux_t*>(fluxes), factor, resLiquid);
+
+				if (_nTotalBoundStates == 0)
+					return 0;
+
+				// Calculate fluxes in solid phase
+				for (int r = 0; r < _stoichiometrySolid.columns(); ++r)
+				{
+					flux_t fwd = rateConstantOrZero(static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(p->kFwdSolid[r]), r, _expSolidFwdLiquid, _expSolidFwd, _nComp, _nTotalBoundStates);
+					for (int c = 0; c < _nComp; ++c)
+					{
+						if (_expSolidFwdLiquid.native(c, r) != 0.0)
+						{
+							if (static_cast<double>(yLiquid[c]) > 0.0)
+								fwd *= pow(static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(yLiquid[c]),
+									static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(_expSolidFwdLiquid.native(c, r)));
+							else
+							{
+								fwd *= 0.0;
+								break;
+							}
+						}
+					}
+					for (int c = 0; c < _nTotalBoundStates; ++c)
+					{
+						if (_expSolidFwd.native(c, r) != 0.0)
+						{
+							if (static_cast<double>(ySolid[c]) > 0.0)
+								fwd *= pow(static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(ySolid[c]),
+									static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(_expSolidFwd.native(c, r)));
+							else
+							{
+								fwd *= 0.0;
+								break;
+							}
+						}
+					}
+
+					flux_t bwd = rateConstantOrZero(static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(p->kBwdSolid[r]), r, _expSolidBwdLiquid, _expSolidBwd, _nComp, _nTotalBoundStates);
+					for (int c = 0; c < _nComp; ++c)
+					{
+						if (_expSolidBwdLiquid.native(c, r) != 0.0)
+						{
+							if (static_cast<double>(yLiquid[c]) > 0.0)
+								bwd *= pow(static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(yLiquid[c]),
+									static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(_expSolidBwdLiquid.native(c, r)));
+							else
+							{
+								bwd *= 0.0;
+								break;
+							}
+						}
+					}
+					for (int c = 0; c < _nTotalBoundStates; ++c)
+					{
+						if (_expSolidBwd.native(c, r) != 0.0)
+						{
+							if (static_cast<double>(ySolid[c]) > 0.0)
+								bwd *= pow(static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(ySolid[c]),
+									static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(_expSolidBwd.native(c, r)));
+							else
+							{
+								bwd *= 0.0;
+								break;
+							}
+						}
+					}
+
+					fluxes[r] = fwd - bwd;
+				}
+
+				// Add reaction terms to solid phase residual
+				_stoichiometrySolid.multiplyVector(static_cast<flux_t*>(fluxes), factor, resSolid);
+
+				return 0;
+			}
+
+			template <typename RowIterator>
+			void jacobianLiquidImpl(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double factor, const RowIterator& jac, LinearBufferAllocator workSpace) const
+			{
+				typename ParamHandler_t::ParamsHandle const p = _paramHandler.update(t, secIdx, colPos, _nComp, _nBoundStates, workSpace);
+
+				BufferedArray<double> fluxes = workSpace.array<double>(2 * _nComp);
+				double* const fluxGradFwd = static_cast<double*>(fluxes);
+				double* const fluxGradBwd = fluxGradFwd + _nComp;
+				for (int r = 0; r < _stoichiometryBulk.columns(); ++r)
+				{
+					// Calculate gradients of forward and backward fluxes
+					fluxGradLiquid(fluxGradFwd, r, _nComp, static_cast<double>(p->kFwdBulk[r]), _expBulkFwd, y);
+					fluxGradLiquid(fluxGradBwd, r, _nComp, static_cast<double>(p->kBwdBulk[r]), _expBulkBwd, y);
+
+					// Add gradients to Jacobian
+					RowIterator curJac = jac;
+					for (int row = 0; row < _nComp; ++row, ++curJac)
+					{
+						const double colFactor = static_cast<double>(_stoichiometryBulk.native(row, r)) * factor;
+						for (int col = 0; col < _nComp; ++col)
+							curJac[col - static_cast<int>(row)] += colFactor * (fluxGradFwd[col] - fluxGradBwd[col]);
 					}
 				}
 			}
 
-			flux_t bwd = rateConstantOrZero(static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(p->kBwdBulk[r]), r, _expBulkBwd, _nComp);
-			for (int c = 0; c < _nComp; ++c)
+			/**
+			 * @brief Calculates the Jacobian contribution of a quasistatonary reaction
+			 * @details Computes the derivatives of the flux with respect to each component for
+			 *          a specific reaction and adds them to the corresponding row of the Jacobian.
+			 *
+			 * @param [in] t Current time point
+			 * @param [in] secIdx Current section index
+			 * @param [in] colPos Column position information
+			 * @param [in] y Array of component concentrations
+			 * @param [in] state State (component) for which to calculate the Jacobian row
+			 * @param [in] reaction Index of the reaction to consider
+			 * @param [in,out] jac Iterator to the Jacobian row to be updated
+			 * @param [in] workSpace Workspace for temporary data
+			 * @tparam RowIterator Type of the Jacobian row iterator
+			 */
+			template <typename RowIterator>
+			void jacobianQuasiStationaryBulkImpl(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction, const RowIterator& jac, LinearBufferAllocator workSpace) const
 			{
-				if (_expBulkBwd.native(c, r) != 0.0)
-				{
-					if (static_cast<double>(y[c]) > 0.0)
-						bwd *= pow(static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(y[c]),
-							static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(_expBulkBwd.native(c, r)));
-					else
-					{
-						bwd *= 0.0;
-						break;
-					}
-				}
-			}
+				typename ParamHandler_t::ParamsHandle const p = _paramHandler.update(t, secIdx, colPos, _nComp, _nBoundStates, workSpace);
 
-			fluxes[r] = fwd - bwd;
-		}
+				BufferedArray<double> fluxes = workSpace.array<double>(2 * _nComp);
+				double* const fluxGradFwd = static_cast<double*>(fluxes);
+				double* const fluxGradBwd = fluxGradFwd + _nComp;
 
-		// Add reaction terms to residual
-		_stoichiometryBulk.multiplyVector(static_cast<flux_t*>(fluxes), factor, res);
+				int r = _quasiStationaryReactionIndices[reaction];
+				// Calculate gradients of forward and backward fluxes
+				fluxGradLiquid(fluxGradFwd, r, _nComp, static_cast<double>(p->kFwdBulk[r]), _expBulkFwd, y);
+				fluxGradLiquid(fluxGradBwd, r, _nComp, static_cast<double>(p->kBwdBulk[r]), _expBulkBwd, y);
 
-		return 0;
-	}
-
-	template <typename StateType, typename ResidualType, typename ParamType>
-	int residualCombinedImpl(double t, unsigned int secIdx, const ColumnPosition& colPos,
-		StateType const* yLiquid, StateType const* ySolid, ResidualType* resLiquid, ResidualType* resSolid, double factor, LinearBufferAllocator workSpace) const
-	{
-		typename ParamHandler_t::ParamsHandle const p = _paramHandler.update(t, secIdx, colPos, _nComp, _nBoundStates, workSpace);
-
-		// Calculate fluxes in liquid phase
-		typedef typename DoubleActivePromoter<StateType, ParamType>::type flux_t;
-		BufferedArray<flux_t> fluxes = workSpace.array<flux_t>(maxNumReactions());
-		for (int r = 0; r < _stoichiometryLiquid.columns(); ++r)
-		{
-			flux_t fwd = rateConstantOrZero(static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(p->kFwdLiquid[r]), r, _expLiquidFwd, _expLiquidFwdSolid, _nComp, _nTotalBoundStates);
-			for (int c = 0; c < _nComp; ++c)
-			{
-				if (_expLiquidFwd.native(c, r) != 0.0)
-				{
-					if (static_cast<double>(yLiquid[c]) > 0.0)
-						fwd *= pow(static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(yLiquid[c]),
-							static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(_expLiquidFwd.native(c, r)));
-					else
-					{
-						fwd *= 0.0;
-						break;
-					}
-				}
-			}
-			for (int c = 0; c < _nTotalBoundStates; ++c)
-			{
-				if (_expLiquidFwdSolid.native(c, r) != 0.0)
-				{
-					if (static_cast<double>(ySolid[c]) > 0.0)
-						fwd *= pow(static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(ySolid[c]),
-							static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(_expLiquidFwdSolid.native(c, r)));
-					else
-					{
-						fwd *= 0.0;
-						break;
-					}
-				}
-			}
-
-			flux_t bwd = rateConstantOrZero(static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(p->kBwdLiquid[r]), r, _expLiquidBwd, _expLiquidBwdSolid, _nComp, _nTotalBoundStates);
-			for (int c = 0; c < _nComp; ++c)
-			{
-				if (_expLiquidBwd.native(c, r) != 0.0)
-				{
-					if (static_cast<double>(yLiquid[c]) > 0.0)
-						bwd *= pow(static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(yLiquid[c]),
-							static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(_expLiquidBwd.native(c, r)));
-					else
-					{
-						bwd *= 0.0;
-						break;
-					}
-				}
-			}
-			for (int c = 0; c < _nTotalBoundStates; ++c)
-			{
-				if (_expLiquidBwdSolid.native(c, r) != 0.0)
-				{
-					if (static_cast<double>(ySolid[c]) > 0.0)
-						bwd *= pow(static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(ySolid[c]),
-							static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(_expLiquidBwdSolid.native(c, r)));
-					else
-					{
-						bwd *= 0.0;
-						break;
-					}
-				}
-			}
-
-			fluxes[r] = fwd - bwd;
-		}
-
-		// Add reaction terms to liquid phase residual
-		_stoichiometryLiquid.multiplyVector(static_cast<flux_t*>(fluxes), factor, resLiquid);
-
-		if (_nTotalBoundStates == 0)
-			return 0;
-
-		// Calculate fluxes in solid phase
-		for (int r = 0; r < _stoichiometrySolid.columns(); ++r)
-		{
-			flux_t fwd = rateConstantOrZero(static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(p->kFwdSolid[r]), r, _expSolidFwdLiquid, _expSolidFwd, _nComp, _nTotalBoundStates);
-			for (int c = 0; c < _nComp; ++c)
-			{
-				if (_expSolidFwdLiquid.native(c, r) != 0.0)
-				{
-					if (static_cast<double>(yLiquid[c]) > 0.0)
-						fwd *= pow(static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(yLiquid[c]),
-							static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(_expSolidFwdLiquid.native(c, r)));
-					else
-					{
-						fwd *= 0.0;
-						break;
-					}
-				}
-			}
-			for (int c = 0; c < _nTotalBoundStates; ++c)
-			{
-				if (_expSolidFwd.native(c, r) != 0.0)
-				{
-					if (static_cast<double>(ySolid[c]) > 0.0)
-						fwd *= pow(static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(ySolid[c]),
-							static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(_expSolidFwd.native(c, r)));
-					else
-					{
-						fwd *= 0.0;
-						break;
-					}
-				}
-			}
-
-			flux_t bwd = rateConstantOrZero(static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(p->kBwdSolid[r]), r, _expSolidBwdLiquid, _expSolidBwd, _nComp, _nTotalBoundStates);
-			for (int c = 0; c < _nComp; ++c)
-			{
-				if (_expSolidBwdLiquid.native(c, r) != 0.0)
-				{
-					if (static_cast<double>(yLiquid[c]) > 0.0)
-						bwd *= pow(static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(yLiquid[c]),
-							static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(_expSolidBwdLiquid.native(c, r)));
-					else
-					{
-						bwd *= 0.0;
-						break;
-					}
-				}
-			}
-			for (int c = 0; c < _nTotalBoundStates; ++c)
-			{
-				if (_expSolidBwd.native(c, r) != 0.0)
-				{
-					if (static_cast<double>(ySolid[c]) > 0.0)
-						bwd *= pow(static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(ySolid[c]),
-							static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(_expSolidBwd.native(c, r)));
-					else
-					{
-						bwd *= 0.0;
-						break;
-					}
-				}
-			}
-
-			fluxes[r] = fwd - bwd;
-		}
-
-		// Add reaction terms to solid phase residual
-		_stoichiometrySolid.multiplyVector(static_cast<flux_t*>(fluxes), factor, resSolid);
-
-		return 0;
-	}
-
-	template <typename RowIterator>
-	void jacobianLiquidImpl(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double factor, const RowIterator& jac, LinearBufferAllocator workSpace) const
-	{
-		typename ParamHandler_t::ParamsHandle const p = _paramHandler.update(t, secIdx, colPos, _nComp, _nBoundStates, workSpace);
-
-		BufferedArray<double> fluxes = workSpace.array<double>(2 * _nComp);
-		double* const fluxGradFwd = static_cast<double*>(fluxes);
-		double* const fluxGradBwd = fluxGradFwd + _nComp;
-		for (int r = 0; r < _stoichiometryBulk.columns(); ++r)
-		{
-			// Calculate gradients of forward and backward fluxes
-			fluxGradLiquid(fluxGradFwd, r, _nComp, static_cast<double>(p->kFwdBulk[r]), _expBulkFwd, y);
-			fluxGradLiquid(fluxGradBwd, r, _nComp, static_cast<double>(p->kBwdBulk[r]), _expBulkBwd, y);
-
-			// Add gradients to Jacobian
-			RowIterator curJac = jac;
-			for (int row = 0; row < _nComp; ++row, ++curJac)
-			{
-				const double colFactor = static_cast<double>(_stoichiometryBulk.native(row, r)) * factor;
+				// Add gradients to Jacobian
+				RowIterator curJac = jac;
+				const double colFactor = static_cast<double>(_stoichiometryBulk.native(state, r));
 				for (int col = 0; col < _nComp; ++col)
-					curJac[col - static_cast<int>(row)] += colFactor * (fluxGradFwd[col] - fluxGradBwd[col]);
+				{	// Row iterator is diagonal centerd 
+					curJac[col - state] += colFactor * (fluxGradFwd[col] - fluxGradBwd[col]);
+				}
+
 			}
-		}
-	}
 
-	/**
-	 * @brief Calculates the Jacobian contribution of a quasistatonary reaction 
-	 * @details Computes the derivatives of the flux with respect to each component for 
-	 *          a specific reaction and adds them to the corresponding row of the Jacobian.
-	 *
-	 * @param [in] t Current time point
-	 * @param [in] secIdx Current section index
-	 * @param [in] colPos Column position information
-	 * @param [in] y Array of component concentrations
-	 * @param [in] state State (component) for which to calculate the Jacobian row
-	 * @param [in] reaction Index of the reaction to consider
-	 * @param [in,out] jac Iterator to the Jacobian row to be updated
-	 * @param [in] workSpace Workspace for temporary data
-	 * @tparam RowIterator Type of the Jacobian row iterator
-	 */
-	template <typename RowIterator>
-	void jacobianQuasiStationaryBulkImpl(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction ,const RowIterator& jac, LinearBufferAllocator workSpace) const
-	{
-		typename ParamHandler_t::ParamsHandle const p = _paramHandler.update(t, secIdx, colPos, _nComp, _nBoundStates, workSpace);
-
-		BufferedArray<double> fluxes = workSpace.array<double>(2 * _nComp);
-		double* const fluxGradFwd = static_cast<double*>(fluxes);
-		double* const fluxGradBwd = fluxGradFwd + _nComp;
-		
-		int r = _quasiStationaryReactionIndices[reaction];
-		// Calculate gradients of forward and backward fluxes
-		fluxGradLiquid(fluxGradFwd, r, _nComp, static_cast<double>(p->kFwdBulk[r]), _expBulkFwd, y);
-		fluxGradLiquid(fluxGradBwd, r, _nComp, static_cast<double>(p->kBwdBulk[r]), _expBulkBwd, y);
-
-		// Add gradients to Jacobian
-		RowIterator curJac = jac; 
-		const double colFactor = static_cast<double>(_stoichiometryBulk.native(state, r));
-		for (int col = 0; col < _nComp; ++col)
-		{	// Row iterator is diagonal centerd 
-			curJac[col - state] += colFactor *(fluxGradFwd[col] - fluxGradBwd[col]);
-		}
-		
-	}
-
-	template <typename RowIteratorLiquid, typename RowIteratorSolid>
-	void jacobianCombinedImpl(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* yLiquid, double const* ySolid, double factor, const RowIteratorLiquid& jacLiquid, const RowIteratorSolid& jacSolid, LinearBufferAllocator workSpace) const
-	{
-		typename ParamHandler_t::ParamsHandle const p = _paramHandler.update(t, secIdx, colPos, _nComp, _nBoundStates, workSpace);
-
-		BufferedArray<double> fluxes = workSpace.array<double>(2 * (_nComp + _nTotalBoundStates));
-		double* const fluxGradFwd = static_cast<double*>(fluxes);
-		double* const fluxGradBwd = fluxGradFwd + _nComp + _nTotalBoundStates;
-
-		for (int r = 0; r < _stoichiometryLiquid.columns(); ++r)
-		{
-			// Calculate gradients of forward and backward fluxes
-			fluxGradCombined(fluxGradFwd, r, _nComp, _nTotalBoundStates, static_cast<double>(p->kFwdLiquid[r]), _expLiquidFwd, _expLiquidFwdSolid, yLiquid, ySolid);
-			fluxGradCombined(fluxGradBwd, r, _nComp, _nTotalBoundStates, static_cast<double>(p->kBwdLiquid[r]), _expLiquidBwd, _expLiquidBwdSolid, yLiquid, ySolid);
-
-			// Add gradients to Jacobian
-			RowIteratorLiquid curJac = jacLiquid;
-			for (int row = 0; row < _nComp; ++row, ++curJac)
+			template <typename RowIteratorLiquid, typename RowIteratorSolid>
+			void jacobianCombinedImpl(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* yLiquid, double const* ySolid, double factor, const RowIteratorLiquid& jacLiquid, const RowIteratorSolid& jacSolid, LinearBufferAllocator workSpace) const
 			{
-				const double colFactor = static_cast<double>(_stoichiometryLiquid.native(row, r)) * factor;
-				for (int col = 0; col < _nComp + _nTotalBoundStates; ++col)
-					curJac[col - static_cast<int>(row)] += colFactor * (fluxGradFwd[col] - fluxGradBwd[col]);
+				typename ParamHandler_t::ParamsHandle const p = _paramHandler.update(t, secIdx, colPos, _nComp, _nBoundStates, workSpace);
+
+				BufferedArray<double> fluxes = workSpace.array<double>(2 * (_nComp + _nTotalBoundStates));
+				double* const fluxGradFwd = static_cast<double*>(fluxes);
+				double* const fluxGradBwd = fluxGradFwd + _nComp + _nTotalBoundStates;
+
+				for (int r = 0; r < _stoichiometryLiquid.columns(); ++r)
+				{
+					// Calculate gradients of forward and backward fluxes
+					fluxGradCombined(fluxGradFwd, r, _nComp, _nTotalBoundStates, static_cast<double>(p->kFwdLiquid[r]), _expLiquidFwd, _expLiquidFwdSolid, yLiquid, ySolid);
+					fluxGradCombined(fluxGradBwd, r, _nComp, _nTotalBoundStates, static_cast<double>(p->kBwdLiquid[r]), _expLiquidBwd, _expLiquidBwdSolid, yLiquid, ySolid);
+
+					// Add gradients to Jacobian
+					RowIteratorLiquid curJac = jacLiquid;
+					for (int row = 0; row < _nComp; ++row, ++curJac)
+					{
+						const double colFactor = static_cast<double>(_stoichiometryLiquid.native(row, r)) * factor;
+						for (int col = 0; col < _nComp + _nTotalBoundStates; ++col)
+							curJac[col - static_cast<int>(row)] += colFactor * (fluxGradFwd[col] - fluxGradBwd[col]);
+					}
+				}
+
+				if (_nTotalBoundStates == 0)
+					return;
+
+				for (int r = 0; r < _stoichiometrySolid.columns(); ++r)
+				{
+					// Calculate gradients of forward and backward fluxes
+					fluxGradCombined(fluxGradFwd, r, _nComp, _nTotalBoundStates, static_cast<double>(p->kFwdSolid[r]), _expSolidFwdLiquid, _expSolidFwd, yLiquid, ySolid);
+					fluxGradCombined(fluxGradBwd, r, _nComp, _nTotalBoundStates, static_cast<double>(p->kBwdSolid[r]), _expSolidBwdLiquid, _expSolidBwd, yLiquid, ySolid);
+
+					// Add gradients to Jacobian
+					RowIteratorSolid curJac = jacSolid;
+					for (int row = 0; row < _nTotalBoundStates; ++row, ++curJac)
+					{
+						const double colFactor = static_cast<double>(_stoichiometrySolid.native(row, r)) * factor;
+						for (int col = 0; col < _nComp + _nTotalBoundStates; ++col)
+							curJac[col - static_cast<int>(_nComp) - static_cast<int>(row)] += colFactor * (fluxGradFwd[col] - fluxGradBwd[col]);
+					}
+				}
 			}
-		}
 
-		if (_nTotalBoundStates == 0)
-			return;
-
-		for (int r = 0; r < _stoichiometrySolid.columns(); ++r)
-		{
-			// Calculate gradients of forward and backward fluxes
-			fluxGradCombined(fluxGradFwd, r, _nComp, _nTotalBoundStates, static_cast<double>(p->kFwdSolid[r]), _expSolidFwdLiquid, _expSolidFwd, yLiquid, ySolid);
-			fluxGradCombined(fluxGradBwd, r, _nComp, _nTotalBoundStates, static_cast<double>(p->kBwdSolid[r]), _expSolidBwdLiquid, _expSolidBwd, yLiquid, ySolid);
-
-			// Add gradients to Jacobian
-			RowIteratorSolid curJac = jacSolid;
-			for (int row = 0; row < _nTotalBoundStates; ++row, ++curJac)
+			virtual void timeDerivativeQuasiStationaryReaction(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double* dY, LinearBufferAllocator workSpace)
 			{
-				const double colFactor = static_cast<double>(_stoichiometrySolid.native(row, r)) * factor;
-				for (int col = 0; col < _nComp + _nTotalBoundStates; ++col)
-					curJac[col - static_cast<int>(_nComp) - static_cast<int>(row)] += colFactor * (fluxGradFwd[col] - fluxGradBwd[col]);
+				if (!this->hasQuasiStationaryReactionsBulk())
+					return;
+
+				//if (!ParamHandler_t::dependsOnTime())
+				//	return;
+
+				typename ParamHandler_t::ParamsHandle const p = _paramHandler.update(t, secIdx, colPos, _nComp, _nBoundStates, workSpace);
+
+				for (int r = 0; r < _stoichiometryBulk.columns(); ++r)
+				{
+					if (_reactionQuasiStationarity[r] == 0)
+						continue;
+
+					double kFwdBulk_r = static_cast<double>(p->kFwdBulk[r]);
+					double kBwdBulk_r = static_cast<double>(p->kBwdBulk[r]);
+
+					double flow = calculateReactionRate<double, double>(r, y, kFwdBulk_r, kBwdBulk_r);
+					for (int c = 0; c < _nComp; ++c)
+						dY[c] = -static_cast<double>(_stoichiometryBulk.native(c, r)) * flow;
+				}
+
 			}
-		}
-	}
 
-	virtual void timeDerivativeQuasiStationaryReaction(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double* dY, LinearBufferAllocator workSpace) 
-	{
-		if (!this->hasQuasiStationaryReactionsBulk())
-			return;
+			/**
+			 * @brief Calculates conservation relations for quasi-stationary reactions in bulk phase
+			 * @details For quasi-stationary reactions, this method identifies conservation laws by
+			 *          finding the left null space of the stoichiometry matrix for the quasi-stationary
+			 *          reactions. The method populates matrix M with the conservation relations and
+			 *          marks components participating in quasi-stationary reactions in componentsInQssReactions.
+			 *
+			 * @param [in,out] conservationMatrix Matrix to be filled with conservation relations
+			 * @param [in,out] numConservationLaws Number of independent conservation laws found
+			 * @param [in,out] componentsInQssReactions Vector marking components that participate in quasi-stationary reactions (1 if active, 0 otherwise)
+			 * @tparam ResidualType Type used for the residual calculations
+			 */
+			template<typename ResidualType>
+			void ConservedMoietiesBulk(Eigen::Matrix<ResidualType, Eigen::Dynamic, Eigen::Dynamic>& conservationMatrix, int& numConservationLaws, std::vector<int>& componentsInQssReactions)
+			{
+				// Count the number of quasi-stationary reactions
+				int numQuasiStationaryReactions = std::count(_reactionQuasiStationarity.begin(), _reactionQuasiStationarity.end(), true);
+				std::fill(componentsInQssReactions.begin(), componentsInQssReactions.end(), 0);
 
-		//if (!ParamHandler_t::dependsOnTime())
-		//	return;
-		
-		typename ParamHandler_t::ParamsHandle const p = _paramHandler.update(t, secIdx, colPos, _nComp, _nBoundStates, workSpace);
+				if (numQuasiStationaryReactions == 0)
+				{
+					numConservationLaws = 0;
+					return;
+				}
+				// Create quasiStationaryStoichiometry matrix with stoichiometry of quasi-stationary reactions
+				Eigen::MatrixXd quasiStationaryStoichiometry(_stoichiometryBulk.rows(), numQuasiStationaryReactions);
 
-		for (int r = 0; r < _stoichiometryBulk.columns(); ++r)
+				int reactionIndex = 0;
+				for (int j = 0; j < _stoichiometryBulk.columns(); j++)
+				{
+					if (_reactionQuasiStationarity[j] == 0)
+						continue;
+
+					for (int i = 0; i < _stoichiometryBulk.rows(); ++i)
+					{
+						quasiStationaryStoichiometry(i, reactionIndex) = static_cast<double>(_stoichiometryBulk.native(i, j));
+					}
+					reactionIndex++;
+				}
+
+				// Count active components and mark them in componentsInQssReactions
+				std::vector<int> quasiStationaryCompIdx;
+				quasiStationaryCompIdx.reserve(_nComp);
+
+				std::vector<int> notQuasiStationaryCompIdx;
+				notQuasiStationaryCompIdx.reserve(_nComp);
+
+				if (componentsInQssReactions.size() != _nComp)
+				{
+					throw InvalidParameterException("Calculating conserved Moities: Vector for marking components in quasi stationary reactions must have size equal to number of components");
+				}
+
+				for (int i = 0; i < quasiStationaryStoichiometry.rows(); ++i)
+				{
+					bool isActive = (quasiStationaryStoichiometry.row(i).norm() >= 1e-15);
+					componentsInQssReactions[i] = isActive ? 1 : 0;
+					if (isActive)
+					{
+						quasiStationaryCompIdx.push_back(i);
+					}
+					else
+					{
+						notQuasiStationaryCompIdx.push_back(i);
+					}
+				}
+
+				// Create compressed matrix of only active rows
+				const int nActiveComponents = quasiStationaryCompIdx.size();
+				if (nActiveComponents == 0)
+				{
+					throw InvalidParameterException(
+						"Calculating conserved Moities: No components participate in quasi-stationary reactions. "
+						"Check your stoichiometry matrix."
+					);
+				}
+
+				// Extract active rows to compressed matrix
+				Eigen::MatrixXd compactStoichiometry(nActiveComponents, numQuasiStationaryReactions);
+				for (int i = 0; i < nActiveComponents; ++i)
+				{
+					compactStoichiometry.row(i) = quasiStationaryStoichiometry.row(quasiStationaryCompIdx[i]);
+				}
+
+				// Check matrix rank
+				int rank = compactStoichiometry.fullPivLu().rank();
+				if (rank != numQuasiStationaryReactions)
+				{
+					throw InvalidParameterException(
+						"Calculating conserved moieties: The stoichiometric matrix for quasi-stationary reactions "
+						"has rank " + std::to_string(rank) + " but " + std::to_string(numQuasiStationaryReactions) +
+						" reactions. This indicates redundant reactions or conservation laws, which are "
+						"not supported in combination with quasi-stationary reactions yet."
+					);
+				}
+
+				// Calculate null space of stoichiometry for conservation relations with LU decomposition
+				// This corresponds to the left null space of the stoichiometry matrix
+				Eigen::MatrixXd conservationRelations = compactStoichiometry.transpose().fullPivLu().kernel().transpose();
+				numConservationLaws = conservationRelations.rows();
+
+
+				// Create final matrix conservationMatrix with proper dimensions
+				// acording to componentsInQssReactions: 0 -> not conserved 1-> conserved (either dynamic or not)
+				int idx = 0;
+				int nonActiveIdx = 0;
+				conservationMatrix = Eigen::Matrix<ResidualType, Eigen::Dynamic, Eigen::Dynamic>::Zero(_nComp, _nComp);
+				for (int i = 0; i < _nComp; ++i)
+				{
+					if (componentsInQssReactions[i] == 0) // dynamic but not active
+					{
+						conservationMatrix(i, notQuasiStationaryCompIdx[nonActiveIdx]) = static_cast<ResidualType>(1.0);
+						nonActiveIdx++;
+					}
+					else if (idx < conservationRelations.rows())
+					{
+						int activeIdx = 0;
+						for (int j = 0; j < conservationRelations.cols(); ++j)
+						{
+							conservationMatrix(i, quasiStationaryCompIdx[activeIdx]) = static_cast<ResidualType>(conservationRelations(idx, j));
+							activeIdx++;
+						}
+						idx++;
+					}
+				}
+
+			}
+
+			void CalcConservedMoietiesBulk()
+			{
+				// Count the number of quasi-stationary reactions
+				int numQuasiStationaryReactions = std::count(_reactionQuasiStationarity.begin(), _reactionQuasiStationarity.end(), true);
+				std::fill(_quasiStationaryComponentBulkMap.begin(), _quasiStationaryComponentBulkMap.end(), 0);
+
+				if (numQuasiStationaryReactions == 0)
+				{
+					_nConservedQuants = 0;
+				}
+				// Create quasiStationaryStoichiometry matrix with stoichiometry of quasi-stationary reactions
+				Eigen::MatrixXd quasiStationaryStoichiometry(_stoichiometryBulk.rows(), numQuasiStationaryReactions);
+
+				int reactionIndex = 0;
+				for (int j = 0; j < _stoichiometryBulk.columns(); j++)
+				{
+					if (_reactionQuasiStationarity[j] == 0)
+						continue;
+
+					for (int i = 0; i < _stoichiometryBulk.rows(); ++i)
+					{
+						quasiStationaryStoichiometry(i, reactionIndex) = static_cast<double>(_stoichiometryBulk.native(i, j));
+					}
+					reactionIndex++;
+				}
+
+				// Count active components and mark them in componentsInQssReactions
+				std::vector<int> quasiStationaryCompIdx;
+				quasiStationaryCompIdx.reserve(_nComp);
+
+				std::vector<int> notQuasiStationaryCompIdx;
+				notQuasiStationaryCompIdx.reserve(_nComp);
+
+				if (_quasiStationaryComponentBulkMap.size() != _nComp)
+				{
+					throw InvalidParameterException("Calculating conserved Moities: Vector for marking components in quasi stationary reactions must have size equal to number of components");
+				}
+
+				for (int i = 0; i < quasiStationaryStoichiometry.rows(); ++i)
+				{
+					bool isActive = (quasiStationaryStoichiometry.row(i).norm() >= 1e-15);
+					_quasiStationaryComponentBulkMap[i] = isActive ? 1 : 0;
+					if (isActive)
+					{
+						quasiStationaryCompIdx.push_back(i);
+					}
+					else
+					{
+						notQuasiStationaryCompIdx.push_back(i);
+					}
+				}
+
+				// Create compressed matrix of only active rows
+				const int nActiveComponents = quasiStationaryCompIdx.size();
+				if (nActiveComponents == 0)
+				{
+					throw InvalidParameterException(
+						"Calculating conserved Moities: No components participate in quasi-stationary reactions. "
+						"Check your stoichiometry matrix."
+					);
+				}
+
+				// Extract active rows to compressed matrix
+				Eigen::MatrixXd compactStoichiometry(nActiveComponents, numQuasiStationaryReactions);
+				for (int i = 0; i < nActiveComponents; ++i)
+				{
+					compactStoichiometry.row(i) = quasiStationaryStoichiometry.row(quasiStationaryCompIdx[i]);
+				}
+
+				// Check matrix rank
+				int rank = compactStoichiometry.fullPivLu().rank();
+				if (rank != numQuasiStationaryReactions)
+				{
+					throw InvalidParameterException(
+						"Calculating conserved moieties: The stoichiometric matrix for quasi-stationary reactions "
+						"has rank " + std::to_string(rank) + " but " + std::to_string(numQuasiStationaryReactions) +
+						" reactions. This indicates redundant reactions or conservation laws, which are "
+						"not supported in combination with quasi-stationary reactions yet."
+					);
+				}
+
+				// Calculate null space of stoichiometry for conservation relations with LU decomposition
+				// This corresponds to the left null space of the stoichiometry matrix
+				Eigen::MatrixXd conservationRelations = compactStoichiometry.transpose().fullPivLu().kernel().transpose();
+				_nConservedQuants = conservationRelations.rows();
+
+
+				// Create final matrix conservationMatrix with proper dimensions
+				// acording to componentsInQssReactions: 0 -> not conserved 1-> conserved (either dynamic or not)
+				int idx = 0;
+				int nonActiveIdx = 0;
+				_MconvMoityBulk = Eigen::Matrix<active, Eigen::Dynamic, Eigen::Dynamic>::Zero(_nComp, _nComp);
+				for (int i = 0; i < _nComp; ++i)
+				{
+					if (_quasiStationaryComponentBulkMap[i] == 0) // dynamic but not active
+					{
+						_MconvMoityBulk(i, notQuasiStationaryCompIdx[nonActiveIdx]) = static_cast<active>(1.0);
+						nonActiveIdx++;
+					}
+					else if (idx < conservationRelations.rows())
+					{
+						int activeIdx = 0;
+						for (int j = 0; j < conservationRelations.cols(); ++j)
+						{
+							_MconvMoityBulk(i, quasiStationaryCompIdx[activeIdx]) = static_cast<active>(conservationRelations(idx, j));
+							activeIdx++;
+						}
+						idx++;
+					}
+				}
+
+			}
+		};
+
+		typedef MassActionLawReactionBase<MassActionLawParamHandler> MassActionLawReaction;
+		typedef MassActionLawReactionBase<ExtMassActionLawParamHandler> ExternalMassActionLawReaction;
+
+		namespace reaction
 		{
-			if (_reactionQuasiStationarity[r] == 0)
-				continue;
+			void registerMassActionLawReaction(std::unordered_map<std::string, std::function<model::IDynamicReactionModel* ()>>& reactions)
+			{
+				reactions[MassActionLawReaction::identifier()] = []() { return new MassActionLawReaction(); };
+				reactions[ExternalMassActionLawReaction::identifier()] = []() { return new ExternalMassActionLawReaction(); };
+			}
+		}  // namespace reaction
 
-			double kFwdBulk_r = static_cast<double>(p->kFwdBulk[r]);
-			double kBwdBulk_r = static_cast<double>(p->kBwdBulk[r]);
-
-			double flow = calculateReactionRate<double, double>(r, y, kFwdBulk_r, kBwdBulk_r);
-			for (int c = 0; c < _nComp; ++c)
-				dY[c] = -static_cast<double>(_stoichiometryBulk.native(c, r)) * flow;
-		}
-
-	}
-};
-
-typedef MassActionLawReactionBase<MassActionLawParamHandler> MassActionLawReaction;
-typedef MassActionLawReactionBase<ExtMassActionLawParamHandler> ExternalMassActionLawReaction;
-
-namespace reaction
-{
-	void registerMassActionLawReaction(std::unordered_map<std::string, std::function<model::IDynamicReactionModel*()>>& reactions)
-	{
-		reactions[MassActionLawReaction::identifier()] = []() { return new MassActionLawReaction(); };
-		reactions[ExternalMassActionLawReaction::identifier()] = []() { return new ExternalMassActionLawReaction(); };
-	}
-}  // namespace reaction
-
-}  // namespace model
+	}  // namespace model
 
 }  // namespace cadet

--- a/src/libcadet/model/reaction/MassActionLawReaction.cpp
+++ b/src/libcadet/model/reaction/MassActionLawReaction.cpp
@@ -323,7 +323,7 @@ namespace cadet
 			}
 
 			virtual int const* reactionQuasiStationarity() const CADET_NOEXCEPT { return _reactionQuasiStationarity.data(); }
-			virtual bool hasQuasiStationaryReactionsBulk() const CADET_NOEXCEPT
+			auto  hasQuasiStationaryReactionsBulk() const CADET_NOEXCEPT -> bool
 			{
 				return std::any_of(_reactionQuasiStationarity.begin(), _reactionQuasiStationarity.end(), [](int i) -> bool { return i; });
 			}
@@ -432,7 +432,7 @@ namespace cadet
 			virtual unsigned int numReactionsLiquid() const CADET_NOEXCEPT { return _stoichiometryBulk.columns(); }
 			virtual unsigned int numReactionsCombined() const CADET_NOEXCEPT { return _stoichiometryLiquid.columns() + _stoichiometrySolid.columns(); }
 
-			virtual unsigned int numReactionQuasiStationary() const
+			auto numReactionQuasiStationary() const -> unsigned int  override
 			{
 				return  std::count(_reactionQuasiStationarity.begin(), _reactionQuasiStationarity.end(), true);
 			}
@@ -1031,7 +1031,7 @@ namespace cadet
 				return 0;
 			}
 
-			void timeDerivativeQuasiStationaryReaction(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double* dY, LinearBufferAllocator workSpace) const
+			void timeDerivativeQuasiStationaryReaction(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double* dY, LinearBufferAllocator workSpace) const override
 			{
 				if (!this->hasQuasiStationaryReactionsBulk())
 					return;
@@ -1181,6 +1181,7 @@ namespace cadet
 				if (numQuasiStationaryReactions == 0)
 				{
 					_nConservedQuants = 0;
+					return;
 				}
 				// Create quasiStationaryStoichiometry matrix with stoichiometry of quasi-stationary reactions
 				Eigen::MatrixXd quasiStationaryStoichiometry(_stoichiometryBulk.rows(), numQuasiStationaryReactions);
@@ -1263,8 +1264,8 @@ namespace cadet
 				// acording to componentsInQssReactions: 0 -> not conserved 1-> conserved (either dynamic or not)
 				int mIdx = 0;
 				int nonActiveIdx = 0;
-				_MconvMoityBulk = Eigen::Matrix<active, Eigen::Dynamic, Eigen::Dynamic>::Zero(_nComp , _nComp); //todo so groß wie der ganze state vector vielleicht als einheintsmatrix anlegen?
-				for (int i = 0; i < _nComp; ++i) //todo den ganzen state vector entlang
+				_MconvMoityBulk = Eigen::Matrix<active, Eigen::Dynamic, Eigen::Dynamic>::Zero(_nComp , _nComp);
+				for (int i = 0; i < _nComp; ++i)
 				{
 					if (_quasiStationaryComponentBulkMap[i] == 0) // dynamic but not active
 					{

--- a/src/libcadet/model/reaction/MassActionLawReaction.cpp
+++ b/src/libcadet/model/reaction/MassActionLawReaction.cpp
@@ -318,7 +318,7 @@ public:
 
 	virtual unsigned int workspaceSize(unsigned int nComp, unsigned int totalNumBoundStates, unsigned int const* nBoundStates) const CADET_NOEXCEPT
 	{
-		return _paramHandler.cacheSize(maxNumReactions(), nComp, totalNumBoundStates) + std::max(maxNumReactions() * sizeof(active), 2 * (_nComp + totalNumBoundStates) * sizeof(double));
+		return _paramHandler.cacheSize(maxNumReactions(), nComp, totalNumBoundStates) + std::max(maxNumReactions() * sizeof(active), 2 * (_nComp + totalNumBoundStates) * sizeof(double)) + 2*maxNumReactions();
 	}
 	
 	virtual int const* reactionQuasiStationarity() const CADET_NOEXCEPT { return _reactionQuasiStationarity.data(); }
@@ -1052,37 +1052,7 @@ protected:
 			}
 		}
 	}
-	//todp: vielleicht kann die funktion weg
-	template <typename RowIterator>
-	void jacobianSingleFluxImpl(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction, const RowIterator& jac, LinearBufferAllocator workSpace) const
-	{
-		
-		if(reaction >= _stoichiometryBulk.columns())
-			return;
 
-		typename ParamHandler_t::ParamsHandle const p = _paramHandler.update(t, secIdx, colPos, _nComp, _nBoundStates, workSpace);
-		
-		BufferedArray<double> fluxes = workSpace.array<double>(2 * _nComp);
-		double* const fluxGradFwd = static_cast<double*>(fluxes);
-		double* const fluxGradBwd = fluxGradFwd + _nComp;
-
-
-		for (int r = 0; r < _stoichiometryBulk.columns(); ++r)
-		{
-			if (_reactionQuasiStationarity[r])
-				continue;
-			// Calculate gradients of forward and backward fluxes
-			fluxGradLiquid(fluxGradFwd, r, _nComp, static_cast<double>(p->kFwdBulk[r]), _expBulkFwd, y);
-			fluxGradLiquid(fluxGradBwd, r, _nComp, static_cast<double>(p->kBwdBulk[r]), _expBulkBwd, y);
-
-			// Add gradients to Jacobian
-			RowIterator curJac = jac;
-				const double colFactor = static_cast<double>(_stoichiometryBulk.native(state, r)) * 1.0;
-				for (int col = 0; col < _nComp; ++col)
-					curJac[col - static_cast<int>(state)] += colFactor * (fluxGradFwd[col] - fluxGradBwd[col]);
-
-		}
-	}
 	/**
 	 * @brief Calculates the Jacobian contribution of a quasistatonary reaction 
 	 * @details Computes the derivatives of the flux with respect to each component for 
@@ -1092,8 +1062,8 @@ protected:
 	 * @param [in] secIdx Current section index
 	 * @param [in] colPos Column position information
 	 * @param [in] y Array of component concentrations
-	 * @param [in] stateIdx State (component) for which to calculate the Jacobian row
-	 * @param [in] reactionIdx Index of the reaction to consider
+	 * @param [in] state State (component) for which to calculate the Jacobian row
+	 * @param [in] reaction Index of the reaction to consider
 	 * @param [in,out] jac Iterator to the Jacobian row to be updated
 	 * @param [in] workSpace Workspace for temporary data
 	 * @tparam RowIterator Type of the Jacobian row iterator

--- a/src/libcadet/model/reaction/MichaelisMentenReaction.cpp
+++ b/src/libcadet/model/reaction/MichaelisMentenReaction.cpp
@@ -152,6 +152,9 @@ public:
 
 	virtual unsigned int numReactionsLiquid() const CADET_NOEXCEPT { return _stoichiometryBulk.columns(); }
 	virtual unsigned int numReactionsCombined() const CADET_NOEXCEPT { return 0; }
+	void fillConservedMoietiesBulk(Eigen::MatrixXd& M, std::vector<int>& QSReaction, std::vector<int>& QSComponent) {}
+	virtual int quasiStationaryFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,
+		active* fluxes, std::vector<int>& mapQSReac, LinearBufferAllocator workSpace) const { return 0; }
 
 	CADET_DYNAMICREACTIONMODEL_BOILERPLATE
 

--- a/src/libcadet/model/reaction/MichaelisMentenReaction.cpp
+++ b/src/libcadet/model/reaction/MichaelisMentenReaction.cpp
@@ -152,7 +152,6 @@ public:
 	virtual int const* reactionQuasiStationarity() const CADET_NOEXCEPT { return nullptr; }
 	virtual unsigned int numReactionsLiquid() const CADET_NOEXCEPT { return _stoichiometryBulk.columns(); }
 	virtual unsigned int numReactionsCombined() const CADET_NOEXCEPT { return 0; }
-	void fillConservedMoietiesBulk(Eigen::MatrixXd& M, unsigned int& QSReaction, std::vector<int>& QSComponent) {}
 
 	template <typename RowIterator>
 	void jacobianQuasiSteadyLiquidImpl(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction ,const RowIterator& jac, LinearBufferAllocator workSpace) const { }
@@ -161,14 +160,9 @@ public:
 	void jacobianSingleFluxImpl(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction, const RowIterator& jac, LinearBufferAllocator workSpace) const { }
 	
 	virtual void timeDerivativeQuasiStationaryReaction(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double* dReacDt, LinearBufferAllocator workSpace) { }
-	virtual int quasiStationaryFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, active const* y,
-		Eigen::Map<Eigen::VectorXd> fluxes, int const* mapQSReac, LinearBufferAllocator workSpace) {
-		return 0;
-	}
-	virtual int quasiStationaryFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,
-		Eigen::Map<Eigen::VectorXd> fluxes, int const* mapQSReac, LinearBufferAllocator workSpace) {
-		return 0;
-	}
+	template<typename StateType, typename ResidualType>
+	int quasiStationaryFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, StateType const* y,
+		Eigen::Map<Eigen::Vector<ResidualType, Eigen::Dynamic>> fluxes, int const* mapQSReac, LinearBufferAllocator workSpace) {return 0;}
 
 	CADET_DYNAMICREACTIONMODEL_BOILERPLATE
 

--- a/src/libcadet/model/reaction/MichaelisMentenReaction.cpp
+++ b/src/libcadet/model/reaction/MichaelisMentenReaction.cpp
@@ -154,7 +154,7 @@ public:
 	virtual unsigned int numReactionsCombined() const CADET_NOEXCEPT { return 0; }
 	virtual unsigned int numReactionQuasiStationary() const CADET_NOEXCEPT { return 0; }
 	template <typename ResidualType>
-	void fillConservedMoietiesBulk21(Eigen::Matrix<ResidualType, Eigen::Dynamic, Eigen::Dynamic>& M, std::vector<int>& QsCompBulk) {}
+	void fillConservedMoietiesBulk21(Eigen::Matrix<ResidualType, Eigen::Dynamic, Eigen::Dynamic>& M, int& QsCompBulk) {}
 
 	template <typename RowIterator>
 	void jacobianQuasiSteadyLiquidImpl(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction ,const RowIterator& jac, LinearBufferAllocator workSpace) const { }

--- a/src/libcadet/model/reaction/MichaelisMentenReaction.cpp
+++ b/src/libcadet/model/reaction/MichaelisMentenReaction.cpp
@@ -153,11 +153,11 @@ public:
 	virtual unsigned int numReactionsLiquid() const CADET_NOEXCEPT { return _stoichiometryBulk.columns(); }
 	virtual unsigned int numReactionsCombined() const CADET_NOEXCEPT { return 0; }
 	virtual unsigned int numReactionQuasiStationary() const CADET_NOEXCEPT { return 0; }
-	template <typename ResidualType>
-	void fillConservedMoietiesBulk21(Eigen::Matrix<ResidualType, Eigen::Dynamic, Eigen::Dynamic>& M, int& QsCompBulk) {}
+	template<typename ResidualType>
+	void ConservedMoietiesBulk(Eigen::Matrix<ResidualType, Eigen::Dynamic, Eigen::Dynamic>& M, int& conservedState, std::vector<int>& QsCompBulk) {}
 
 	template <typename RowIterator>
-	void jacobianQuasiSteadyLiquidImpl(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction ,const RowIterator& jac, LinearBufferAllocator workSpace) const { }
+	void jacobianQuasiStationaryBulkImpl(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction ,const RowIterator& jac, LinearBufferAllocator workSpace) const { }
 	
 	template <typename RowIterator>
 	void jacobianSingleFluxImpl(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction, const RowIterator& jac, LinearBufferAllocator workSpace) const { }
@@ -165,7 +165,7 @@ public:
 	virtual void timeDerivativeQuasiStationaryReaction(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double* dReacDt, LinearBufferAllocator workSpace) { }
 	template<typename StateType, typename ResidualType>
 	int quasiStationaryFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, StateType const* y,
-		Eigen::Map<Eigen::Vector<ResidualType, Eigen::Dynamic>> fluxes, int const* mapQSReac, LinearBufferAllocator workSpace) {return 0;}
+		Eigen::Map<Eigen::Vector<ResidualType, Eigen::Dynamic>> fluxes, LinearBufferAllocator workSpace) {return 0;}
 
 	CADET_DYNAMICREACTIONMODEL_BOILERPLATE
 

--- a/src/libcadet/model/reaction/MichaelisMentenReaction.cpp
+++ b/src/libcadet/model/reaction/MichaelisMentenReaction.cpp
@@ -153,8 +153,20 @@ public:
 	virtual unsigned int numReactionsLiquid() const CADET_NOEXCEPT { return _stoichiometryBulk.columns(); }
 	virtual unsigned int numReactionsCombined() const CADET_NOEXCEPT { return 0; }
 	void fillConservedMoietiesBulk(Eigen::MatrixXd& M, std::vector<int>& QSReaction, std::vector<int>& QSComponent) {}
+
+	template <typename RowIterator>
+	void jacobianQuasiSteadyLiquidImpl(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double factor, const RowIterator& jac, LinearBufferAllocator workSpace) const { }
+
+
+	virtual int quasiStationaryFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, active const* y,
+		Eigen::Map<Eigen::VectorXd> fluxes, std::vector<int> mapQSReac, LinearBufferAllocator workSpace) {
+		return 0;
+	}
+
 	virtual int quasiStationaryFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,
-		active* fluxes, std::vector<int>& mapQSReac, LinearBufferAllocator workSpace) const { return 0; }
+		Eigen::Map<Eigen::VectorXd> fluxes, std::vector<int> mapQSReac, LinearBufferAllocator workSpace) {
+		return 0;
+	}
 
 	CADET_DYNAMICREACTIONMODEL_BOILERPLATE
 
@@ -171,7 +183,7 @@ protected:
 
 		if ((_stoichiometryBulk.columns() > 0) && ((_paramHandler.vMax().size() < _stoichiometryBulk.columns()) || (_paramHandler.kMM().size() < _stoichiometryBulk.columns())))
 			throw InvalidParameterException("MM_VMAX and MM_KMM have to have the same size (number of reactions)");
-		
+
 		if ((_stoichiometryBulk.columns() > 0) && (_paramHandler.kInhibit().size() < _stoichiometryBulk.columns() * _nComp))
 			throw InvalidParameterException("MM_KI have to have the size (number of reactions) x (number of components)");
 
@@ -222,7 +234,7 @@ protected:
 				continue;
 			}
 
-			fluxes[r] = static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(p->vMax[r]) * y[idxSubs] / (static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(p->kMM[r]) + y[idxSubs]);
+			fluxes[r] = static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(p->vMax[r])* y[idxSubs] / (static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(p->kMM[r]) + y[idxSubs]);
 
 			for (int comp = 0; comp < _nComp; ++comp)
 			{
@@ -306,9 +318,8 @@ protected:
 	}
 
 	template <typename RowIteratorLiquid, typename RowIteratorSolid>
-	void jacobianCombinedImpl(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* yLiquid, double const* ySolid, double factor, const RowIteratorLiquid& jacLiquid, const RowIteratorSolid& jacSolid, LinearBufferAllocator workSpace) const
-	{
-	}
+	void jacobianCombinedImpl(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* yLiquid, double const* ySolid, double factor, const RowIteratorLiquid& jacLiquid, const RowIteratorSolid& jacSolid, LinearBufferAllocator workSpace) const {}
+
 };
 
 typedef MichaelisMentenReactionBase<MichaelisMentenParamHandler> MichaelisMentenReaction;

--- a/src/libcadet/model/reaction/MichaelisMentenReaction.cpp
+++ b/src/libcadet/model/reaction/MichaelisMentenReaction.cpp
@@ -155,14 +155,12 @@ public:
 	void fillConservedMoietiesBulk(Eigen::MatrixXd& M, std::vector<int>& QSReaction, std::vector<int>& QSComponent) {}
 
 	template <typename RowIterator>
-	void jacobianQuasiSteadyLiquidImpl(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double factor, const RowIterator& jac, LinearBufferAllocator workSpace) const { }
-
-
+	void jacobianQuasiSteadyLiquidImpl(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction ,const RowIterator& jac, LinearBufferAllocator workSpace) const { }
+	virtual void timeDerivativeQuasiStationaryReaction(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double* dReacDt, LinearBufferAllocator workSpace) { }
 	virtual int quasiStationaryFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, active const* y,
 		Eigen::Map<Eigen::VectorXd> fluxes, std::vector<int> mapQSReac, LinearBufferAllocator workSpace) {
 		return 0;
 	}
-
 	virtual int quasiStationaryFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,
 		Eigen::Map<Eigen::VectorXd> fluxes, std::vector<int> mapQSReac, LinearBufferAllocator workSpace) {
 		return 0;

--- a/src/libcadet/model/reaction/MichaelisMentenReaction.cpp
+++ b/src/libcadet/model/reaction/MichaelisMentenReaction.cpp
@@ -156,6 +156,10 @@ public:
 
 	template <typename RowIterator>
 	void jacobianQuasiSteadyLiquidImpl(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction ,const RowIterator& jac, LinearBufferAllocator workSpace) const { }
+	
+	template <typename RowIterator>
+	void jacobianSingleFluxImpl(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction, const RowIterator& jac, LinearBufferAllocator workSpace) const { }
+	
 	virtual void timeDerivativeQuasiStationaryReaction(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double* dReacDt, LinearBufferAllocator workSpace) { }
 	virtual int quasiStationaryFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, active const* y,
 		Eigen::Map<Eigen::VectorXd> fluxes, std::vector<int> mapQSReac, LinearBufferAllocator workSpace) {

--- a/src/libcadet/model/reaction/MichaelisMentenReaction.cpp
+++ b/src/libcadet/model/reaction/MichaelisMentenReaction.cpp
@@ -162,7 +162,6 @@ public:
 	template <typename RowIterator>
 	void jacobianSingleFluxImpl(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction, const RowIterator& jac, LinearBufferAllocator workSpace) const { }
 	
-	virtual void timeDerivativeQuasiStationaryReaction(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double* dReacDt, LinearBufferAllocator workSpace) { }
 	template<typename StateType, typename ResidualType>
 	int quasiStationaryFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, StateType const* y,
 		Eigen::Map<Eigen::Vector<ResidualType, Eigen::Dynamic>> fluxes, LinearBufferAllocator workSpace) {return 0;}

--- a/src/libcadet/model/reaction/MichaelisMentenReaction.cpp
+++ b/src/libcadet/model/reaction/MichaelisMentenReaction.cpp
@@ -149,10 +149,10 @@ public:
 
 		return true;
 	}
-
+	virtual int const* reactionQuasiStationarity() const CADET_NOEXCEPT { return nullptr; }
 	virtual unsigned int numReactionsLiquid() const CADET_NOEXCEPT { return _stoichiometryBulk.columns(); }
 	virtual unsigned int numReactionsCombined() const CADET_NOEXCEPT { return 0; }
-	void fillConservedMoietiesBulk(Eigen::MatrixXd& M, std::vector<int>& QSReaction, std::vector<int>& QSComponent) {}
+	void fillConservedMoietiesBulk(Eigen::MatrixXd& M, unsigned int& QSReaction, std::vector<int>& QSComponent) {}
 
 	template <typename RowIterator>
 	void jacobianQuasiSteadyLiquidImpl(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction ,const RowIterator& jac, LinearBufferAllocator workSpace) const { }
@@ -162,11 +162,11 @@ public:
 	
 	virtual void timeDerivativeQuasiStationaryReaction(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double* dReacDt, LinearBufferAllocator workSpace) { }
 	virtual int quasiStationaryFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, active const* y,
-		Eigen::Map<Eigen::VectorXd> fluxes, std::vector<int> mapQSReac, LinearBufferAllocator workSpace) {
+		Eigen::Map<Eigen::VectorXd> fluxes, int const* mapQSReac, LinearBufferAllocator workSpace) {
 		return 0;
 	}
 	virtual int quasiStationaryFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,
-		Eigen::Map<Eigen::VectorXd> fluxes, std::vector<int> mapQSReac, LinearBufferAllocator workSpace) {
+		Eigen::Map<Eigen::VectorXd> fluxes, int const* mapQSReac, LinearBufferAllocator workSpace) {
 		return 0;
 	}
 

--- a/src/libcadet/model/reaction/MichaelisMentenReaction.cpp
+++ b/src/libcadet/model/reaction/MichaelisMentenReaction.cpp
@@ -152,6 +152,9 @@ public:
 	virtual int const* reactionQuasiStationarity() const CADET_NOEXCEPT { return nullptr; }
 	virtual unsigned int numReactionsLiquid() const CADET_NOEXCEPT { return _stoichiometryBulk.columns(); }
 	virtual unsigned int numReactionsCombined() const CADET_NOEXCEPT { return 0; }
+	virtual unsigned int numReactionQuasiStationary() const CADET_NOEXCEPT { return 0; }
+	template <typename ResidualType>
+	void fillConservedMoietiesBulk21(Eigen::Matrix<ResidualType, Eigen::Dynamic, Eigen::Dynamic>& M, std::vector<int>& QsCompBulk) {}
 
 	template <typename RowIterator>
 	void jacobianQuasiSteadyLiquidImpl(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, int state, int reaction ,const RowIterator& jac, LinearBufferAllocator workSpace) const { }

--- a/src/libcadet/model/reaction/ReactionModelBase.cpp
+++ b/src/libcadet/model/reaction/ReactionModelBase.cpp
@@ -87,6 +87,7 @@ bool DynamicReactionModelBase::setParameter(const ParameterId& pId, bool value)
 	return false;
 }
 
+
 active* DynamicReactionModelBase::getParameter(const ParameterId& pId)
 {
 	auto paramHandle = _parameters.find(pId);

--- a/src/libcadet/model/reaction/ReactionModelBase.hpp
+++ b/src/libcadet/model/reaction/ReactionModelBase.hpp
@@ -65,6 +65,8 @@ public:
 	
 	virtual int quasiStationaryFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,
 		Eigen::Map<Eigen::VectorXd> fluxes, std::vector<int> mapQSReac, LinearBufferAllocator workSpace) = 0;
+
+	virtual void timeDerivativeQuasiStationaryReaction(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double* dReacDt, LinearBufferAllocator workSpace) = 0;
 	
 protected:
 	int _nComp; //!< Number of components
@@ -167,27 +169,27 @@ protected:
 		jacobianLiquidImpl(t, secIdx, colPos, y, factor, jac, workSpace);                                                                               \
 	}                                                                                                                                                   \
 		virtual void analyticQuasiSteadyJacobianLiquid(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,                    \
-		double factor, linalg::BandMatrix::RowIterator jac, LinearBufferAllocator workSpace) const                                                      \
+		int state,int reaction, linalg::BandMatrix::RowIterator jac, LinearBufferAllocator workSpace) const                                                      \
 	{                                                                                                                                                   \
-		jacobianQuasiSteadyLiquidImpl(t, secIdx, colPos, y, factor, jac, workSpace);                                                                    \
+		jacobianQuasiSteadyLiquidImpl(t, secIdx, colPos, y, state, reaction,jac, workSpace);                                                                    \
 	}                                                                                                                                                   \
 	                                                                                                                                                    \
 	virtual void analyticQuasiSteadyJacobianLiquid(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,                        \
-		double factor, linalg::DenseBandedRowIterator jac, LinearBufferAllocator workSpace) const                                                       \
+		int state, int reaction,linalg::DenseBandedRowIterator jac, LinearBufferAllocator workSpace) const                                                       \
 	{                                                                                                                                                   \
-		jacobianQuasiSteadyLiquidImpl(t, secIdx, colPos, y, factor, jac, workSpace);                                                                    \
+		jacobianQuasiSteadyLiquidImpl(t, secIdx, colPos, y, state, reaction,jac, workSpace);                                                                    \
 	}                                                                                                                                                   \
 	                                                                                                                                                    \
 	virtual void analyticQuasiSteadyJacobianLiquid(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,                        \
-		double factor, linalg::BandedSparseRowIterator jac, LinearBufferAllocator workSpace) const                                                      \
+		int state, int reaction,linalg::BandedSparseRowIterator jac, LinearBufferAllocator workSpace) const                                                      \
 	{                                                                                                                                                   \
-		jacobianQuasiSteadyLiquidImpl(t, secIdx, colPos, y, factor, jac, workSpace);                                                                    \
+		jacobianQuasiSteadyLiquidImpl(t, secIdx, colPos, y, state, reaction, jac, workSpace);                                                                    \
 	}                                                                                                                                                   \
 	                                                                                                                                                    \
 	virtual void analyticQuasiSteadyJacobianLiquid(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,                        \
-		double factor, linalg::BandedEigenSparseRowIterator jac, LinearBufferAllocator workSpace) const                                                 \
+		int state,int reaction, linalg::BandedEigenSparseRowIterator jac, LinearBufferAllocator workSpace) const                                                 \
 	{                                                                                                                                                   \
-		jacobianQuasiSteadyLiquidImpl(t, secIdx, colPos, y, factor, jac, workSpace);                                                                    \
+		jacobianQuasiSteadyLiquidImpl(t, secIdx, colPos, y, state, reaction,jac, workSpace);                                                                    \
 	}																																					\
 																																						\
 	virtual void analyticJacobianCombinedAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* yLiquid, double const* ySolid,  \

--- a/src/libcadet/model/reaction/ReactionModelBase.hpp
+++ b/src/libcadet/model/reaction/ReactionModelBase.hpp
@@ -254,7 +254,7 @@ protected:
 		return quasiStationaryFlux( t, secIdx,   colPos,  y, fluxes, mapQSReac, workSpace);																			\
 	}																																					\
 																																						\
-	virtual void fillConservedMoietiesBulk2(Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>& M, std::vector<int>& QsCompBulk)\
+	virtual void fillConservedMoietiesBulk2(Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>& M, int& QsCompBulk)\
 	{\
 		fillConservedMoietiesBulk21(M, QsCompBulk);\
 	}\

--- a/src/libcadet/model/reaction/ReactionModelBase.hpp
+++ b/src/libcadet/model/reaction/ReactionModelBase.hpp
@@ -19,8 +19,8 @@
 #define LIBCADET_REACTIONMODELBASE_HPP_
 
 #include "model/ReactionModel.hpp"
-#include "linalg/ActiveDenseMatrix.hpp"
 #include "ParamIdUtil.hpp"
+
 #include <unordered_map>
 
 namespace cadet
@@ -58,16 +58,11 @@ public:
 
 	virtual void setExternalFunctions(IExternalFunction** extFuns, unsigned int size) { }
 
-	virtual bool hasQuasiStationaryReactionsBulk() const CADET_NOEXCEPT { return false;}
-	virtual int const* reactionQuasiStationarity() const = 0;
-
-	
 protected:
 	int _nComp; //!< Number of components
 	unsigned int const* _nBoundStates; //!< Array with number of bound states for each component
 	unsigned int const* _boundOffset; //!< Array with offsets to the first bound state of each component
 	int _nTotalBoundStates;
-	
 
 	std::unordered_map<ParameterId, active*> _parameters; //!< Map used to translate ParameterIds to actual variables
 
@@ -96,7 +91,7 @@ protected:
  *          The implementation is inserted inline in the class declaration.
  */
 #ifdef ENABLE_DG
-#define CADET_DYNAMICREACTIONMODEL_BOILERPLATE                                                                                                         \
+#define CADET_DYNAMICREACTIONMODEL_BOILERPLATE                                                                                                          \
 	virtual int residualLiquidAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, active const* y,                                         \
 		active* res, const active& factor, LinearBufferAllocator workSpace) const                                                                       \
 	{                                                                                                                                                   \
@@ -162,32 +157,9 @@ protected:
 	{                                                                                                                                                   \
 		jacobianLiquidImpl(t, secIdx, colPos, y, factor, jac, workSpace);                                                                               \
 	}                                                                                                                                                   \
-		virtual void analyticJacobianQuasiStationaryReaction(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,                    \
-		int state,int reaction, linalg::BandMatrix::RowIterator jac, LinearBufferAllocator workSpace) const                                             \
-	{                                                                                                                                                   \
-		jacobianQuasiStationaryBulkImpl(t, secIdx, colPos, y, state, reaction,jac, workSpace);                                                            \
-	}                                                                                                                                                   \
-	                                                                                                                                                    \
-	virtual void analyticJacobianQuasiStationaryReaction(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,                        \
-		int state, int reaction,linalg::DenseBandedRowIterator jac, LinearBufferAllocator workSpace) const                                              \
-	{                                                                                                                                                   \
-		jacobianQuasiStationaryBulkImpl(t, secIdx, colPos, y, state, reaction,jac, workSpace);                                                            \
-	}                                                                                                                                                   \
-	                                                                                                                                                    \
-	virtual void analyticJacobianQuasiStationaryReaction(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,                        \
-		int state, int reaction,linalg::BandedSparseRowIterator jac, LinearBufferAllocator workSpace) const                                             \
-	{                                                                                                                                                   \
-		jacobianQuasiStationaryBulkImpl(t, secIdx, colPos, y, state, reaction, jac, workSpace);                                                           \
-	}                                                                                                                                                   \
-	                                                                                                                                                    \
-	virtual void analyticJacobianQuasiStationaryReaction(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,                        \
-		int state,int reaction, linalg::BandedEigenSparseRowIterator jac, LinearBufferAllocator workSpace) const                                        \
-	{                                                                                                                                                   \
-		jacobianQuasiStationaryBulkImpl(t, secIdx, colPos, y, state, reaction,jac, workSpace);                                                            \
-	}																																					\
-																																						\
+		                                                                                                                                                \
 	virtual void analyticJacobianCombinedAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* yLiquid, double const* ySolid,  \
-		double factor, linalg::BandedEigenSparseRowIterator jacLiquid, linalg::DenseBandedRowIterator jacSolid, LinearBufferAllocator workSpace) const	\
+		double factor, linalg::BandedEigenSparseRowIterator jacLiquid, linalg::DenseBandedRowIterator jacSolid, LinearBufferAllocator workSpace) const \
 	{                                                                                                                                                   \
 		jacobianCombinedImpl(t, secIdx, colPos, yLiquid, ySolid, factor, jacLiquid, jacSolid, workSpace);                                               \
 	}                                                                                                                                                   \
@@ -208,33 +180,7 @@ protected:
 		double factor, linalg::BandMatrix::RowIterator jacLiquid, linalg::DenseBandedRowIterator jacSolid, LinearBufferAllocator workSpace) const       \
 	{                                                                                                                                                   \
 		jacobianCombinedImpl(t, secIdx, colPos, yLiquid, ySolid, factor, jacLiquid, jacSolid, workSpace);                                               \
-	}																																					\
-																																						\
-	virtual int computeQuasiStationaryReactionFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,										\
-		Eigen::Map<Eigen::Vector<active, Eigen::Dynamic>> fluxes, LinearBufferAllocator workSpace)								\
-	{                                                                                                                                                   \
-		return quasiStationaryFlux( t, secIdx,   colPos,  y, fluxes, workSpace);																		\
-	}																																					\
-																																						 \
-	 virtual int computeQuasiStationaryReactionFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, active const* y,										\
-		Eigen::Map<Eigen::Vector<double, Eigen::Dynamic>> fluxes, LinearBufferAllocator workSpace)								\
-	{                                                                                                                                                   \
-			return quasiStationaryFlux( t, secIdx,   colPos,  y, fluxes,  workSpace);																		\
-	}																																					\
-																																						\
-	virtual int computeQuasiStationaryReactionFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,										\
-		Eigen::Map<Eigen::Vector<double, Eigen::Dynamic>> fluxes, LinearBufferAllocator workSpace)								\
-	{                                                                                                                                                   \
-		return quasiStationaryFlux( t, secIdx,   colPos,  y, fluxes, workSpace);																			\
-	}																																					\
-																																						\
-	virtual int computeQuasiStationaryReactionFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, active const* y,										\
-		Eigen::Map<Eigen::Vector<active, Eigen::Dynamic>> fluxes, LinearBufferAllocator workSpace)								\
-	{                                                                                                                                                   \
-		return quasiStationaryFlux( t, secIdx,   colPos,  y, fluxes,  workSpace);																			\
-	}																																					\
-																																						\
-
+	}
 #else
 #define CADET_DYNAMICREACTIONMODEL_BOILERPLATE                                                                                                          \
 	virtual int residualLiquidAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, active const* y,                                         \

--- a/src/libcadet/model/reaction/ReactionModelBase.hpp
+++ b/src/libcadet/model/reaction/ReactionModelBase.hpp
@@ -59,8 +59,12 @@ public:
 	virtual void setExternalFunctions(IExternalFunction** extFuns, unsigned int size) { };
 	virtual void fillConservedMoietiesBulk(Eigen::MatrixXd& M, std::vector<int>& QSReaction, std::vector<int>& _QsCompBulk) = 0;
 
+
+	virtual int quasiStationaryFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, active const* y,
+		Eigen::Map<Eigen::VectorXd> fluxes, std::vector<int> mapQSReac, LinearBufferAllocator workSpace) = 0;
+	
 	virtual int quasiStationaryFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,
-		active* fluxes, std::vector<int>& mapQSReac, LinearBufferAllocator workSpace) const = 0;
+		Eigen::Map<Eigen::VectorXd> fluxes, std::vector<int> mapQSReac, LinearBufferAllocator workSpace) = 0;
 	
 protected:
 	int _nComp; //!< Number of components
@@ -162,9 +166,32 @@ protected:
 	{                                                                                                                                                   \
 		jacobianLiquidImpl(t, secIdx, colPos, y, factor, jac, workSpace);                                                                               \
 	}                                                                                                                                                   \
-		                                                                                                                                                \
+		virtual void analyticQuasiSteadyJacobianLiquid(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,                    \
+		double factor, linalg::BandMatrix::RowIterator jac, LinearBufferAllocator workSpace) const                                                      \
+	{                                                                                                                                                   \
+		jacobianQuasiSteadyLiquidImpl(t, secIdx, colPos, y, factor, jac, workSpace);                                                                    \
+	}                                                                                                                                                   \
+	                                                                                                                                                    \
+	virtual void analyticQuasiSteadyJacobianLiquid(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,                        \
+		double factor, linalg::DenseBandedRowIterator jac, LinearBufferAllocator workSpace) const                                                       \
+	{                                                                                                                                                   \
+		jacobianQuasiSteadyLiquidImpl(t, secIdx, colPos, y, factor, jac, workSpace);                                                                    \
+	}                                                                                                                                                   \
+	                                                                                                                                                    \
+	virtual void analyticQuasiSteadyJacobianLiquid(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,                        \
+		double factor, linalg::BandedSparseRowIterator jac, LinearBufferAllocator workSpace) const                                                      \
+	{                                                                                                                                                   \
+		jacobianQuasiSteadyLiquidImpl(t, secIdx, colPos, y, factor, jac, workSpace);                                                                    \
+	}                                                                                                                                                   \
+	                                                                                                                                                    \
+	virtual void analyticQuasiSteadyJacobianLiquid(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,                        \
+		double factor, linalg::BandedEigenSparseRowIterator jac, LinearBufferAllocator workSpace) const                                                 \
+	{                                                                                                                                                   \
+		jacobianQuasiSteadyLiquidImpl(t, secIdx, colPos, y, factor, jac, workSpace);                                                                    \
+	}																																					\
+																																						\
 	virtual void analyticJacobianCombinedAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* yLiquid, double const* ySolid,  \
-		double factor, linalg::BandedEigenSparseRowIterator jacLiquid, linalg::DenseBandedRowIterator jacSolid, LinearBufferAllocator workSpace) const \
+		double factor, linalg::BandedEigenSparseRowIterator jacLiquid, linalg::DenseBandedRowIterator jacSolid, LinearBufferAllocator workSpace) const	\
 	{                                                                                                                                                   \
 		jacobianCombinedImpl(t, secIdx, colPos, yLiquid, ySolid, factor, jacLiquid, jacSolid, workSpace);                                               \
 	}                                                                                                                                                   \

--- a/src/libcadet/model/reaction/ReactionModelBase.hpp
+++ b/src/libcadet/model/reaction/ReactionModelBase.hpp
@@ -210,44 +210,27 @@ protected:
 	{                                                                                                                                                   \
 		jacobianCombinedImpl(t, secIdx, colPos, yLiquid, ySolid, factor, jacLiquid, jacSolid, workSpace);                                               \
 	}																																					\
-	virtual void analyticJacobianLiquidSingleFluxAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,						\
-		int state, int reaction, linalg::BandMatrix::RowIterator jac, LinearBufferAllocator workSpace) const                                            \
-	{                                                                                                                                                   \
-	jacobianSingleFluxImpl(t, secIdx, colPos, y, state, reaction, jac, workSpace);																		\
-	}                                                                                                                                                   \
-																																						\
-	virtual void analyticJacobianLiquidSingleFluxAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,						\
-		int state, int reaction, linalg::DenseBandedRowIterator jac, LinearBufferAllocator workSpace) const                                             \
-	{                                                                                                                                                   \
-	jacobianSingleFluxImpl(t, secIdx, colPos, y, state, reaction, jac, workSpace);																		\
-	}                                                                                                                                                   \
-																																						\
-	virtual void analyticJacobianLiquidSingleFluxAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,						\
-		int state, int reaction, linalg::BandedSparseRowIterator jac, LinearBufferAllocator workSpace) const											\
-	{                                                                                                                                                   \
-	jacobianSingleFluxImpl(t, secIdx, colPos, y, state, reaction, jac, workSpace);																		\
-	}	                                                                                                                                               \
 																																						\
 	virtual int computeQuasiStationaryReactionFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,										\
-		Eigen::Map<Eigen::Vector<active, Eigen::Dynamic>> fluxes, int const* mapQSReac, LinearBufferAllocator workSpace)								\
+		Eigen::Map<Eigen::Vector<active, Eigen::Dynamic>> fluxes, LinearBufferAllocator workSpace)								\
 	{                                                                                                                                                   \
 		return quasiStationaryFlux( t, secIdx,   colPos,  y, fluxes, workSpace);																		\
 	}																																					\
 																																						 \
 	 virtual int computeQuasiStationaryReactionFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, active const* y,										\
-		Eigen::Map<Eigen::Vector<double, Eigen::Dynamic>> fluxes, int const* mapQSReac, LinearBufferAllocator workSpace)								\
+		Eigen::Map<Eigen::Vector<double, Eigen::Dynamic>> fluxes, LinearBufferAllocator workSpace)								\
 	{                                                                                                                                                   \
 			return quasiStationaryFlux( t, secIdx,   colPos,  y, fluxes,  workSpace);																		\
 	}																																					\
 																																						\
 	virtual int computeQuasiStationaryReactionFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,										\
-		Eigen::Map<Eigen::Vector<double, Eigen::Dynamic>> fluxes, int const* mapQSReac, LinearBufferAllocator workSpace)								\
+		Eigen::Map<Eigen::Vector<double, Eigen::Dynamic>> fluxes, LinearBufferAllocator workSpace)								\
 	{                                                                                                                                                   \
 		return quasiStationaryFlux( t, secIdx,   colPos,  y, fluxes, workSpace);																			\
 	}																																					\
 																																						\
 	virtual int computeQuasiStationaryReactionFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, active const* y,										\
-		Eigen::Map<Eigen::Vector<active, Eigen::Dynamic>> fluxes, int const* mapQSReac, LinearBufferAllocator workSpace)								\
+		Eigen::Map<Eigen::Vector<active, Eigen::Dynamic>> fluxes, LinearBufferAllocator workSpace)								\
 	{                                                                                                                                                   \
 		return quasiStationaryFlux( t, secIdx,   colPos,  y, fluxes,  workSpace);																			\
 	}																																					\

--- a/src/libcadet/model/reaction/ReactionModelBase.hpp
+++ b/src/libcadet/model/reaction/ReactionModelBase.hpp
@@ -61,7 +61,6 @@ public:
 	virtual bool hasQuasiStationaryReactionsBulk() const CADET_NOEXCEPT { return false;}
 	virtual int const* reactionQuasiStationarity() const = 0;
 
-	virtual void timeDerivativeQuasiStationaryReaction(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double* dReacDt, LinearBufferAllocator workSpace) = 0;
 	
 protected:
 	int _nComp; //!< Number of components

--- a/src/libcadet/model/reaction/ReactionModelBase.hpp
+++ b/src/libcadet/model/reaction/ReactionModelBase.hpp
@@ -57,10 +57,8 @@ public:
 	virtual active* getParameter(const ParameterId& pId);
 
 	virtual void setExternalFunctions(IExternalFunction** extFuns, unsigned int size) { }
-	//void fillConservedMoietiesBulk2(Eigen::Matrix<active, Eigen::Dynamic, Eigen:: Dynamic>& M, std::vector<int>& QsCompBulk) {}
-	//void fillConservedMoietiesBulk2(Eigen::Matrix<double, Eigen::Dynamic, Eigen:: Dynamic>& M, std::vector<int>& QsCompBulk) {}
+
 	virtual bool hasQuasiStationaryReactionsBulk() const CADET_NOEXCEPT { return false;}
-	//virtual unsigned int numReactionQuasiStationary() const CADET_NOEXCEPT { return 0;}
 	virtual int const* reactionQuasiStationarity() const = 0;
 
 	virtual void timeDerivativeQuasiStationaryReaction(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double* dReacDt, LinearBufferAllocator workSpace) = 0;
@@ -168,25 +166,25 @@ protected:
 		virtual void analyticJacobianQuasiStationaryReaction(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,                    \
 		int state,int reaction, linalg::BandMatrix::RowIterator jac, LinearBufferAllocator workSpace) const                                             \
 	{                                                                                                                                                   \
-		jacobianQuasiSteadyLiquidImpl(t, secIdx, colPos, y, state, reaction,jac, workSpace);                                                            \
+		jacobianQuasiStationaryBulkImpl(t, secIdx, colPos, y, state, reaction,jac, workSpace);                                                            \
 	}                                                                                                                                                   \
 	                                                                                                                                                    \
 	virtual void analyticJacobianQuasiStationaryReaction(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,                        \
 		int state, int reaction,linalg::DenseBandedRowIterator jac, LinearBufferAllocator workSpace) const                                              \
 	{                                                                                                                                                   \
-		jacobianQuasiSteadyLiquidImpl(t, secIdx, colPos, y, state, reaction,jac, workSpace);                                                            \
+		jacobianQuasiStationaryBulkImpl(t, secIdx, colPos, y, state, reaction,jac, workSpace);                                                            \
 	}                                                                                                                                                   \
 	                                                                                                                                                    \
 	virtual void analyticJacobianQuasiStationaryReaction(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,                        \
 		int state, int reaction,linalg::BandedSparseRowIterator jac, LinearBufferAllocator workSpace) const                                             \
 	{                                                                                                                                                   \
-		jacobianQuasiSteadyLiquidImpl(t, secIdx, colPos, y, state, reaction, jac, workSpace);                                                           \
+		jacobianQuasiStationaryBulkImpl(t, secIdx, colPos, y, state, reaction, jac, workSpace);                                                           \
 	}                                                                                                                                                   \
 	                                                                                                                                                    \
 	virtual void analyticJacobianQuasiStationaryReaction(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,                        \
 		int state,int reaction, linalg::BandedEigenSparseRowIterator jac, LinearBufferAllocator workSpace) const                                        \
 	{                                                                                                                                                   \
-		jacobianQuasiSteadyLiquidImpl(t, secIdx, colPos, y, state, reaction,jac, workSpace);                                                            \
+		jacobianQuasiStationaryBulkImpl(t, secIdx, colPos, y, state, reaction,jac, workSpace);                                                            \
 	}																																					\
 																																						\
 	virtual void analyticJacobianCombinedAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* yLiquid, double const* ySolid,  \
@@ -233,30 +231,34 @@ protected:
 	virtual int computeQuasiStationaryReactionFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,										\
 		Eigen::Map<Eigen::Vector<active, Eigen::Dynamic>> fluxes, int const* mapQSReac, LinearBufferAllocator workSpace)								\
 	{                                                                                                                                                   \
-		return quasiStationaryFlux( t, secIdx,   colPos,  y, fluxes, mapQSReac, workSpace);																		\
+		return quasiStationaryFlux( t, secIdx,   colPos,  y, fluxes, workSpace);																		\
 	}																																					\
 																																						 \
 	 virtual int computeQuasiStationaryReactionFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, active const* y,										\
 		Eigen::Map<Eigen::Vector<double, Eigen::Dynamic>> fluxes, int const* mapQSReac, LinearBufferAllocator workSpace)								\
 	{                                                                                                                                                   \
-			return quasiStationaryFlux( t, secIdx,   colPos,  y, fluxes, mapQSReac, workSpace);																		\
+			return quasiStationaryFlux( t, secIdx,   colPos,  y, fluxes,  workSpace);																		\
 	}																																					\
 																																						\
 	virtual int computeQuasiStationaryReactionFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,										\
 		Eigen::Map<Eigen::Vector<double, Eigen::Dynamic>> fluxes, int const* mapQSReac, LinearBufferAllocator workSpace)								\
 	{                                                                                                                                                   \
-		return quasiStationaryFlux( t, secIdx,   colPos,  y, fluxes, mapQSReac, workSpace);																			\
+		return quasiStationaryFlux( t, secIdx,   colPos,  y, fluxes, workSpace);																			\
 	}																																					\
 																																						\
 	virtual int computeQuasiStationaryReactionFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, active const* y,										\
 		Eigen::Map<Eigen::Vector<active, Eigen::Dynamic>> fluxes, int const* mapQSReac, LinearBufferAllocator workSpace)								\
 	{                                                                                                                                                   \
-		return quasiStationaryFlux( t, secIdx,   colPos,  y, fluxes, mapQSReac, workSpace);																			\
+		return quasiStationaryFlux( t, secIdx,   colPos,  y, fluxes,  workSpace);																			\
 	}																																					\
 																																						\
-	virtual void fillConservedMoietiesBulk2(Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>& M, int& QsCompBulk)\
+	virtual void fillConservedMoietiesBulk(Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>& M, int& nConservedQuants, std::vector<int>& QsCompBulk)\
 	{\
-		fillConservedMoietiesBulk21(M, QsCompBulk);\
+		ConservedMoietiesBulk(M, nConservedQuants, QsCompBulk);\
+	}\
+	virtual void fillConservedMoietiesBulk(Eigen::Matrix<active, Eigen::Dynamic, Eigen::Dynamic>& M, int& nConservedQuants, std::vector<int>& QsCompBulk)\
+	{\
+		ConservedMoietiesBulk(M, nConservedQuants, QsCompBulk);\
 	}\
 
 #else

--- a/src/libcadet/model/reaction/ReactionModelBase.hpp
+++ b/src/libcadet/model/reaction/ReactionModelBase.hpp
@@ -57,14 +57,14 @@ public:
 	virtual active* getParameter(const ParameterId& pId);
 
 	virtual void setExternalFunctions(IExternalFunction** extFuns, unsigned int size) { };
-	virtual void fillConservedMoietiesBulk(Eigen::MatrixXd& M, std::vector<int>& QSReaction, std::vector<int>& _QsCompBulk) = 0;
-
+	virtual void fillConservedMoietiesBulk(Eigen::MatrixXd& M, unsigned int& QSReaction, std::vector<int>& _QsCompBulk) = 0;
+	virtual int const* reactionQuasiStationarity() const = 0;
 
 	virtual int quasiStationaryFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, active const* y,
-		Eigen::Map<Eigen::VectorXd> fluxes, std::vector<int> mapQSReac, LinearBufferAllocator workSpace) = 0;
+		Eigen::Map<Eigen::VectorXd> fluxes, int const* mapQSReac, LinearBufferAllocator workSpace) = 0;
 	
 	virtual int quasiStationaryFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,
-		Eigen::Map<Eigen::VectorXd> fluxes, std::vector<int> mapQSReac, LinearBufferAllocator workSpace) = 0;
+		Eigen::Map<Eigen::VectorXd> fluxes, int const* mapQSReac, LinearBufferAllocator workSpace) = 0;
 
 	virtual void timeDerivativeQuasiStationaryReaction(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double* dReacDt, LinearBufferAllocator workSpace) = 0;
 	

--- a/src/libcadet/model/reaction/ReactionModelBase.hpp
+++ b/src/libcadet/model/reaction/ReactionModelBase.hpp
@@ -57,8 +57,10 @@ public:
 	virtual active* getParameter(const ParameterId& pId);
 
 	virtual void setExternalFunctions(IExternalFunction** extFuns, unsigned int size) { }
-	virtual void fillConservedMoietiesBulk(Eigen::MatrixXd& M, std::vector<int>& QsCompBulk) { }
+	//void fillConservedMoietiesBulk2(Eigen::Matrix<active, Eigen::Dynamic, Eigen:: Dynamic>& M, std::vector<int>& QsCompBulk) {}
+	//void fillConservedMoietiesBulk2(Eigen::Matrix<double, Eigen::Dynamic, Eigen:: Dynamic>& M, std::vector<int>& QsCompBulk) {}
 	virtual bool hasQuasiStationaryReactionsBulk() const CADET_NOEXCEPT { return false;}
+	//virtual unsigned int numReactionQuasiStationary() const CADET_NOEXCEPT { return 0;}
 	virtual int const* reactionQuasiStationarity() const = 0;
 
 	virtual void timeDerivativeQuasiStationaryReaction(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double* dReacDt, LinearBufferAllocator workSpace) = 0;
@@ -250,7 +252,13 @@ protected:
 		Eigen::Map<Eigen::Vector<active, Eigen::Dynamic>> fluxes, int const* mapQSReac, LinearBufferAllocator workSpace)								\
 	{                                                                                                                                                   \
 		return quasiStationaryFlux( t, secIdx,   colPos,  y, fluxes, mapQSReac, workSpace);																			\
-	}
+	}																																					\
+																																						\
+	virtual void fillConservedMoietiesBulk2(Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>& M, std::vector<int>& QsCompBulk)\
+	{\
+		fillConservedMoietiesBulk21(M, QsCompBulk);\
+	}\
+
 #else
 #define CADET_DYNAMICREACTIONMODEL_BOILERPLATE                                                                                                          \
 	virtual int residualLiquidAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, active const* y,                                         \

--- a/src/libcadet/model/reaction/ReactionModelBase.hpp
+++ b/src/libcadet/model/reaction/ReactionModelBase.hpp
@@ -169,27 +169,27 @@ protected:
 		jacobianLiquidImpl(t, secIdx, colPos, y, factor, jac, workSpace);                                                                               \
 	}                                                                                                                                                   \
 		virtual void analyticQuasiSteadyJacobianLiquid(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,                    \
-		int state,int reaction, linalg::BandMatrix::RowIterator jac, LinearBufferAllocator workSpace) const                                                      \
+		int state,int reaction, linalg::BandMatrix::RowIterator jac, LinearBufferAllocator workSpace) const                                             \
 	{                                                                                                                                                   \
-		jacobianQuasiSteadyLiquidImpl(t, secIdx, colPos, y, state, reaction,jac, workSpace);                                                                    \
+		jacobianQuasiSteadyLiquidImpl(t, secIdx, colPos, y, state, reaction,jac, workSpace);                                                            \
 	}                                                                                                                                                   \
 	                                                                                                                                                    \
 	virtual void analyticQuasiSteadyJacobianLiquid(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,                        \
-		int state, int reaction,linalg::DenseBandedRowIterator jac, LinearBufferAllocator workSpace) const                                                       \
+		int state, int reaction,linalg::DenseBandedRowIterator jac, LinearBufferAllocator workSpace) const                                              \
 	{                                                                                                                                                   \
-		jacobianQuasiSteadyLiquidImpl(t, secIdx, colPos, y, state, reaction,jac, workSpace);                                                                    \
+		jacobianQuasiSteadyLiquidImpl(t, secIdx, colPos, y, state, reaction,jac, workSpace);                                                            \
 	}                                                                                                                                                   \
 	                                                                                                                                                    \
 	virtual void analyticQuasiSteadyJacobianLiquid(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,                        \
-		int state, int reaction,linalg::BandedSparseRowIterator jac, LinearBufferAllocator workSpace) const                                                      \
+		int state, int reaction,linalg::BandedSparseRowIterator jac, LinearBufferAllocator workSpace) const                                             \
 	{                                                                                                                                                   \
-		jacobianQuasiSteadyLiquidImpl(t, secIdx, colPos, y, state, reaction, jac, workSpace);                                                                    \
+		jacobianQuasiSteadyLiquidImpl(t, secIdx, colPos, y, state, reaction, jac, workSpace);                                                           \
 	}                                                                                                                                                   \
 	                                                                                                                                                    \
 	virtual void analyticQuasiSteadyJacobianLiquid(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,                        \
-		int state,int reaction, linalg::BandedEigenSparseRowIterator jac, LinearBufferAllocator workSpace) const                                                 \
+		int state,int reaction, linalg::BandedEigenSparseRowIterator jac, LinearBufferAllocator workSpace) const                                        \
 	{                                                                                                                                                   \
-		jacobianQuasiSteadyLiquidImpl(t, secIdx, colPos, y, state, reaction,jac, workSpace);                                                                    \
+		jacobianQuasiSteadyLiquidImpl(t, secIdx, colPos, y, state, reaction,jac, workSpace);                                                            \
 	}																																					\
 																																						\
 	virtual void analyticJacobianCombinedAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* yLiquid, double const* ySolid,  \
@@ -214,8 +214,31 @@ protected:
 		double factor, linalg::BandMatrix::RowIterator jacLiquid, linalg::DenseBandedRowIterator jacSolid, LinearBufferAllocator workSpace) const       \
 	{                                                                                                                                                   \
 		jacobianCombinedImpl(t, secIdx, colPos, yLiquid, ySolid, factor, jacLiquid, jacSolid, workSpace);                                               \
-	}
-	
+	}																																					\
+	virtual void analyticJacobianLiquidSingleFluxAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,						\
+		int state, int reaction, linalg::BandMatrix::RowIterator jac, LinearBufferAllocator workSpace) const                                            \
+	{                                                                                                                                                   \
+	jacobianSingleFluxImpl(t, secIdx, colPos, y, state, reaction, jac, workSpace);																		\
+	}                                                                                                                                                   \
+																																						\
+	virtual void analyticJacobianLiquidSingleFluxAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,						\
+		int state, int reaction, linalg::DenseBandedRowIterator jac, LinearBufferAllocator workSpace) const                                             \
+	{                                                                                                                                                   \
+	jacobianSingleFluxImpl(t, secIdx, colPos, y, state, reaction, jac, workSpace);																		\
+	}                                                                                                                                                   \
+																																						\
+	virtual void analyticJacobianLiquidSingleFluxAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,						\
+		int state, int reaction, linalg::BandedSparseRowIterator jac, LinearBufferAllocator workSpace) const											\
+	{                                                                                                                                                   \
+	jacobianSingleFluxImpl(t, secIdx, colPos, y, state, reaction, jac, workSpace);																		\
+	}                                                                                                                                                   \
+	/*\
+	virtual void analyticJacobianLiquidSingleFluxAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, \
+		int state, int reaction, linalg::BandedEigenSparseRowIterator jac, LinearBufferAllocator workSpace) const                                                 \
+	{                                                                                                                                                   \
+	jacobianSingleFluxImpl(t, secIdx, colPos, y, state, reaction, jac, workSpace);                                                                    \
+	}																																					\
+	\*/
 #else
 #define CADET_DYNAMICREACTIONMODEL_BOILERPLATE                                                                                                          \
 	virtual int residualLiquidAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, active const* y,                                         \

--- a/src/libcadet/model/reaction/ReactionModelBase.hpp
+++ b/src/libcadet/model/reaction/ReactionModelBase.hpp
@@ -235,14 +235,6 @@ protected:
 		return quasiStationaryFlux( t, secIdx,   colPos,  y, fluxes,  workSpace);																			\
 	}																																					\
 																																						\
-	virtual void fillConservedMoietiesBulk(Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>& M, int& nConservedQuants, std::vector<int>& QsCompBulk)\
-	{\
-		ConservedMoietiesBulk(M, nConservedQuants, QsCompBulk);\
-	}\
-	virtual void fillConservedMoietiesBulk(Eigen::Matrix<active, Eigen::Dynamic, Eigen::Dynamic>& M, int& nConservedQuants, std::vector<int>& QsCompBulk)\
-	{\
-		ConservedMoietiesBulk(M, nConservedQuants, QsCompBulk);\
-	}\
 
 #else
 #define CADET_DYNAMICREACTIONMODEL_BOILERPLATE                                                                                                          \

--- a/src/libcadet/model/reaction/ReactionModelBase.hpp
+++ b/src/libcadet/model/reaction/ReactionModelBase.hpp
@@ -19,8 +19,8 @@
 #define LIBCADET_REACTIONMODELBASE_HPP_
 
 #include "model/ReactionModel.hpp"
+#include "linalg/ActiveDenseMatrix.hpp"
 #include "ParamIdUtil.hpp"
-
 #include <unordered_map>
 
 namespace cadet
@@ -56,13 +56,18 @@ public:
 
 	virtual active* getParameter(const ParameterId& pId);
 
-	virtual void setExternalFunctions(IExternalFunction** extFuns, unsigned int size) { }
+	virtual void setExternalFunctions(IExternalFunction** extFuns, unsigned int size) { };
+	virtual void fillConservedMoietiesBulk(Eigen::MatrixXd& M, std::vector<int>& QSReaction, std::vector<int>& _QsCompBulk) = 0;
 
+	virtual int quasiStationaryFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y,
+		active* fluxes, std::vector<int>& mapQSReac, LinearBufferAllocator workSpace) const = 0;
+	
 protected:
 	int _nComp; //!< Number of components
 	unsigned int const* _nBoundStates; //!< Array with number of bound states for each component
 	unsigned int const* _boundOffset; //!< Array with offsets to the first bound state of each component
 	int _nTotalBoundStates;
+	
 
 	std::unordered_map<ParameterId, active*> _parameters; //!< Map used to translate ParameterIds to actual variables
 
@@ -91,7 +96,7 @@ protected:
  *          The implementation is inserted inline in the class declaration.
  */
 #ifdef ENABLE_DG
-#define CADET_DYNAMICREACTIONMODEL_BOILERPLATE                                                                                                          \
+#define CADET_DYNAMICREACTIONMODEL_BOILERPLATE                                                                                                         \
 	virtual int residualLiquidAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, active const* y,                                         \
 		active* res, const active& factor, LinearBufferAllocator workSpace) const                                                                       \
 	{                                                                                                                                                   \
@@ -181,6 +186,7 @@ protected:
 	{                                                                                                                                                   \
 		jacobianCombinedImpl(t, secIdx, colPos, yLiquid, ySolid, factor, jacLiquid, jacSolid, workSpace);                                               \
 	}
+	
 #else
 #define CADET_DYNAMICREACTIONMODEL_BOILERPLATE                                                                                                          \
 	virtual int residualLiquidAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, active const* y,                                         \


### PR DESCRIPTION
Fixes #20.
This PR will add the feature to set reactions into a rapid equilibrium in liquid phase for the CSTR

## Workflow:
- [x] Add a function that calculates the mass matrix with respect to conserved moieties.
- [x] Update residualImpl
 - [x] keep ordering for dynamic states
- [x] Update consitentInitalisation
  - [x] transfer from leanconsistentinitalisation to  consistent initalisation
- [x] Update Jacobian
- [x] Add AD formulation -> Ask Jan first
- [x] Update derivative Jacobian
- [x] Add interface
- [x] Add error messages
- [x] Run tests and make sure my changes don't break existing functionality.
- [ ] Add test, that ensures the functionality of the new feature.
- [ ] Update the documentation.
- [x] Make Eigen libary obligatory for CADET (already done in #471 )


More information about the algorithm are available under the [forum post about reactions in rapid equilibrium](https://forum.cadet-web.de/t/reaction-in-rapid-equilibrium/1098)
