### PR TITLE
Fix manual trigger of CI and CD workflows

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,7 +6,7 @@ on:
       ref:
         description: 'Commit hash, branch name, or tag to run the CD pipeline for'
         required: false
-        default: 'HEAD'
+        default: 'master'
         type: string
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
       ref:
         description: 'Commit hash, branch name, or tag to run the CI pipeline for'
         required: false
-        default: 'HEAD'
+        default: 'master'
         type: string
 
 


### PR DESCRIPTION
The default `HEAD` is not supported as input for the manual trigger, instead we changed it to master