### PR TITLE
Overload ScalarParameter methods for reaction model compatibility

### DIFF
--- a/src/libcadet/model/Parameters.hpp
+++ b/src/libcadet/model/Parameters.hpp
@@ -704,8 +704,7 @@ public:
 
 	/**
 	 * @brief Reserves space in the storage of the parameters
-	 * @param [in] numElem Total number of components in all slices / binding site types
-	 * @param [in] numSlices Number of slices / binding site types
+	 * @param [in] nReactions Number of reactions
 	 * @param [in] nComp Number of components
 	 * @param [in] nBoundStates Number of bound states
 	 */

--- a/src/libcadet/model/Parameters.hpp
+++ b/src/libcadet/model/Parameters.hpp
@@ -172,6 +172,14 @@ public:
 	 */
 	inline void reserve(unsigned int numElem, unsigned int numSlices, unsigned int nComp, unsigned int const* nBoundStates) { }
 
+	/**
+	 * @brief Reserves space in the storage of the parameter
+	 * @param [in] numSlices Number of slices / binding site types
+	 * @param [in] nComp Number of components
+	 * @param [in] nBoundStates number of bound states
+	 */
+	inline void reserve(unsigned int numSlices, unsigned int nComp, unsigned int nBoundStates) { }
+
 	inline const active& get() const CADET_NOEXCEPT { return *_p; }
 	inline active& get() CADET_NOEXCEPT { return *_p; }
 
@@ -695,6 +703,15 @@ public:
 	inline void reserve(unsigned int numElem, unsigned int numSlices, unsigned int nComp, unsigned int const* nBoundStates) { }
 
 	/**
+	 * @brief Reserves space in the storage of the parameters
+	 * @param [in] numElem Total number of components in all slices / binding site types
+	 * @param [in] numSlices Number of slices / binding site types
+	 * @param [in] nComp Number of components
+	 * @param [in] nBoundStates Number of bound states
+	 */
+	inline void reserve(unsigned int nReactions, unsigned int nComp, unsigned int nBoundStates) { }
+
+	/**
 	 * @brief Calculates a parameter in order to take the external profile into account
 	 * @param [out] result Stores the result of the paramter
 	 * @param [in] extVal Value of the external function
@@ -767,6 +784,23 @@ public:
 	 * @return Amount of additional memory in bytes
 	 */
 	inline std::size_t additionalDynamicMemory(unsigned int nComp, unsigned int totalNumBoundStates, unsigned int const* nBoundStates) const CADET_NOEXCEPT { return 0; }
+
+	/**
+	 * @brief Returns the amount of additional memory (usually dynamically allocated by containers) for storing the final parameters
+	 * @details In a model, externally dependent parameters are stored in a struct, usually called
+	 *          VariableParams. This is sufficient for "static" parameter types that do
+	 *          not require additional memory (which is usually allocated dynamically).
+	 *          For containers using additional dynamic memory, only the container itself
+	 *          is stored in the struct. Memory for the content of the container (i.e., the
+	 *          elements) is still required. This function computes this amount of additional
+	 *          memory.
+	 *
+	 * @param [in] nComp Number of components
+	 * @param [in] totalNumBoundStates Total number of bound states
+	 * @param [in] nBoundStates Number of bound states
+	 * @return Amount of additional memory in bytes
+	 */
+	inline std::size_t additionalDynamicMemory(unsigned int nComp, unsigned int totalNumBoundStates, unsigned int nBoundStates) const CADET_NOEXCEPT { return 0; }
 
 	/**
 	 * @brief Prepares the cache for the updated values


### PR DESCRIPTION
When using `ScalarParameter` in a reaction model, the code generated from the configuration wouldn't compile because it generates code with invalid function headers, e.g.
```cpp
inline void reserve(unsigned int nReactions, unsigned int nComp, unsigned int nBoundStates)
{
  _Kh20.reserve(nReactions, nComp, nBoundStates);
  // [...]
}
```
This PR fixes the situation by overloading the existing headers with ones compatible with code generated from the reaction model codegen template. It is required for #413.