### PR TITLE
SelectiveStdWritePolicy::writeObj: write logs

### DIFF
--- a/include/common/Logger.hpp
+++ b/include/common/Logger.hpp
@@ -40,7 +40,7 @@ namespace log
 
 		static inline void end(LogLevel lvl) { std::cout << std::endl; }
 
-		template <class T> 
+		template <class T>
 		static inline void writeObj(LogLevel lvl, const T& obj)
 		{
 			std::cout << obj;
@@ -57,7 +57,7 @@ namespace log
 
 		static inline void end(LogLevel lvl) { std::cerr << std::endl; }
 
-		template <class T> 
+		template <class T>
 		static inline void writeObj(LogLevel lvl, const T& obj)
 		{
 			std::cerr << obj;
@@ -82,13 +82,13 @@ namespace log
 				std::cout << std::endl;
 		}
 
-		template <class T> 
+		template <class T>
 		static inline void writeObj(LogLevel lvl, const T& obj)
 		{
 			if (lvl < switchLvl)
-				std::cerr << std::endl;
+				std::cerr << obj;
 			else
-				std::cout << std::endl;
+				std::cout << obj;
 		}
 	};
 


### PR DESCRIPTION
As far as I can tell, `cadet::log::SelectiveStdWritePolicy<switchLvl>` will not write out any objects to either `std::cerr` or `std::cout` -- it will only write end-of-line sequences to both streams. This behavior seems inconsistent with both its intent and with the other two logging policies implemented (`cadet::log::StdOutWritePolicy` and `cadet::log::StdErrWritePolicy`), so this commit changes the implementation of `cadet::log::SelectiveStdWritePolicy::writeObj` to be consistent with those two logging policies.