### PR TITLE
Fix multiple bindings configuration bug in binding mode specification

### DIFF
--- a/src/libcadet/model/binding/LinearBinding.cpp
+++ b/src/libcadet/model/binding/LinearBinding.cpp
@@ -427,7 +427,7 @@ public:
 			else
 			{
 				// Copy what we need (ignore excess values)
-				std::copy_n(vecKin.begin(), _reactionQuasistationarity.size(), _reactionQuasistationarity.begin());
+				std::transform(vecKin.begin(), vecKin.begin() + _reactionQuasistationarity.size(), _reactionQuasistationarity.begin(), [](int val) { return !static_cast<bool>(val); });
 			}
 		}
 		else


### PR DESCRIPTION
This PR fixes the configuration of the binding mode(s) when a vector is being used to specify multiple bindings, e.g. for multiple particle types.

