### PR TITLE
Add support for external templateCodeGen in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,6 +164,8 @@ add_feature_info(ENABLE_STATIC_LINK_CLI ENABLE_STATIC_LINK_CLI "Prefer static ov
 option(CMAKE_INSTALL_RPATH_USE_LINK_PATH "Add paths to linker search and installed rpath" ON)
 add_feature_info(CMAKE_INSTALL_RPATH_USE_LINK_PATH CMAKE_INSTALL_RPATH_USE_LINK_PATH "Add paths to linker search and installed rpath")
 
+set(EXTERNAL_TEMPLATE_CODEGEN "" CACHE STRING "Uses an external templateCodeGen instead of compiling one")
+
 # Hande RPATH on OSX when not installing to a system directory, see
 # https://groups.google.com/d/msg/fenics-dev/KSCrob4M_1M/zsJwdN-SCAAJ
 # and https://cmake.org/Wiki/CMake_RPATH_handling#Always_full_RPATH
@@ -438,6 +440,15 @@ if (ENABLE_IPO)
 endif()
 
 
+set(TEMPLATE_CODEGEN_CMD "templateCodeGen")
+if (NOT "${EXTERNAL_TEMPLATE_CODEGEN}" STREQUAL "")
+	if (EXISTS "${EXTERNAL_TEMPLATE_CODEGEN}")
+		set(TEMPLATE_CODEGEN_CMD "${EXTERNAL_TEMPLATE_CODEGEN}")
+	else()
+		message(WARNING "External templateCodeGen ${EXTERNAL_TEMPLATE_CODEGEN} not found, fallback to compiling")
+	endif()
+endif()
+
 # ---------------------------------------------------
 #   Add selected modules to the build system and add the targets to the list of all targets
 # ---------------------------------------------------
@@ -577,6 +588,7 @@ message("Install dir: ${CMAKE_INSTALL_PREFIX}")
 message("C Flags: ${CMAKE_C_FLAGS}")
 message("C++ Flags: ${CMAKE_CXX_FLAGS}")
 message("IPO enabled: ${IPO_AVAILABLE}")
+message("templateCodeGen: ${TEMPLATE_CODEGEN_CMD}")
 message("------------------------------- Modules -------------------------------")
 message("CADET-CLI: ${ENABLE_CADET_CLI}")
 message("Tools: ${ENABLE_CADET_TOOLS}")

--- a/src/build-tools/CMakeLists.txt
+++ b/src/build-tools/CMakeLists.txt
@@ -13,11 +13,13 @@
 # Name of the current project
 project(CadetBuildTools CXX C)
 
-# Add the template code generator
-add_executable(templateCodeGen ${CMAKE_SOURCE_DIR}/src/build-tools/templateCodeGen.cpp)
-target_include_directories(templateCodeGen PRIVATE ${CMAKE_SOURCE_DIR}/ThirdParty/json ${CMAKE_SOURCE_DIR}/ThirdParty/inja)
-target_compile_features(templateCodeGen PRIVATE cxx_std_23)
-set_target_properties(templateCodeGen PROPERTIES CXX_EXTENSIONS OFF)
+if (EXTERNAL_TEMPLATE_CODEGEN STREQUAL "")
+	# Add the template code generator
+	add_executable(templateCodeGen ${CMAKE_SOURCE_DIR}/src/build-tools/templateCodeGen.cpp)
+	target_include_directories(templateCodeGen PRIVATE ${CMAKE_SOURCE_DIR}/ThirdParty/json ${CMAKE_SOURCE_DIR}/ThirdParty/inja)
+	target_compile_features(templateCodeGen PRIVATE cxx_std_23)
+	set_target_properties(templateCodeGen PROPERTIES CXX_EXTENSIONS OFF)
+endif()
 
 # Info message
 message(STATUS "Added build tools")

--- a/src/libcadet/CMakeLists.txt
+++ b/src/libcadet/CMakeLists.txt
@@ -233,7 +233,7 @@ foreach(BM IN LISTS LIBCADET_BINDINGMODEL_SOURCES)
 	get_filename_component(BMFILEWE ${BM} NAME_WE)
 	get_filename_component(BMFILE ${BM} NAME)
 	add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${BMFILE}
-		COMMAND templateCodeGen ${CMAKE_SOURCE_DIR}/src/libcadet/model/binding/ExternalFunctionTemplate.cpp ${BM} ${CMAKE_CURRENT_BINARY_DIR}/${BMFILE} 
+		COMMAND ${TEMPLATE_CODEGEN_CMD} ${CMAKE_SOURCE_DIR}/src/libcadet/model/binding/ExternalFunctionTemplate.cpp ${BM} ${CMAKE_CURRENT_BINARY_DIR}/${BMFILE}
 		MAIN_DEPENDENCY ${BM}
 		DEPENDS ${CMAKE_SOURCE_DIR}/src/libcadet/model/binding/ExternalFunctionTemplate.cpp
 		COMMENT "Generating code for ${BMFILEWE}"
@@ -245,7 +245,7 @@ foreach(RM IN LISTS LIBCADET_REACTIONMODEL_SOURCES)
 	get_filename_component(RMFILEWE ${RM} NAME_WE)
 	get_filename_component(RMFILE ${RM} NAME)
 	add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${RMFILE}
-		COMMAND templateCodeGen ${CMAKE_SOURCE_DIR}/src/libcadet/model/reaction/ExternalFunctionTemplate.cpp ${RM} ${CMAKE_CURRENT_BINARY_DIR}/${RMFILE} 
+		COMMAND ${TEMPLATE_CODEGEN_CMD} ${CMAKE_SOURCE_DIR}/src/libcadet/model/reaction/ExternalFunctionTemplate.cpp ${RM} ${CMAKE_CURRENT_BINARY_DIR}/${RMFILE}
 		MAIN_DEPENDENCY ${RM}
 		DEPENDS ${CMAKE_SOURCE_DIR}/src/libcadet/model/reaction/ExternalFunctionTemplate.cpp
 		COMMENT "Generating code for ${RMFILEWE}"


### PR DESCRIPTION
This helps in cross compiled builds where the cross compiler would also build templateCodeGen. Here, templateCodeGen cannot run on the host and the build fails.

Helps with #396 and #372.