### PR TITLE
Unify flowrate / velocity interface

### DIFF
--- a/doc/modelling/unit_operations/general_rate_model.rst
+++ b/doc/modelling/unit_operations/general_rate_model.rst
@@ -264,6 +264,7 @@ Specification of flow rate / velocity and direction
 Since volumetric flow rates are specified for each network connection, the unit operation can infer its interstitial velocity via
 
 .. math::
+    :label: interstitialVelocity
 
     \begin{aligned}
         u = u_{\text{int}} = \frac{F_{\text{in}}}{A \varepsilon_c},
@@ -280,9 +281,9 @@ The final behavior for axial flow models is controlled by the interplay of cross
 
 - If cross section area :math:`A` is given and :math:`u` is not, :math:`u` is inferred from the volumetric flow rate.
 
-- If :math:`u` is given and :math:`A` is not, the provided interstitial velocity is used, i.e. a column radius with :math:`A` being consistent with the volumetric flow rate is assumed.
+- If :math:`u` is given and :math:`A` is not, the provided interstitial velocity is used, i.e. the column cross section is prescribed by the volumetric flow rate as per Eq. (:eq:`ModelColumn`).
 
-- If both cross section area :math:`A` and interstitial velocity :math:`u` are given, the sign of the provided interstitial velocity only determines the flow direction while the magnitude of the actual interstitial velocity :math:`u` is inferred from the volumetric flow rate.
+- If both cross section area :math:`A` and interstitial velocity :math:`u` are given, only the sign of the provided interstitial velocity determines the flow direction while the magnitude of the actual interstitial velocity :math:`u` is inferred from the volumetric flow rate.
 
 The final behavior for radial flow models is controlled by the interplay of column length/height and interstitial velocity coefficient:
 

--- a/doc/modelling/unit_operations/general_rate_model.rst
+++ b/doc/modelling/unit_operations/general_rate_model.rst
@@ -280,9 +280,9 @@ The final behavior for axial flow models is controlled by the interplay of cross
 
 - If cross section area :math:`A` is given and :math:`u` is not, :math:`u` is inferred from the volumetric flow rate.
 
-- If :math:`u` is given and :math:`A` is not, the volumetric flow rate is ignored and the provided interstitial velocity is used.
+- If :math:`u` is given and :math:`A` is not, the provided interstitial velocity is used, i.e. a column radius with :math:`A` being consistent with the volumetric flow rate is assumed.
 
-- If both cross section area :math:`A` and interstitial velocity :math:`u` are given, the magnitude of the actual interstitial velocity :math:`u` is inferred from the volumetric flow rate and the flow direction is given by the sign of the provided :math:`u`.
+- If both cross section area :math:`A` and interstitial velocity :math:`u` are given, the sign of the provided interstitial velocity only determines the flow direction while the magnitude of the actual interstitial velocity :math:`u` is inferred from the volumetric flow rate.
 
 The final behavior for radial flow models is controlled by the interplay of column length/height and interstitial velocity coefficient:
 


### PR DESCRIPTION
Our interface and internal computation of the entangled parameters `velocity`, `cross_section_area` and the flow rates specified in the `connections` matrix are ambiguous, the interface should be unique and explicit, any reparameterizations etc. belong to the frontend.
This PR
- [ ] removes `velocity` from the interface, which is then solely computed from the cross section area and flow rate. Note that this is how its done in CADET-Process and CASEMA (cross section or radius needed for error estimates in 2D models) anyways.
- [ ] introduces an optional `FLOW_DIRECTION` field, only -1 and 1 are accepted for forward and backward flow respectively, this also substitutes the field `VELOCITY_COEFF` for radial and frustum flow
- [ ] updates documentation accordingly
- [ ] before merge: update cadet-verification for this interface change and run the verify_cadet-core workflow