### PR TITLE
Do not return coordinates for singleton dimensions

### DIFF
--- a/src/libcadet/api/CAPIv1.cpp
+++ b/src/libcadet/api/CAPIv1.cpp
@@ -917,10 +917,19 @@ namespace v1
 			return cdtDataNotStored;
 		}
 
+		bool keepAxialSingletonDimension = unitRec->keepBulkSingletonDim();
+
 		if (nCoords)
 			*nCoords = unitRec->numAxialCells();
+
+		if (nCoords && *nCoords == 1 && !keepAxialSingletonDimension)
+		{
+			return cdtDataNotStored;
+		}
+
 		if (data)
 			*data = unitRec->primaryCoordinates();
+
 		return cdtOK;
 	}
 
@@ -941,6 +950,7 @@ namespace v1
 			*nCoords = unitRec->numRadialCells();
 		if (data)
 			*data = unitRec->secondaryCoordinates();
+
 		return cdtOK;
 	}
 
@@ -957,14 +967,23 @@ namespace v1
 			return cdtDataNotStored;
 		}
 
+		bool keepParticleSingletonDimension = unitRec->keepParticleSingletonDim();
+
+		if (nCoords)
+			*nCoords = unitRec->numParticleShells(parType);
+
+		if (nCoords && *nCoords == 1 && !keepParticleSingletonDimension)
+		{
+			return cdtDataNotStored;
+		}
+
 		int offset = 0;
 		for (int i = 0; i < parType; ++i)
 			offset += unitRec->numParticleShells(i);
 
-		if (nCoords)
-			*nCoords = unitRec->numParticleShells(parType);
 		if (data)
 			*data = unitRec->particleCoordinates() + offset;
+
 		return cdtOK;
 	}
 
@@ -985,6 +1004,7 @@ namespace v1
 			*nTime = sysRec->numDataPoints();
 		if (time)
 			*time = sysRec->time();
+
 		return cdtOK;
 	}
 

--- a/src/libcadet/model/LumpedRateModelWithPoresDG2D.hpp
+++ b/src/libcadet/model/LumpedRateModelWithPoresDG2D.hpp
@@ -365,7 +365,7 @@ protected:
 		virtual bool hasParticleMobilePhase() const CADET_NOEXCEPT { return true; }
 		virtual bool hasSolidPhase() const CADET_NOEXCEPT { return _disc.strideBound[_disc.nParType] > 0; }
 		virtual bool hasVolume() const CADET_NOEXCEPT { return false; }
-		virtual bool isParticleLumped() const CADET_NOEXCEPT { return false; }
+		virtual bool isParticleLumped() const CADET_NOEXCEPT { return true; }
 		virtual bool hasPrimaryExtent() const CADET_NOEXCEPT { return true; }
 		virtual bool hasSmoothnessIndicator() const CADET_NOEXCEPT { return false; }
 

--- a/src/libcadet/model/LumpedRateModelWithoutPores.hpp
+++ b/src/libcadet/model/LumpedRateModelWithoutPores.hpp
@@ -300,7 +300,7 @@ protected:
 		virtual bool hasParticleMobilePhase() const CADET_NOEXCEPT { return false; }
 		virtual bool hasSolidPhase() const CADET_NOEXCEPT { return _disc.strideBound > 0; }
 		virtual bool hasVolume() const CADET_NOEXCEPT { return false; }
-		virtual bool isParticleLumped() const CADET_NOEXCEPT { return false; }
+		virtual bool isParticleLumped() const CADET_NOEXCEPT { return true; }
 		virtual bool hasPrimaryExtent() const CADET_NOEXCEPT { return true; }
 
 		virtual unsigned int numComponents() const CADET_NOEXCEPT { return _disc.nComp; }

--- a/src/libcadet/model/LumpedRateModelWithoutPoresDG.hpp
+++ b/src/libcadet/model/LumpedRateModelWithoutPoresDG.hpp
@@ -304,7 +304,7 @@ namespace cadet
 				virtual bool hasParticleMobilePhase() const CADET_NOEXCEPT { return false; }
 				virtual bool hasSolidPhase() const CADET_NOEXCEPT { return _disc.strideBound > 0; }
 				virtual bool hasVolume() const CADET_NOEXCEPT { return false; }
-				virtual bool isParticleLumped() const CADET_NOEXCEPT { return false; }
+				virtual bool isParticleLumped() const CADET_NOEXCEPT { return true; }
 				virtual bool hasPrimaryExtent() const CADET_NOEXCEPT { return true; }
 
 				virtual unsigned int numComponents() const CADET_NOEXCEPT { return _disc.nComp; }

--- a/src/libcadet/model/StirredTankModel.cpp
+++ b/src/libcadet/model/StirredTankModel.cpp
@@ -284,7 +284,10 @@ bool CSTRModel::configure(IParameterProvider& paramProvider)
 		else
 			throw InvalidParameterException("Field CONST_SOLID_VOLUME or INIT_LIQUID_VOLUME required");
 
-		_constSolidVolume = init_liquid_volume / (1.0 - paramProvider.getDouble("POROSITY")) - init_liquid_volume; // V_s = V_l / (1 - epsilon) - V_l = (V_l + V_s) * (1 -epsilon)
+		const double epsilon = paramProvider.getDouble("POROSITY");
+
+		if (epsilon > 0.0) // else, constant solid volume is already set to zero
+			_constSolidVolume = init_liquid_volume * (1.0 - epsilon) / epsilon; // V_s = (V_l + V_s) * (1 - epsilon) -> V_s = V_l * (1 - \epsilon) / \epsilon
 	}
 	_parameters[makeParamId(hashString("CONST_SOLID_VOLUME"), _unitOpIdx, CompIndep, ParTypeIndep, BoundStateIndep, ReactionIndep, SectionIndep)] = &_constSolidVolume;
 


### PR DESCRIPTION
Fixes #334 

additionally, we fix the support of the old CSTR interface (fix of #311)

## Checklist

Please ensure you've completed the following tasks. Mark them with an `x` inside the brackets:

- [x] I have checked the CADET [Developer Guide](https://cadet.github.io/master/developer_guide)  
- [x] My code follows the project's code style and [RSE guidelines](https://rse-guidelines.readthedocs.io/en/latest/intro.html).
- [x] I have run relevant tests and verified that my changes do not break existing functionality.
- [x] I have updated documentation as needed.
- [x] I have reviewed my code for security considerations and potential vulnerabilities.
- [x] I have added necessary comments or descriptions for maintainers and reviewers.

## To do
- [x] Fix C-API
- [x] Check all units for `isParticleLumped`
- [x] Check why `cadet-cli --version` returns the wrong version number
- [x] Fix CSTR old interface support

