### PR TITLE
Fix possible error in jacobian tests

### DIFF
--- a/test/Crystallization.cpp
+++ b/test/Crystallization.cpp
@@ -166,8 +166,9 @@ TEST_CASE("Crystallization Jacobian verification for a DPFR/LRM with primary and
 	pp_setup.pushScope("model");
 	pp_setup.pushScope("unit_001");
 
-	// for this specific test, we need to define a (high) absolute tolerance as the values in this test are numerically very challenging (values of ca. 1E+24)
+	// for this specific test, we need to define a (high) tolerances as the values in this test are numerically very challenging (values of ca. 1E+24)
 	const double ADabsTol = 2e+7;
+	const double FDabsTol = 5e+7;
 
-	cadet::test::column::testJacobianAD(pp_setup, std::numeric_limits<float>::epsilon() * 100.0, ADabsTol);
+	cadet::test::column::testJacobianAD(pp_setup, FDabsTol, ADabsTol);
 }

--- a/test/GeneralRateModelDG.cpp
+++ b/test/GeneralRateModelDG.cpp
@@ -265,7 +265,7 @@ TEST_CASE("GRM_DG linear binding single particle matches particle distribution",
 
 TEST_CASE("GRM_DG multiple particle types Jacobian analytic vs AD", "[GRM],[DG],[DG1D],[Jacobian],[AD],[ParticleType],[CI]")
 {
-	cadet::test::particle::testJacobianMixedParticleTypes("GENERAL_RATE_MODEL", "DG");
+	cadet::test::particle::testJacobianMixedParticleTypes("GENERAL_RATE_MODEL", "DG", 1e-14);
 }
 
 TEST_CASE("GRM_DG multiple particle types time derivative Jacobian vs FD", "[GRM],[DG],[DG1D],[UnitOp],[Residual],[Jacobian],[ParticleType],[CI]")
@@ -285,27 +285,27 @@ TEST_CASE("GRM_DG linear binding single particle matches spatially dependent par
 
 TEST_CASE("GRM_DG dynamic reactions Jacobian vs AD bulk", "[GRM],[DG],[DG1D],[Jacobian],[AD],[ReactionModel],[CI]")
 {
-	cadet::test::reaction::testUnitJacobianDynamicReactionsAD("GENERAL_RATE_MODEL", "DG", true, false, false);
+	cadet::test::reaction::testUnitJacobianDynamicReactionsAD("GENERAL_RATE_MODEL", "DG", true, false, false, 1e-14);
 }
 
 TEST_CASE("GRM_DG dynamic reactions Jacobian vs AD particle", "[GRM],[DG],[DG1D],[Jacobian],[AD],[ReactionModel],[CI]")
 {
-	cadet::test::reaction::testUnitJacobianDynamicReactionsAD("GENERAL_RATE_MODEL", "DG", false, true, false);
+	cadet::test::reaction::testUnitJacobianDynamicReactionsAD("GENERAL_RATE_MODEL", "DG", false, true, false, 1e-14);
 }
 
 TEST_CASE("GRM_DG dynamic reactions Jacobian vs AD modified particle", "[GRM],[DG],[DG1D],[Jacobian],[AD],[ReactionModel],[CI]")
 {
-	cadet::test::reaction::testUnitJacobianDynamicReactionsAD("GENERAL_RATE_MODEL", "DG", false, true, true);
+	cadet::test::reaction::testUnitJacobianDynamicReactionsAD("GENERAL_RATE_MODEL", "DG", false, true, true, 1e-14);
 }
 
 TEST_CASE("GRM_DG dynamic reactions Jacobian vs AD bulk and particle", "[GRM],[DG],[DG1D],[Jacobian],[AD],[ReactionModel],[CI]")
 {
-	cadet::test::reaction::testUnitJacobianDynamicReactionsAD("GENERAL_RATE_MODEL", "DG", true, true, false);
+	cadet::test::reaction::testUnitJacobianDynamicReactionsAD("GENERAL_RATE_MODEL", "DG", true, true, false, 1e-14);
 }
 
 TEST_CASE("GRM_DG dynamic reactions Jacobian vs AD bulk and modified particle", "[GRM],[DG],[DG1D],[Jacobian],[AD],[ReactionModel],[CI]")
 {
-	cadet::test::reaction::testUnitJacobianDynamicReactionsAD("GENERAL_RATE_MODEL", "DG", true, true, true);
+	cadet::test::reaction::testUnitJacobianDynamicReactionsAD("GENERAL_RATE_MODEL", "DG", true, true, true, 1e-14);
 }
 
 TEST_CASE("GRM_DG dynamic reactions time derivative Jacobian vs FD bulk", "[GRM],[DG],[DG1D],[Jacobian],[Residual],[ReactionModel],[CI],[FD]")

--- a/test/JacobianHelper.hpp
+++ b/test/JacobianHelper.hpp
@@ -409,8 +409,9 @@ inline void checkJacobianPatternFD(const std::function<void(double const*, doubl
 			CAPTURE(col);
 			CAPTURE(colA[row]);
 			CAPTURE(colB[row]);
-			if (std::abs(colA[row]) <= absTol)
-				CHECK(std::abs(colA[row]) <= absTol);
+
+			if (std::abs(colA[row]) <= absTol) // allow different signs, if both entries are near zero
+				CHECK(std::abs(colB[row]) <= absTol);
 			else if (std::isnan(colA[row]))
 				CHECK(std::isnan(colB[row]));
 			else


### PR DESCRIPTION
During the jacobian tests we compare the residual calculated with finite differences in both directions (stored in `colA` and `colB`):

```c++
... if (std::isnan(colA[row]))
  CHECK(std::isnan(colB[row]));
else
  CHECK(std::signbit(colA[row]) == std::signbit(colB[row]));
```

However, the first test is:

```c++
if (std::abs(colA[row]) <= absTol)
  CHECK(std::abs(colA[row]) <= absTol);
```

where we compare `colA` to `colA`. To me this seems like a typo, because very other check compares the result in `colA` with `colB`.

With this change some test fail now.

ToDos:
- [x] someone else confirm that this change is reasonable
- [x] fix tests again
  - GRM_DG multiple particle types Jacobian analytic vs AD
  - GRM_DG dynamic reactions Jacobian vs AD bulk
  - GRM_DG dynamic reactions Jacobian vs AD particle
  - GRM_DG dynamic reactions Jacobian vs AD modified particle
  - GRM_DG dynamic reactions Jacobian vs AD bulk and particle
  - GRM_DG dynamic reactions Jacobian vs AD bulk and modified particle
  - Crystallization Jacobian verification for a DPFR/LRM with primary and secondary nucleation and growth