### PR TITLE
Add binding model submodule tests to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,8 +168,11 @@ jobs:
           ${BUILD_DIR}/test/testRunner [CI]
       - name: Run CI test set II
         run: |
-          ${BUILD_DIR}/test/testRunner [CI_sensitivity1]
+          ${BUILD_DIR}/test/testRunner [CI_binding]
       - name: Run CI test set III
+        run: |
+          ${BUILD_DIR}/test/testRunner [CI_sensitivity1]
+      - name: Run CI test set IV
         run: |
           ${BUILD_DIR}/test/testRunner [CI_sensitivity2]
   MacOS:

--- a/src/libcadet/model/GeneralRateModelDG.cpp
+++ b/src/libcadet/model/GeneralRateModelDG.cpp
@@ -1436,11 +1436,11 @@ int GeneralRateModelDG::residualParticle(double t, unsigned int parType, unsigne
 
 			for (int bnd = 0; bnd < _disc.nBound[parType * _disc.nComp + comp]; bnd++)
 			{
-				if (parSurfDiff[_disc.nBoundBeforeType[parType] + _disc.boundOffset[parType * _disc.nComp + comp] + bnd] != 0.0) // some bound states might still not be effected by surface diffusion
+				if (parSurfDiff[_disc.boundOffset[parType * _disc.nComp + comp] + bnd] != 0.0) // some bound states might still not be effected by surface diffusion
 				{
 					Eigen::Map<const Vector<StateType, Dynamic>, 0, InnerStride<Dynamic>> c_s(c_p + _disc.nComp + idxr.offsetBoundComp(ParticleTypeIndex{ parType }, ComponentIndex{ comp }) + bnd, nPoints, InnerStride<Dynamic>(idxr.strideParNode(parType)));
 					ParamType invBetaP = (1.0 - static_cast<ParamType>(_parPorosity[parType])) / (static_cast<ParamType>(_poreAccessFactor[_disc.nComp * parType + comp]) * static_cast<ParamType>(_parPorosity[parType]));
-					sum_cp_cs += invBetaP * static_cast<ParamType>(parSurfDiff[_disc.nBoundBeforeType[parType] + _disc.boundOffset[parType * _disc.nComp + comp] + bnd]) * c_s;
+					sum_cp_cs += invBetaP * static_cast<ParamType>(parSurfDiff[_disc.boundOffset[parType * _disc.nComp + comp] + bnd]) * c_s;
 
 					/* For kinetic bindings with surface diffusion: add the additional DG-discretized particle mass balance equations to residual */
 
@@ -1455,7 +1455,7 @@ int GeneralRateModelDG::residualParticle(double t, unsigned int parType, unsigne
 
 						// Apply squared inverse mapping and surface diffusion
 						c_s_modified = 2.0 / static_cast<ParamType>(_disc.deltaR[_disc.offsetMetric[parType]]) * 2.0 / static_cast<ParamType>(_disc.deltaR[_disc.offsetMetric[parType]]) *
-							static_cast<ParamType>(parSurfDiff[_disc.nBoundBeforeType[parType] + _disc.boundOffset[parType * _disc.nComp + comp] + bnd]) * c_s;
+							static_cast<ParamType>(parSurfDiff[_disc.boundOffset[parType * _disc.nComp + comp] + bnd]) * c_s;
 
 						Eigen::Map<const Vector<ResidualType, Dynamic>, 0, InnerStride<Dynamic>> c_s_modified_const(&c_s_modified[0], nPoints, InnerStride<Dynamic>(1));
 						parGSMVolumeIntegral<ResidualType, ResidualType>(parType, c_s_modified_const, resCs);
@@ -1502,7 +1502,7 @@ int GeneralRateModelDG::residualParticle(double t, unsigned int parType, unsigne
 			{
 				for (int bnd = 0; bnd < _disc.nBound[parType * _disc.nComp + comp]; bnd++)
 				{
-					if (parSurfDiff[_disc.nBoundBeforeType[parType] + _disc.boundOffset[parType * _disc.nComp + comp] + bnd] != 0.0) // some bound states might still not be effected by surface diffusion
+					if (parSurfDiff[_disc.boundOffset[parType * _disc.nComp + comp] + bnd] != 0.0) // some bound states might still not be effected by surface diffusion
 					{
 						// Get solid phase vector
 						Eigen::Map<const Vector<StateType, Dynamic>, 0, InnerStride<Dynamic>> c_s(c_p + strideParLiquid + idxr.offsetBoundComp(ParticleTypeIndex{ parType }, ComponentIndex{ comp }) + bnd,
@@ -1510,7 +1510,7 @@ int GeneralRateModelDG::residualParticle(double t, unsigned int parType, unsigne
 						// Compute g_s = d c_s / d xi
 						solve_auxiliary_DG<StateType>(parType, c_s, strideCell, strideNode, comp);
 						// Apply invBeta_p, d_s and add to sum -> gSum += d_s * invBeta_p * (D c - M^-1 B [c - c^*])
-						_g_pSum += _g_p.template cast<ResidualType>() * invBetaP * static_cast<ParamType>(parSurfDiff[_disc.nBoundBeforeType[parType] + _disc.boundOffset[parType * _disc.nComp + comp] + bnd]);
+						_g_pSum += _g_p.template cast<ResidualType>() * invBetaP * static_cast<ParamType>(parSurfDiff[_disc.boundOffset[parType * _disc.nComp + comp] + bnd]);
 
 						/* For kinetic bindings with surface diffusion: add the additional DG-discretized particle mass balance equations to residual */
 
@@ -1529,7 +1529,7 @@ int GeneralRateModelDG::residualParticle(double t, unsigned int parType, unsigne
 							Eigen::Map<Vector<ResidualType, Dynamic>, 0, InnerStride<>> _g_p_ResType(reinterpret_cast<ResidualType*>(&_disc.g_p[parType][0]), nPoints, InnerStride<>(1));
 
 							applyParInvMap<ResidualType, ParamType>(_g_p_ResType, parType);
-							_g_p_ResType *= static_cast<ParamType>(parSurfDiff[_disc.nBoundBeforeType[parType] + _disc.boundOffset[parType * _disc.nComp + comp] + bnd]);
+							_g_p_ResType *= static_cast<ParamType>(parSurfDiff[_disc.boundOffset[parType * _disc.nComp + comp] + bnd]);
 
 							// Eigen access to auxiliary variable of current bound state
 							Eigen::Map<const Vector<ResidualType, Dynamic>, 0, InnerStride<Dynamic>> _g_p_ResType_const(&_g_p_ResType[0], nPoints, InnerStride<Dynamic>(1));

--- a/src/libcadet/model/GeneralRateModelDG.hpp
+++ b/src/libcadet/model/GeneralRateModelDG.hpp
@@ -1025,7 +1025,7 @@ protected:
 							int const* const qsReaction = _binding[parType]->reactionQuasiStationarity();
 
 							for (unsigned int bnd = 0; bnd < _disc.nBound[parType * _disc.nComp + comp]; bnd++) {
-								if (_parSurfDiff[_disc.nBoundBeforeType[parType] + _disc.boundOffset[parType * _disc.nComp + comp] + bnd] != 0.0) {
+								if (_parSurfDiff[_disc.boundOffset[parType * _disc.nComp + comp] + bnd] != 0.0) {
 									// row: add current component offset and go node strides from there for each dispersion block entry
 									// col: jump oover liquid states, add current bound state offset and go node strides from there for each dispersion block entry
 									tripletList.push_back(T(offset + comp * sComp + i * sNode,
@@ -1070,7 +1070,7 @@ protected:
 							int const* const qsReaction = _binding[parType]->reactionQuasiStationarity();
 
 							for (unsigned int bnd = 0; bnd < _disc.nBound[parType * _disc.nComp + comp]; bnd++) {
-								if (_parSurfDiff[_disc.nBoundBeforeType[parType] + _disc.boundOffset[parType * _disc.nComp + comp] + bnd] != 0.0) {
+								if (_parSurfDiff[_disc.boundOffset[parType * _disc.nComp + comp] + bnd] != 0.0) {
 									// row: add current component offset and go node strides from there for each dispersion block entry
 									// col: jump over liquid states, add current bound state offset and go node strides from there for each dispersion block entry. adjust for j start
 									tripletList.push_back(T(offset + comp * sComp + i * sNode,
@@ -1113,7 +1113,7 @@ protected:
 							int const* const qsReaction = _binding[parType]->reactionQuasiStationarity();
 
 							for (unsigned int bnd = 0; bnd < _disc.nBound[parType * _disc.nComp + comp]; bnd++) {
-								if (_parSurfDiff[_disc.nBoundBeforeType[parType] + _disc.boundOffset[parType * _disc.nComp + comp] + bnd] != 0.0) {
+								if (_parSurfDiff[_disc.boundOffset[parType * _disc.nComp + comp] + bnd] != 0.0) {
 									// row: add component offset and jump over previous cells. Go node strides from there for each dispersion block entry
 									// col: jump over liquid states, add current bound state offset and jump over previous cells. Go back one cell (and node or adjust for start) and go node strides from there for each dispersion block entry.
 									tripletList.push_back(T(offset + comp * sComp + (_disc.nParCell[parType] - 1) * sCell + i * sNode,
@@ -1151,7 +1151,7 @@ protected:
 								int const* const qsReaction = _binding[parType]->reactionQuasiStationarity();
 
 								for (unsigned int bnd = 0; bnd < _disc.nBound[parType * _disc.nComp + comp]; bnd++) {
-									if (_parSurfDiff[_disc.nBoundBeforeType[parType] + _disc.boundOffset[parType * _disc.nComp + comp] + bnd] != 0.0) {
+									if (_parSurfDiff[_disc.boundOffset[parType * _disc.nComp + comp] + bnd] != 0.0) {
 										// row: add component offset and jump over previous cells. Go node strides from there for each dispersion block entry
 										// col: jump over liquid states, add current bound state offset and jump over previous cell. go back one cell and go node strides from there for each dispersion block entry. adjust for j start
 										tripletList.push_back(T(offset + comp * sComp + sCell + i * sNode,
@@ -1194,7 +1194,7 @@ protected:
 								int const* const qsReaction = _binding[parType]->reactionQuasiStationarity();
 
 								for (unsigned int bnd = 0; bnd < _disc.nBound[parType * _disc.nComp + comp]; bnd++) {
-									if (_parSurfDiff[_disc.nBoundBeforeType[parType] + _disc.boundOffset[parType * _disc.nComp + comp] + bnd] != 0.0) {
+									if (_parSurfDiff[_disc.boundOffset[parType * _disc.nComp + comp] + bnd] != 0.0) {
 										// row: add component offset and jump over previous cells. Go node strides from there for each dispersion block entry
 										// col: jump over liquid states, add current bound state offset and jump over previous cells. Go back one cell and go node strides from there for each dispersion block entry. adjust for j start
 										tripletList.push_back(T(offset + comp * sComp + sCell + i * sNode,
@@ -1234,7 +1234,7 @@ protected:
 								int const* const qsReaction = _binding[parType]->reactionQuasiStationarity();
 
 								for (unsigned int bnd = 0; bnd < _disc.nBound[parType * _disc.nComp + comp]; bnd++) {
-									if (_parSurfDiff[_disc.nBoundBeforeType[parType] + _disc.boundOffset[parType * _disc.nComp + comp] + bnd] != 0.0) {
+									if (_parSurfDiff[_disc.boundOffset[parType * _disc.nComp + comp] + bnd] != 0.0) {
 										// row: add component offset and jump over previous cells. Go node strides from there for each dispersion block entry
 										// col: jump over liquid states, add current bound state offset and jump over previous cells. Go back one cell and node and go node strides from there for each dispersion block entry
 										tripletList.push_back(T(offset + comp * sComp + (_disc.nParCell[parType] - 2) * sCell + i * sNode,
@@ -1280,7 +1280,7 @@ protected:
 									int const* const qsReaction = _binding[parType]->reactionQuasiStationarity();
 
 									for (unsigned int bnd = 0; bnd < _disc.nBound[parType * _disc.nComp + comp]; bnd++) {
-										if (_parSurfDiff[_disc.nBoundBeforeType[parType] + _disc.boundOffset[parType * _disc.nComp + comp] + bnd] != 0.0) {
+										if (_parSurfDiff[_disc.boundOffset[parType * _disc.nComp + comp] + bnd] != 0.0) {
 											// row: add component offset and jump over previous cells. Go node strides from there for each dispersion block entry
 											// col: jump over liquid states, add current bound state offset and jump over previous cells. Go back one cell and node and go node strides from there for each dispersion block entry
 											tripletList.push_back(T(offset + comp * sComp + cell * sCell + i * sNode,
@@ -1340,7 +1340,6 @@ protected:
 
 		Indexer idxr(_disc);
 
-		active const* const _parSurfDiff = getSectionDependentSlice(_parSurfDiffusion, _disc.strideBound[_disc.nParType], secIdx) + _disc.nBoundBeforeType[parType];
 		unsigned int offset = idxr.offsetCp(ParticleTypeIndex{ parType }, ParticleIndex{ colNode });
 
 		for (unsigned int parNode = 0; parNode < _disc.nParPoints[parType]; parNode++) {
@@ -1834,11 +1833,11 @@ protected:
 		for (unsigned int i = 0; i < block.rows(); i++, jac += idxr.strideParLiquid()) {
 			for (unsigned int comp = 0; comp < _disc.nComp; comp++) {
 				for (unsigned int bnd = 0; bnd < _disc.nBound[type * _disc.nComp + comp]; bnd++, ++jac) {
-					if (static_cast<double>(surfDiff[_disc.nBoundBeforeType[type] + _disc.boundOffset[type * _disc.nComp + comp] + bnd]) != 0.0
+					if (static_cast<double>(surfDiff[_disc.boundOffset[type * _disc.nComp + comp] + bnd]) != 0.0
 						&& !nonKinetic[idxr.offsetBoundComp(ParticleTypeIndex{ type }, ComponentIndex{ comp }) + bnd]) {
 						// row, col: at current node and bound state
 						jac[0] += block(i, i)
-							* static_cast<double>(surfDiff[_disc.nBoundBeforeType[type] + _disc.boundOffset[type * _disc.nComp + comp] + bnd]);
+							* static_cast<double>(surfDiff[_disc.boundOffset[type * _disc.nComp + comp] + bnd]);
 					}
 				}
 			}
@@ -1869,14 +1868,14 @@ protected:
 					}
 					/* liquid on solid blocks */
 					for (unsigned int bnd = 0; bnd < _disc.nBound[type * _disc.nComp + comp]; bnd++) {
-						if (static_cast<double>(surfDiff[_disc.nBoundBeforeType[type] + _disc.boundOffset[type * _disc.nComp + comp] + bnd]) != 0.0) {
+						if (static_cast<double>(surfDiff[_disc.boundOffset[type * _disc.nComp + comp] + bnd]) != 0.0) {
 							for (unsigned int j = 0; j < block.cols(); j++) {
 								// row: at current node and component; col: jump to node j and to current bound state
 								jac[(j - i) * idxr.strideParNode(type) + offRowToCol + idxr.strideParLiquid() - comp
 									+ idxr.offsetBoundComp(ParticleTypeIndex{ type }, ComponentIndex{ comp }) + bnd
 								]
 									= block(i, j) * static_cast<double>(beta_p[comp])
-									* static_cast<double>(surfDiff[_disc.nBoundBeforeType[type] + _disc.boundOffset[type * _disc.nComp + comp] + bnd]);
+									* static_cast<double>(surfDiff[_disc.boundOffset[type * _disc.nComp + comp] + bnd]);
 							}
 						}
 					}
@@ -1884,13 +1883,13 @@ protected:
 				/* solid on solid blocks */
 				for (unsigned int comp = 0; comp < _disc.nComp; comp++) {
 					for (unsigned int bnd = 0; bnd < _disc.nBound[type * _disc.nComp + comp]; bnd++, ++jac) {
-						if (static_cast<double>(surfDiff[_disc.nBoundBeforeType[type] + _disc.boundOffset[type * _disc.nComp + comp] + bnd]) != 0.0
+						if (static_cast<double>(surfDiff[_disc.boundOffset[type * _disc.nComp + comp] + bnd]) != 0.0
 							&& !nonKinetic[idxr.offsetBoundComp(ParticleTypeIndex{ type }, ComponentIndex{ comp }) + bnd]) {
 							for (unsigned int j = 0; j < block.cols(); j++) {
 								// row: at current node and bound state; col: jump to node j
 								jac[(j - i) * idxr.strideParNode(type) + offRowToCol + bnd]
 									= block(i, j)
-									* static_cast<double>(surfDiff[_disc.nBoundBeforeType[type] + _disc.boundOffset[type * _disc.nComp + comp] + bnd]);
+									* static_cast<double>(surfDiff[_disc.boundOffset[type * _disc.nComp + comp] + bnd]);
 							}
 						}
 					}

--- a/test/BindingModelTests.cpp
+++ b/test/BindingModelTests.cpp
@@ -187,7 +187,7 @@ int ConfiguredBindingModel::requiredBufferSize() CADET_NOEXCEPT
 	return 0;
 }
 
-void testJacobianAD(const char* modelName, unsigned int nComp, unsigned int const* nBound, bool isKinetic, const char* config, double const* point, bool skipStructureTest, double absTol, double relTol)
+void testJacobianAD(const char* modelName, unsigned int nComp, unsigned int const* nBound, bool isKinetic, const char* config, double const* point, bool skipStructureTest, double FDsignAbsTol, double absTol, double relTol)
 {
 	ConfiguredBindingModel cbm = ConfiguredBindingModel::create(modelName, nComp, nBound, isKinetic, config);
 
@@ -229,12 +229,12 @@ void testJacobianAD(const char* modelName, unsigned int nComp, unsigned int cons
 		cadet::test::checkJacobianPatternFD(
 			[&](double const* lDir, double* res) -> void { cbm.model().flux(1.0, 0u, ColumnPosition{0.0, 0.0, 0.0}, lDir + cbm.nComp(), lDir, res, cbm.buffer()); },
 			[&](double const* lDir, double* res) -> void { jacAna.submatrixMultiplyVector(lDir, cbm.nComp(), 0, numEq, numDofs, res); },
-			yState.data(), dir.data(), colA.data(), colB.data(), numDofs, numEq);
+			yState.data(), dir.data(), colA.data(), colB.data(), numDofs, numEq, FDsignAbsTol);
 
 		cadet::test::checkJacobianPatternFD(
 			[&](double const* lDir, double* res) -> void { cbm.model().flux(1.0, 0u, ColumnPosition{0.0, 0.0, 0.0}, lDir + cbm.nComp(), lDir, res, cbm.buffer()); },
 			[&](double const* lDir, double* res) -> void { jacAD.multiplyVector(lDir, res); },
-			yState.data(), dir.data(), colA.data(), colB.data(), numDofs, numEq);
+			yState.data(), dir.data(), colA.data(), colB.data(), numDofs, numEq, FDsignAbsTol);
 	}
 
 	// Check Jacobians against each other

--- a/test/BindingModelTests.hpp
+++ b/test/BindingModelTests.hpp
@@ -130,10 +130,11 @@ namespace binding
 	 * @param [in] config JSON string with binding model parameters
 	 * @param [in] point Liquid phase and solid phase values to check Jacobian at
 	 * @param [in] skipStructureTest Determines whether the structural test using finite differences is skipped
+	 * @param [in] FDsignAbsTol Absolute tolerance in FD pattern sign check
 	 * @param [in] absTol Absolute error tolerance
 	 * @param [in] relTol Relative error tolerance
 	 */
-	void testJacobianAD(const char* modelName, unsigned int nComp, unsigned int const* nBound, bool isKinetic, const char* config, double const* point, bool skipStructureTest = false, double absTol = 0.0, double relTol = std::numeric_limits<float>::epsilon() * 100.0);
+	void testJacobianAD(const char* modelName, unsigned int nComp, unsigned int const* nBound, bool isKinetic, const char* config, double const* point, bool skipStructureTest = false, double FDsignAbsTol = 0.0, double absTol = 0.0, double relTol = std::numeric_limits<float>::epsilon() * 100.0);
 
 	/**
 	 * @brief Checks residual and analytic Jacobian of normal model variant against externally dependent ones

--- a/test/BindingModels.cpp
+++ b/test/BindingModels.cpp
@@ -273,7 +273,7 @@ CADET_BINDINGTEST("MOBILE_PHASE_MODULATOR", "EXT_MOBILE_PHASE_MODULATOR", (1,1,1
 	        "EXT_MPM_BETA_T": [0.0, 1.5, 2.0],
 	        "EXT_MPM_BETA_TT": [0.0, 0.0, 0.0],
 	        "EXT_MPM_BETA_TTT": [0.0, 0.0, 0.0],
-			"EXT_MPM_LINEAR_THRESHOLD": 1e-10
+			"MPM_LINEAR_THRESHOLD": 1e-10
 	)json", \
 	R"json( "EXT_MPM_KA": [0.0, 0.0, 0.0, 0.0],
 	        "EXT_MPM_KA_T": [0.0, 1.14, 1.0, 2.0],
@@ -295,7 +295,7 @@ CADET_BINDINGTEST("MOBILE_PHASE_MODULATOR", "EXT_MOBILE_PHASE_MODULATOR", (1,1,1
 	        "EXT_MPM_BETA_T": [0.0, 1.5, 0.0, 2.0],
 	        "EXT_MPM_BETA_TT": [0.0, 0.0, 0.0, 0.0],
 	        "EXT_MPM_BETA_TTT": [0.0, 0.0, 0.0, 0.0],
-			"EXT_MPM_LINEAR_THRESHOLD": 1e-10
+			"MPM_LINEAR_THRESHOLD": 1e-10
 	)json", \
 	1e-10, 1e-10, CADET_NONBINDING_LIQUIDPHASE_COMP_UNUSED, CADET_COMPARE_BINDING_VS_NONBINDING)
 	
@@ -334,7 +334,7 @@ CADET_BINDINGTEST("MOBILE_PHASE_MODULATOR", "EXT_MOBILE_PHASE_MODULATOR", (1,1,1
 	        "EXT_MPM_BETA_T": [0.0, 1.5, 2.0],
 	        "EXT_MPM_BETA_TT": [0.0, 0.0, 0.0],
 	        "EXT_MPM_BETA_TTT": [0.0, 0.0, 0.0],
-			"EXT_MPM_LINEAR_THRESHOLD": 1e-10
+			"MPM_LINEAR_THRESHOLD": 1e-10
 	)json", \
 	R"json( "EXT_MPM_KA": [0.0, 0.0, 0.0, 0.0],
 	        "EXT_MPM_KA_T": [0.0, 1.14, 1.0, 2.0],
@@ -356,7 +356,7 @@ CADET_BINDINGTEST("MOBILE_PHASE_MODULATOR", "EXT_MOBILE_PHASE_MODULATOR", (1,1,1
 	        "EXT_MPM_BETA_T": [0.0, 1.5, 0.0, 2.0],
 	        "EXT_MPM_BETA_TT": [0.0, 0.0, 0.0, 0.0],
 	        "EXT_MPM_BETA_TTT": [0.0, 0.0, 0.0, 0.0],
-			"EXT_MPM_LINEAR_THRESHOLD": 1e-10
+			"MPM_LINEAR_THRESHOLD": 1e-10
 	)json", \
 	1e-10, 1e-10, CADET_NONBINDING_LIQUIDPHASE_COMP_UNUSED, CADET_COMPARE_BINDING_VS_NONBINDING)
 
@@ -1002,7 +1002,7 @@ CADET_BINDINGTEST("MULTI_COMPONENT_LDF_FREUNDLICH", "EXT_MULTI_COMPONENT_LDF_FRE
 	        "EXT_MCLDFFRL_A_T": [3.0, 2.2, 1.5, 0.5],
 	        "EXT_MCLDFFRL_A_TT": [0.0, 0.0, 0.0, 0.0],
 	        "EXT_MCLDFFRL_A_TTT": [0.0, 0.0, 0.0, 0.0],
-	        "EXT_MCLDFFRL_TAU": 0.1
+	        "MCLDFFRL_TAU": 0.1
 	)json", \
 	R"json( "EXT_MCLDFFRL_KLDF": [0.0, 0.0, 0.0],
 	        "EXT_MCLDFFRL_KLDF_T": [1.14, 1.0, 2.0],
@@ -1020,7 +1020,7 @@ CADET_BINDINGTEST("MULTI_COMPONENT_LDF_FREUNDLICH", "EXT_MULTI_COMPONENT_LDF_FRE
 	        "EXT_MCLDFFRL_A_T": [2.2, 1.1, 0.4, 0.1, 0.94, 2.8, 0.5, 1.2, 2.4],
 	        "EXT_MCLDFFRL_A_TT": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
 	        "EXT_MCLDFFRL_A_TTT": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-	        "EXT_MCLDFFRL_TAU": 0.1
+	        "MCLDFFRL_TAU": 0.1
 	)json", \
 	1e-10, 1e-10, CADET_NONBINDING_LIQUIDPHASE_COMP_USED, CADET_DONT_COMPARE_BINDING_VS_NONBINDING)
 
@@ -1059,7 +1059,7 @@ CADET_BINDINGTEST("MULTI_COMPONENT_SIPS", "EXT_MULTI_COMPONENT_SIPS", (1, 1, 1, 
 	        "EXT_SIPS_EXP_TTT": [0.0, 0.0, 0.0, 0.0],
 	        "EXT_SIPS_REFC0": 2.0,
 	        "EXT_SIPS_REFQ": 1.1,
-	        "EXT_SIPS_LINEAR_THRESHOLD": 1e-10
+	        "SIPS_LINEAR_THRESHOLD": 1e-10
 	)json", \
 	R"json( "EXT_SIPS_KA": [0.0, 0.0, 0.0, 0.0, 0.0],
 	        "EXT_SIPS_KA_T": [1.14, 1.0, 2.0, 1.14, 2.0],
@@ -1079,7 +1079,7 @@ CADET_BINDINGTEST("MULTI_COMPONENT_SIPS", "EXT_MULTI_COMPONENT_SIPS", (1, 1, 1, 
 	        "EXT_SIPS_EXP_TTT": [0.0, 0.0, 0.0, 0.0, 0.0],
 	        "EXT_SIPS_REFC0": 2.0,
 	        "EXT_SIPS_REFQ": 1.1,
-	        "EXT_SIPS_LINEAR_THRESHOLD": 1e-10
+	        "SIPS_LINEAR_THRESHOLD": 1e-10
 	)json", \
 	1e-10, 1e-10, CADET_NONBINDING_LIQUIDPHASE_COMP_UNUSED, CADET_COMPARE_BINDING_VS_NONBINDING)
 
@@ -1461,6 +1461,7 @@ CADET_BINDINGTEST("GENERALIZED_ION_EXCHANGE", "EXT_GENERALIZED_ION_EXCHANGE", (1
 	{
 		const unsigned int nBound[] = { 0, 0, 1, 1, 1};
 		const double state[] = { 0.9, 1.1, 1.5e-2, 3.2e-3, 1.5e-5, 3.2e-5, 1.5e-5, 3.2e-5 };
+		double FDsignAbsTol = 1e-10; // specific tolerance for this test, non-default value
 		char const* const config = R"json({
 			"COL_PHI": 49232983.6522396,
 			"COL_KAPPA_EXP": 1.8,
@@ -1487,7 +1488,7 @@ CADET_BINDINGTEST("GENERALIZED_ION_EXCHANGE", "EXT_GENERALIZED_ION_EXCHANGE", (1
 			const bool isKinetic = bindMode;
 			SECTION(std::string("Binding mode ") + (isKinetic ? "dynamic" : "quasi-stationary"))
 			{
-				cadet::test::binding::testJacobianAD("MULTI_COMPONENT_COLLOIDAL", sizeof(nBound) / sizeof(unsigned int), nBound, isKinetic, config, state);
+				cadet::test::binding::testJacobianAD("MULTI_COMPONENT_COLLOIDAL", sizeof(nBound) / sizeof(unsigned int), nBound, isKinetic, config, state, FDsignAbsTol);
 			}
 		}
 	}

--- a/test/BindingModels.hpp
+++ b/test/BindingModels.hpp
@@ -32,7 +32,7 @@
 #define CADET_BINDINGTEST_SINGLE_IMPL_NONBNDJACCONST_false(modelName, tagName, postFix, someNonBinding, stateSomeNon, configSomeNon)
 
 #define CADET_BINDINGTEST_SINGLE_IMPL_NONBNDJACCONST_true(modelName, tagName, postFix, someNonBinding, stateSomeNon, configSomeNon) \
-	TEST_CASE(modelName " binding model consistency of non-binding Jacobian columns" postFix, "[BindingModel],[Jacobian]," tagName) \
+	TEST_CASE(modelName " binding model consistency of non-binding Jacobian columns" postFix, "[BindingModel],[CI_binding],[Jacobian]," tagName) \
 	{ \
 		const unsigned int nBound3[] = BRACED_INIT_LIST someNonBinding; \
 		const double state3[] = BRACED_INIT_LIST stateSomeNon; \
@@ -68,7 +68,7 @@
 #define CADET_BINDINGTEST_SINGLE_IMPL_BNDVSNONBND_false(modelName, tagName, postFix, allBinding, someNonBinding, stateAll, stateSomeNon, configAll, configSomeNon)
 
 #define CADET_BINDINGTEST_SINGLE_IMPL_BNDVSNONBND_true(modelName, tagName, postFix, allBinding, someNonBinding, stateAll, stateSomeNon, configAll, configSomeNon) \
-	TEST_CASE(modelName " binding model consistency of non-binding vs binding" postFix, "[BindingModel],[Jacobian]," tagName) \
+	TEST_CASE(modelName " binding model consistency of non-binding vs binding" postFix, "[BindingModel],[CI_binding],[Jacobian]," tagName) \
 	{ \
 		const unsigned int nBound2[] = BRACED_INIT_LIST allBinding; \
 		const unsigned int nBound3[] = BRACED_INIT_LIST someNonBinding; \
@@ -115,7 +115,7 @@
  * @param cmpBndVsNonbnd Determines whether a test for all-binding vs non-binding variant (Jacobian and residual) is created
  */
 #define CADET_BINDINGTEST_SINGLE_IMPL(modelName, tagName, postFix, allBinding, someNonBinding, stateAll, stateSomeNon, configAll, configSomeNon, consInitTol, consInitCheckTol, usesNonBindingLiquidPhase, cmpBndVsNonbnd) \
-	TEST_CASE(modelName " binding model analytic Jacobian vs AD" postFix, "[Jacobian],[AD],[BindingModel]," tagName) \
+	TEST_CASE(modelName " binding model analytic Jacobian vs AD" postFix, "[Jacobian],[AD],[BindingModel],[CI_binding]," tagName) \
 	{ \
 		const unsigned int nBound2[] = BRACED_INIT_LIST allBinding; \
 		const unsigned int nBound3[] = BRACED_INIT_LIST someNonBinding; \
@@ -180,7 +180,7 @@
 #define CADET_BINDINGTEST_MULTI(modelName, extModelName, postFix, allBinding, someNonBinding, stateAll, stateSomeNon, configAll, configSomeNon, extConfigAll, extConfigSomeNon, consInitTol, consInitCheckTol, usesNonBindingLiquidPhase, cmpBndVsNonbnd) \
 	CADET_BINDINGTEST_SINGLE_IMPL(modelName, "[" modelName "]", postFix, allBinding, someNonBinding, stateAll, stateSomeNon, configAll, configSomeNon, consInitTol, consInitCheckTol, usesNonBindingLiquidPhase, cmpBndVsNonbnd) \
 	CADET_BINDINGTEST_SINGLE_IMPL(extModelName, "[ExternalFunction],[" extModelName "]", postFix, allBinding, someNonBinding, stateAll, stateSomeNon, extConfigAll, extConfigSomeNon, consInitTol, consInitCheckTol, usesNonBindingLiquidPhase, cmpBndVsNonbnd) \
-	TEST_CASE(modelName " binding model consistent with externally dependent variant" postFix, "[BindingModel],[ExternalFunction],[" modelName "],[" extModelName "]") \
+	TEST_CASE(modelName " binding model consistent with externally dependent variant" postFix, "[BindingModel],[CI_binding],[ExternalFunction],[" modelName "],[" extModelName "]") \
 	{ \
 		const unsigned int nBound2[] = BRACED_INIT_LIST allBinding; \
 		const unsigned int nBound3[] = BRACED_INIT_LIST someNonBinding; \
@@ -235,7 +235,7 @@
  * @param consInitCheckTol Error tolerance for residual check in consistent initialization
  */
 #define CADET_BINDINGTEST_ALLBINDING_SINGLE_IMPL(modelName, tagName, allBinding, stateAll, configAll, consInitTol, consInitCheckTol) \
-	TEST_CASE(modelName " binding model analytic Jacobian vs AD", "[Jacobian],[AD],[BindingModel]," tagName) \
+	TEST_CASE(modelName " binding model analytic Jacobian vs AD", "[Jacobian],[AD],[BindingModel],[CI_binding]," tagName) \
 	{ \
 		const unsigned int nBound2[] = BRACED_INIT_LIST allBinding; \
 		const double state2[] = BRACED_INIT_LIST stateAll; \
@@ -277,7 +277,7 @@
 #define CADET_BINDINGTEST_ALLBINDING(modelName, extModelName, allBinding, stateAll, configAll, extConfigAll, consInitTol, consInitCheckTol) \
 	CADET_BINDINGTEST_ALLBINDING_SINGLE_IMPL(modelName, "[" modelName "]", allBinding, stateAll, configAll, consInitTol, consInitCheckTol) \
 	CADET_BINDINGTEST_ALLBINDING_SINGLE_IMPL(extModelName, "[ExternalFunction],[" extModelName "]", allBinding, stateAll, extConfigAll, consInitTol, consInitCheckTol) \
-	TEST_CASE(modelName " binding model consistent with externally dependent variant", "[BindingModel],[ExternalFunction],[" modelName "],[" extModelName "]") \
+	TEST_CASE(modelName " binding model consistent with externally dependent variant", "[BindingModel],[CI_binding],[ExternalFunction],[" modelName "],[" extModelName "]") \
 	{ \
 		const unsigned int nBound2[] = BRACED_INIT_LIST allBinding; \
 		const double state2[] = BRACED_INIT_LIST stateAll; \


### PR DESCRIPTION
This PR adds all binding model submodule tests to the CI, e.g. Jacobian tests for the bindings, without other modules like the unit operation.

fixes #356 

TODO
-------
- [x] include tests in CI
- [x] fix tests that fail