### PR TITLE
Fix tests, CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,18 +163,50 @@ jobs:
           ${INSTALL_PREFIX}/bin/cadet-cli --version || true
           ${INSTALL_PREFIX}/bin/createLWE
           ${INSTALL_PREFIX}/bin/cadet-cli LWE.h5 || true
-      - name: Run CI test set I
-        run: |
-          ${BUILD_DIR}/test/testRunner [CI]
-      - name: Run CI test set II
+      - name: Run CI test set I - bindings
         run: |
           ${BUILD_DIR}/test/testRunner [CI_binding]
-      - name: Run CI test set III
+      - name: Run CI test set II - sensitivities
         run: |
-          ${BUILD_DIR}/test/testRunner [CI_sensitivity1]
+          ${BUILD_DIR}/test/testRunner [CI_sens1]
+          ${BUILD_DIR}/test/testRunner [CI_sens2]
+          ${BUILD_DIR}/test/testRunner [CI_sens3]
+          ${BUILD_DIR}/test/testRunner [CI_sens4]
+          ${BUILD_DIR}/test/testRunner [CI_sens5]
+          ${BUILD_DIR}/test/testRunner [CI_sens6]
+          ${BUILD_DIR}/test/testRunner [CI_sens7]
+          ${BUILD_DIR}/test/testRunner [CI_sens8]
+          ${BUILD_DIR}/test/testRunner [CI_sens9]
+          ${BUILD_DIR}/test/testRunner [CI_sens11]
+          ${BUILD_DIR}/test/testRunner [CI_sens12]
+          ${BUILD_DIR}/test/testRunner [CI_sens13]
+          ${BUILD_DIR}/test/testRunner [CI_sens14]
+          ${BUILD_DIR}/test/testRunner [CI_sens15]
+      - name: Run CI test set III - crystallization
+        run: |
+          ${BUILD_DIR}/test/testRunner [CI_cry1]
+          ${BUILD_DIR}/test/testRunner [CI_cry2]
+          ${BUILD_DIR}/test/testRunner [CI_cry3]
+          ${BUILD_DIR}/test/testRunner [CI_cry4]
+          ${BUILD_DIR}/test/testRunner [CI_cry5]
+          ${BUILD_DIR}/test/testRunner [CI_cry6]
+          ${BUILD_DIR}/test/testRunner [CI_cry7]
+          ${BUILD_DIR}/test/testRunner [CI_cry8]
+          ${BUILD_DIR}/test/testRunner [CI_cry9]
+          ${BUILD_DIR}/test/testRunner [CI_cry10]
+          ${BUILD_DIR}/test/testRunner [CI_cry11]
+          ${BUILD_DIR}/test/testRunner [CI_cry12]
+          ${BUILD_DIR}/test/testRunner [CI_cry13]
+          ${BUILD_DIR}/test/testRunner [CI_cry14]
+          ${BUILD_DIR}/test/testRunner [CI_cry15]
+          ${BUILD_DIR}/test/testRunner [CI_cry16]
+          ${BUILD_DIR}/test/testRunner [CI_cry17]
+          ${BUILD_DIR}/test/testRunner [CI_cry18]
+          ${BUILD_DIR}/test/testRunner [CI_cry19]
+          ${BUILD_DIR}/test/testRunner [CI_cry20]
       - name: Run CI test set IV
         run: |
-          ${BUILD_DIR}/test/testRunner [CI_sensitivity2]
+          ${BUILD_DIR}/test/testRunner [CI]
   MacOS:
     runs-on: macos-latest
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,7 @@ jobs:
           cmake -E make_directory "${BUILD_DIR}"
           cmake -E make_directory "${INSTALL_PREFIX}"
           cd "${BUILD_DIR}"
-          cmake -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" "${SRC_DIR}" -DENABLE_TESTS=ON -DNUM_MAX_AD_DIRS=157
+          cmake -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" "${SRC_DIR}" -DENABLE_TESTS=ON -DNUM_MAX_AD_DIRS=160
           make install -j$(nproc)
       - name: Check executable
         run: |

--- a/BUILD-LINUX.md
+++ b/BUILD-LINUX.md
@@ -52,6 +52,7 @@ sudo apt -y install liblapack3 liblapack-dev libblas3 libblas-dev
 - Open a terminal and change to `CADET-Core/build`
 - If using MKL, execute `export MKLROOT=/opt/intel/mkl`
 - To compile:
+
 	- Using standard LAPACK: Execute `cmake -DCMAKE_INSTALL_PREFIX="../install" ../`
 
 	- Using MKL (sequential): Execute `cmake -DCMAKE_INSTALL_PREFIX="../install" -DBLA_VENDOR=Intel10_64lp_seq ../`

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -50,7 +50,7 @@
       "configurationType": "Debug",
       "inheritEnvironments": [ "msvc_x64_x64" ],
       "buildRoot": "${env.BUILDROOT}_DEBUG_with_Tests",
-      "cmakeCommandArgs": "-DVCPKG_TARGET_TRIPLET=x64-windows-static -DENABLE_STATIC_LINK_LAPACK=ON -DENABLE_STATIC_LINK_DEPS=ON -DENABLE_TESTS=ON -DNUM_MAX_AD_DIRS=157 -DENABLE_ANALYTIC_JACOBIAN_CHECK=OFF --fresh",
+      "cmakeCommandArgs": "-DVCPKG_TARGET_TRIPLET=x64-windows-static -DENABLE_STATIC_LINK_LAPACK=ON -DENABLE_STATIC_LINK_DEPS=ON -DENABLE_TESTS=ON -DNUM_MAX_AD_DIRS=160 -DENABLE_ANALYTIC_JACOBIAN_CHECK=OFF --fresh",
       "buildCommandArgs": "-m -v:minimal",
       "variables": [
         {
@@ -158,7 +158,7 @@
       "configurationType": "RelWithDebInfo",
       "inheritEnvironments": [ "msvc_x64_x64" ],
       "buildRoot": "${env.BUILDROOT}_RELEASE_with_Tests",
-      "cmakeCommandArgs": "-DVCPKG_TARGET_TRIPLET=x64-windows-static -DENABLE_STATIC_LINK_LAPACK=ON -DENABLE_STATIC_LINK_DEPS=ON -DENABLE_TESTS=ON -DNUM_MAX_AD_DIRS=157 -DENABLE_ANALYTIC_JACOBIAN_CHECK=OFF --fresh",
+      "cmakeCommandArgs": "-DVCPKG_TARGET_TRIPLET=x64-windows-static -DENABLE_STATIC_LINK_LAPACK=ON -DENABLE_STATIC_LINK_DEPS=ON -DENABLE_TESTS=ON -DNUM_MAX_AD_DIRS=160 -DENABLE_ANALYTIC_JACOBIAN_CHECK=OFF --fresh",
       "buildCommandArgs": "-m -v:minimal",
       "variables": [
         {

--- a/test/ColumnTests.cpp
+++ b/test/ColumnTests.cpp
@@ -856,10 +856,10 @@ namespace column
 
 		cadet::IUnitOperation* const unitAna = unitoperation::createAndConfigureUnit(jpp, *mb);
 		cadet::IUnitOperation* const unitAD = unitoperation::createAndConfigureUnit(jpp, *mb);
+		unitAD->useAnalyticJacobian(false);
 
 		// Enable AD
 		REQUIRE(unitAD->requiredADdirs() <= cadet::ad::getMaxDirections());
-		unitAD->useAnalyticJacobian(false);
 		cadet::ad::setDirections(unitAD->requiredADdirs());
 
 		cadet::active* adRes = new cadet::active[unitAD->numDofs()];

--- a/test/Crystallization.cpp
+++ b/test/Crystallization.cpp
@@ -29,7 +29,7 @@ const char* getTestDirectory();
 /*
  * Pure PBM tests
 */
-TEST_CASE("Crystallization in a CSTR with initial distribution and growth", "[Crystallization],[PBM],[Simulation],[Reference],[CI]")
+TEST_CASE("Crystallization in a CSTR with initial distribution and growth", "[Crystallization],[PBM],[Simulation],[Reference],[CI_cry1]")
 {
 	const std::string& modelFilePath = std::string("/data/model_cry_CSTR_PBM_growth_benchmark1.json");
 	const std::string& refFilePath = std::string("/data/ref_cry_CSTR_PBM_growth_benchmark1.h5");
@@ -40,7 +40,7 @@ TEST_CASE("Crystallization in a CSTR with initial distribution and growth", "[Cr
 	cadet::test::column::testReferenceBenchmark(modelFilePath, refFilePath, "001", absTol, relTol, disc, false);
 }
 
-TEST_CASE("Crystallization in a CSTR with initial distribution and size-dependent growth", "[Crystallization],[PBM],[Simulation],[Reference],[CI]")
+TEST_CASE("Crystallization in a CSTR with initial distribution and size-dependent growth", "[Crystallization],[PBM],[Simulation],[Reference],[CI_cry2]")
 {
 	const std::string& modelFilePath = std::string("/data/model_cry_CSTR_PBM_growthSizeDep_benchmark1.json");
 	const std::string& refFilePath = std::string("/data/ref_cry_CSTR_PBM_growthSizeDep_benchmark1.h5");
@@ -51,7 +51,7 @@ TEST_CASE("Crystallization in a CSTR with initial distribution and size-dependen
 	cadet::test::column::testReferenceBenchmark(modelFilePath, refFilePath, "001", absTol, relTol, disc, false);
 }
 
-TEST_CASE("Crystallization in a CSTR with primary nucleation and growth", "[Crystallization],[PBM],[Simulation],[Reference],[CI]")
+TEST_CASE("Crystallization in a CSTR with primary nucleation and growth", "[Crystallization],[PBM],[Simulation],[Reference],[CI_cry3]")
 {
 	const std::string& modelFilePath = std::string("/data/model_cry_CSTR_PBM_primaryNucleationAndGrowth_benchmark1.json");
 	const std::string& refFilePath = std::string("/data/ref_cry_CSTR_PBM_primaryNucleationAndGrowth_benchmark1.h5");
@@ -62,7 +62,7 @@ TEST_CASE("Crystallization in a CSTR with primary nucleation and growth", "[Crys
 	cadet::test::column::testReferenceBenchmark(modelFilePath, refFilePath, "001", absTol, relTol, disc, false);
 }
 
-TEST_CASE("Crystallization in a CSTR with primary nucleation, growth and growth rate dispersion", "[Crystallization],[PBM],[Simulation],[Reference],[CI]")
+TEST_CASE("Crystallization in a CSTR with primary nucleation, growth and growth rate dispersion", "[Crystallization],[PBM],[Simulation],[Reference],[CI_cry4]")
 {
 	const std::string& modelFilePath = std::string("/data/model_cry_CSTR_PBM_primaryNucleationGrowthGrowthRateDispersion_benchmark1.json");
 	const std::string& refFilePath = std::string("/data/ref_cry_CSTR_PBM_primaryNucleationGrowthGrowthRateDispersion_benchmark1.h5");
@@ -73,7 +73,7 @@ TEST_CASE("Crystallization in a CSTR with primary nucleation, growth and growth 
 	cadet::test::column::testReferenceBenchmark(modelFilePath, refFilePath, "001", absTol, relTol, disc, false);
 }
 
-TEST_CASE("Crystallization in a CSTR with primary and secondary nucleation and growth", "[Crystallization],[PBM],[Simulation],[Reference],[CI]")
+TEST_CASE("Crystallization in a CSTR with primary and secondary nucleation and growth", "[Crystallization],[PBM],[Simulation],[Reference],[CI_cry5]")
 {
 	const std::string& modelFilePath = std::string("/data/model_cry_CSTR_PBM_primarySecondaryNucleationAndGrowth_benchmark1.json");
 	const std::string& refFilePath = std::string("/data/ref_cry_CSTR_PBM_primarySecondaryNucleationAndGrowth_benchmark1.h5");
@@ -84,7 +84,7 @@ TEST_CASE("Crystallization in a CSTR with primary and secondary nucleation and g
 	cadet::test::column::testReferenceBenchmark(modelFilePath, refFilePath, "001", absTol, relTol, disc, false);
 }
 
-TEST_CASE("Crystallization in a DPFR/LRM with primary and secondary nucleation and growth", "[CrysToFix0],[Crystallization],[PBM],[Simulation],[Reference],[CI]") 
+TEST_CASE("Crystallization in a DPFR/LRM with primary and secondary nucleation and growth", "[Crystallization],[PBM],[Simulation],[Reference],[CI_cry6]") 
 {
 	const std::string& modelFilePath = std::string("/data/model_cry_DPFR_PBM_primarySecondaryNucleationGrowth_benchmark1.json");
 	const std::string& refFilePath = std::string("/data/ref_cry_DPFR_PBM_primarySecondaryNucleationGrowth_benchmark1.h5");
@@ -95,7 +95,7 @@ TEST_CASE("Crystallization in a DPFR/LRM with primary and secondary nucleation a
 	cadet::test::column::testReferenceBenchmark(modelFilePath, refFilePath, "001", absTol, relTol, disc, false);
 }
 
-TEST_CASE("Crystallization Jacobian verification for a CSTR with initial distribution and growth", "[Crystallization],[PBM],[UnitOp],[Jacobian],[CI]")
+TEST_CASE("Crystallization Jacobian verification for a CSTR with initial distribution and growth", "[Crystallization],[PBM],[UnitOp],[Jacobian],[CI_cry7]")
 {
 	// read json model setup file
 	const std::string& modelFileRelPath = std::string("/data/model_cry_CSTR_PBM_growth_benchmark1.json");
@@ -113,7 +113,7 @@ TEST_CASE("Crystallization Jacobian verification for a CSTR with initial distrib
 	cadet::test::column::testJacobianAD(pp_setup, std::numeric_limits<float>::epsilon() * 100.0);
 }
 
-TEST_CASE("Crystallization Jacobian verification for a CSTR with initial distribution and size-dependent growth", "[Crystallization],[PBM],[UnitOp],[Jacobian],[CI]")
+TEST_CASE("Crystallization Jacobian verification for a CSTR with initial distribution and size-dependent growth", "[Crystallization],[PBM],[UnitOp],[Jacobian],[CI_cry8]")
 {
 	// read json model setup file
 	const std::string& modelFileRelPath = std::string("/data/model_cry_CSTR_PBM_growthSizeDep_benchmark1.json");
@@ -131,7 +131,7 @@ TEST_CASE("Crystallization Jacobian verification for a CSTR with initial distrib
 	cadet::test::column::testJacobianAD(pp_setup, std::numeric_limits<float>::epsilon() * 100.0);
 }
 
-TEST_CASE("Crystallization Jacobian verification for a CSTR with primary nucleation and growth", "[Crystallization],[PBM],[UnitOp],[Jacobian],[CI]")
+TEST_CASE("Crystallization Jacobian verification for a CSTR with primary nucleation and growth", "[Crystallization],[PBM],[UnitOp],[Jacobian],[CI_cry9]")
 {
 	// read json model setup file
 	const std::string& modelFileRelPath = std::string("/data/model_cry_CSTR_PBM_primaryNucleationAndGrowth_benchmark1.json");
@@ -149,7 +149,7 @@ TEST_CASE("Crystallization Jacobian verification for a CSTR with primary nucleat
 	cadet::test::column::testJacobianAD(pp_setup, std::numeric_limits<float>::epsilon() * 100.0);
 }
 
-TEST_CASE("Crystallization Jacobian verification for a CSTR with primary nucleation, growth and growth rate dispersion", "[Crystallization],[PBM],[UnitOp],[Jacobian],[CI]")
+TEST_CASE("Crystallization Jacobian verification for a CSTR with primary nucleation, growth and growth rate dispersion", "[Crystallization],[PBM],[UnitOp],[Jacobian],[CI_cry10]")
 {
 	// read json model setup file
 	const std::string& modelFileRelPath = std::string("/data/model_cry_CSTR_PBM_primaryNucleationGrowthGrowthRateDispersion_benchmark1.json");
@@ -167,7 +167,7 @@ TEST_CASE("Crystallization Jacobian verification for a CSTR with primary nucleat
 	cadet::test::column::testJacobianAD(pp_setup, std::numeric_limits<float>::epsilon() * 100.0);
 }
 
-TEST_CASE("Crystallization Jacobian verification for a CSTR with primary and secondary nucleation and growth", "[Crystallization],[PBM],[UnitOp],[Jacobian],[CI]")
+TEST_CASE("Crystallization Jacobian verification for a CSTR with primary and secondary nucleation and growth", "[Crystallization],[PBM],[UnitOp],[Jacobian],[CI_cry11]")
 {
 	// read json model setup file
 	const std::string& modelFileRelPath = std::string("/data/model_cry_CSTR_PBM_primarySecondaryNucleationAndGrowth_benchmark1.json");
@@ -185,7 +185,7 @@ TEST_CASE("Crystallization Jacobian verification for a CSTR with primary and sec
 	cadet::test::column::testJacobianAD(pp_setup, std::numeric_limits<float>::epsilon() * 100.0);
 }
 
-TEST_CASE("Crystallization Jacobian verification for a DPFR/LRM with primary and secondary nucleation and growth", "[Crystallization1],[UnitOp],[Jacobian],[CI]")
+TEST_CASE("Crystallization Jacobian verification for a DPFR/LRM with primary and secondary nucleation and growth", "[Crystallization1],[UnitOp],[Jacobian],[CI_cry12]")
 {
 	// read json model setup file
 	const std::string& modelFileRelPath = std::string("/data/model_cry_DPFR_PBM_primarySecondaryNucleationGrowth_benchmark1.json");
@@ -205,7 +205,7 @@ TEST_CASE("Crystallization Jacobian verification for a DPFR/LRM with primary and
 /*
  * Pure aggregation tests
 */
-TEST_CASE("Crystallization Aggregation in a CSTR", "[Crystallization],[Aggregation],[Simulation],[Reference],[CI]")
+TEST_CASE("Crystallization Aggregation in a CSTR", "[Crystallization],[Aggregation],[Simulation],[Reference],[CI_cry13]")
 {
 	const std::string& modelFilePath = std::string("/data/model_cry_CSTR_aggregation_benchmark1.json");
 	const std::string& refFilePath = std::string("/data/ref_cry_CSTR_aggregation_benchmark1.h5");
@@ -216,7 +216,7 @@ TEST_CASE("Crystallization Aggregation in a CSTR", "[Crystallization],[Aggregati
 	cadet::test::column::testReferenceBenchmark(modelFilePath, refFilePath, "001", absTol, relTol, disc, false);
 }
 
-TEST_CASE("Crystallization Jacobian verification for Aggregation in a CSTR", "[Crystallization],[Aggregation],[UnitOp],[Jacobian],[CI]")
+TEST_CASE("Crystallization Jacobian verification for Aggregation in a CSTR", "[Crystallization],[Aggregation],[UnitOp],[Jacobian],[CI_cry14]")
 {
 	// read json model setup file
 	const std::string& modelFileRelPath = std::string("/data/model_cry_CSTR_aggregation_benchmark1.json");
@@ -235,7 +235,7 @@ TEST_CASE("Crystallization Jacobian verification for Aggregation in a CSTR", "[C
 /*
  * Pure fragmentation/breakage tests
 */
-TEST_CASE("Crystallization Fragmentation in a CSTR", "[Crystallization],[Fragmentation],[Simulation],[Reference],[CI]")
+TEST_CASE("Crystallization Fragmentation in a CSTR", "[Crystallization],[Fragmentation],[Simulation],[Reference],[CI_cry15]")
 {
 	const std::string& modelFilePath = std::string("/data/model_cry_CSTR_fragmentation_benchmark1.json");
 	const std::string& refFilePath = std::string("/data/ref_cry_CSTR_fragmentation_benchmark1.h5");
@@ -246,7 +246,7 @@ TEST_CASE("Crystallization Fragmentation in a CSTR", "[Crystallization],[Fragmen
 	cadet::test::column::testReferenceBenchmark(modelFilePath, refFilePath, "001", absTol, relTol, disc, false);
 }
 
-TEST_CASE("Crystallization Jacobian verification for Fragmentation in a CSTR", "[Crystallization],[Fragmentation],[UnitOp],[Jacobian],[CI]")
+TEST_CASE("Crystallization Jacobian verification for Fragmentation in a CSTR", "[Crystallization],[Fragmentation],[UnitOp],[Jacobian],[CI_cry16]")
 {
 	// read json model setup file
 	const std::string& modelFileRelPath = std::string("/data/model_cry_CSTR_fragmentation_benchmark1.json");
@@ -265,7 +265,7 @@ TEST_CASE("Crystallization Jacobian verification for Fragmentation in a CSTR", "
 /*
  * Combined fragmentation, breakage tests
 */
-TEST_CASE("Crystallization combined Aggregation and Fragmentation in a CSTR", "[Crystallization],[AggFrag],[Simulation],[Reference],[CI]")
+TEST_CASE("Crystallization combined Aggregation and Fragmentation in a CSTR", "[Crystallization],[AggFrag],[Simulation],[Reference],[CI_cry17]")
 {
 	const std::string& modelFilePath = std::string("/data/model_cry_CSTR_aggFrag_benchmark1.json");
 	const std::string& refFilePath = std::string("/data/ref_cry_CSTR_aggFrag_benchmark1.h5");
@@ -276,7 +276,7 @@ TEST_CASE("Crystallization combined Aggregation and Fragmentation in a CSTR", "[
 	cadet::test::column::testReferenceBenchmark(modelFilePath, refFilePath, "001", absTol, relTol, disc, false);
 }
 
-TEST_CASE("Crystallization Jacobian verification for combined Aggregation and Fragmentation in a CSTR", "[Crystallization],[AggFrag],[UnitOp],[Jacobian],[CI]")
+TEST_CASE("Crystallization Jacobian verification for combined Aggregation and Fragmentation in a CSTR", "[Crystallization],[AggFrag],[UnitOp],[Jacobian],[CI_cry18]")
 {
 	// read json model setup file
 	const std::string& modelFileRelPath = std::string("/data/model_cry_CSTR_aggFrag_benchmark1.json");
@@ -295,7 +295,7 @@ TEST_CASE("Crystallization Jacobian verification for combined Aggregation and Fr
 /*
  * Combined PBM, fragmentation, breakage tests
 */
-TEST_CASE("Crystallization combined PBM, Aggregation and Fragmentation in a CSTR", "[Crystallization],[PBMAggFrag],[Simulation],[Reference],[CI]")
+TEST_CASE("Crystallization combined PBM, Aggregation and Fragmentation in a CSTR", "[Crystallization],[PBMAggFrag],[Simulation],[Reference],[CI_cry19]")
 {
 	const std::string& modelFilePath = std::string("/data/model_cry_CSTR_PBM_Agg_Frag_benchmark1.json");
 	const std::string& refFilePath = std::string("/data/ref_cry_CSTR_PBM_Agg_Frag_benchmark1.h5");
@@ -306,7 +306,7 @@ TEST_CASE("Crystallization combined PBM, Aggregation and Fragmentation in a CSTR
 	cadet::test::column::testReferenceBenchmark(modelFilePath, refFilePath, "001", absTol, relTol, disc, false);
 }
 
-TEST_CASE("Crystallization Jacobian verification for combined PBM, Aggregation and Fragmentation in a CSTR", "[Crystallization],[PBMAggFrag],[UnitOp],[Jacobian],[CI]")
+TEST_CASE("Crystallization Jacobian verification for combined PBM, Aggregation and Fragmentation in a CSTR", "[Crystallization],[PBMAggFrag],[UnitOp],[Jacobian],[CI_cry20]")
 {
 	// read json model setup file
 	const std::string& modelFileRelPath = std::string("/data/model_cry_CSTR_PBM_Agg_Frag_benchmark1.json");
@@ -325,7 +325,7 @@ TEST_CASE("Crystallization Jacobian verification for combined PBM, Aggregation a
 /*
  * Combined PBM, aggregation test in a DPFR
 */
-TEST_CASE("Crystallization combined PBM and Aggregation in a DPFR", "[Crystallization],[DPFR_PBMAgg],[Simulation],[Reference],[CI]")
+TEST_CASE("Crystallization combined PBM and Aggregation in a DPFR", "[Crystallization],[DPFR_PBMAgg],[Simulation],[Reference],[CI_cry21]")
 {
 	const std::string& modelFilePath = std::string("/data/model_cry_DPFR_PBM_aggregation_benchmark1.json");
 	const std::string& refFilePath = std::string("/data/ref_cry_DPFR_PBM_aggregation_benchmark1.h5");
@@ -336,7 +336,7 @@ TEST_CASE("Crystallization combined PBM and Aggregation in a DPFR", "[Crystalliz
 	cadet::test::column::testReferenceBenchmark(modelFilePath, refFilePath, "001", absTol, relTol, disc, false);
 }
 
-TEST_CASE("Crystallization Jacobian verification for combined PBM and Aggregation in a DPFR", "[Crystallization],[DPFR_PBMAgg],[UnitOp],[Jacobian],[CI]")
+TEST_CASE("Crystallization Jacobian verification for combined PBM and Aggregation in a DPFR", "[Crystallization],[DPFR_PBMAgg],[UnitOp],[Jacobian],[CI_cry22]")
 {
 	// read json model setup file
 	const std::string& modelFileRelPath = std::string("/data/model_cry_DPFR_PBM_aggregation_benchmark1.json");

--- a/test/Crystallization.cpp
+++ b/test/Crystallization.cpp
@@ -195,6 +195,11 @@ TEST_CASE("Crystallization Jacobian verification for a DPFR/LRM with primary and
 	pp_setup.pushScope("model");
 	pp_setup.pushScope("unit_001");
 
+	// reduce axial discretization to stay within the allowed number of AD directions
+	pp_setup.pushScope("discretization");
+	pp_setup.set("NCOL", 3); // 3 * 52 < 157
+	pp_setup.popScope();
+
 	// for this specific test, we need to define a (high) tolerances as the values in this test are numerically very challenging (values of ca. 1E+24)
 	const double ADabsTol = 5e+8;
 	const double FDabsTol = 1e+10;

--- a/test/GeneralRateModel.cpp
+++ b/test/GeneralRateModel.cpp
@@ -59,7 +59,7 @@ TEST_CASE("GRM Jacobian forward vs backward flow", "[GRM],[FV],[UnitOp],[Residua
 	}
 }
 
-TEST_CASE("GRM numerical Benchmark with parameter sensitivities for linear case", "[GRM],[FV],[Simulation],[Reference],[Sensitivity],[CI_sensitivity1]")
+TEST_CASE("GRM numerical Benchmark with parameter sensitivities for linear case", "[GRM],[FV],[Simulation],[Reference],[Sensitivity],[CI_sens1]")
 {
 	std::string modelFilePath = std::string("/data/model_GRM_dynLin_1comp_benchmark1.json");
 	std::string refFilePath = std::string("/data/ref_GRM_dynLin_1comp_sensbenchmark1_FV_Z32parZ4.h5");
@@ -75,7 +75,7 @@ TEST_CASE("GRM numerical Benchmark with parameter sensitivities for linear case"
 	cadet::test::column::testReferenceBenchmark(modelFilePath, refFilePath, "001", absTol, relTol, disc, true);
 }
 
-TEST_CASE("GRM numerical Benchmark with parameter sensitivities for SMA LWE case", "[GRM],[FV],[Simulation],[Reference],[Sensitivity],[CI_sensitivity1]")
+TEST_CASE("GRM numerical Benchmark with parameter sensitivities for SMA LWE case", "[GRM],[FV],[Simulation],[Reference],[Sensitivity],[CI_sens2]")
 {
 	const std::string& modelFilePath = std::string("/data/model_GRM_reqSMA_4comp_benchmark1.json");
 	const std::string& refFilePath = std::string("/data/ref_GRM_reqSMA_4comp_sensbenchmark1_FV_Z16parZ2.h5");

--- a/test/GeneralRateModelDG.cpp
+++ b/test/GeneralRateModelDG.cpp
@@ -64,7 +64,7 @@ TEST_CASE("GRM_DG non-binding linear pulse vs analytic solution", "[GRM],[DG],[D
 //	}
 //}
 
-TEST_CASE("GRM_DG numerical Benchmark with parameter sensitivities for linear case", "[GRM],[DG],[DG1D],[Simulation],[Reference],[Sensitivity],[CI_sensitivity1]")
+TEST_CASE("GRM_DG numerical Benchmark with parameter sensitivities for linear case", "[GRM],[DG],[DG1D],[Simulation],[Reference],[Sensitivity],[CI_sens3]")
 {
 	std::string modelFilePath = std::string("/data/model_GRM_dynLin_1comp_benchmark1.json");
 	std::string refFilePath = std::string("/data/ref_GRM_dynLin_1comp_sensbenchmark1_cDG_P3Z8_GSM_parP3parZ1.h5");
@@ -80,7 +80,7 @@ TEST_CASE("GRM_DG numerical Benchmark with parameter sensitivities for linear ca
 	cadet::test::column::testReferenceBenchmark(modelFilePath, refFilePath, "001", absTol, relTol, disc, true);
 }
 
-TEST_CASE("GRM_DG numerical Benchmark with parameter sensitivities for SMA LWE case", "[GRM],[DG],[DG1D],[Simulation],[Reference],[Sensitivity],[CI_sensitivity2]")
+TEST_CASE("GRM_DG numerical Benchmark with parameter sensitivities for SMA LWE case", "[GRM],[DG],[DG1D],[Simulation],[Reference],[Sensitivity],[CI_sens4]")
 {
 	const std::string modelFilePath = std::string("/data/model_GRM_reqSMA_4comp_benchmark1.json");
 	const std::string refFilePath = std::string("/data/ref_GRM_reqSMA_4comp_sensbenchmark1_cDG_P3Z8_GSM_parP3parZ1.h5");

--- a/test/LumpedRateModelWithPores.cpp
+++ b/test/LumpedRateModelWithPores.cpp
@@ -59,7 +59,7 @@ TEST_CASE("LRMP Jacobian forward vs backward flow", "[LRMP],[FV],[UnitOp],[Resid
 	}
 }
 
-TEST_CASE("LRMP numerical Benchmark with parameter sensitivities for linear case", "[LRMP],[FV],[Simulation],[Reference],[Sensitivity],[CI_sensitivity1]")
+TEST_CASE("LRMP numerical Benchmark with parameter sensitivities for linear case", "[LRMP],[FV],[Simulation],[Reference],[Sensitivity],[CI_sens9]")
 {
 	const std::string& modelFilePath = std::string("/data/model_LRMP_dynLin_1comp_benchmark1.json");
 	const std::string& refFilePath = std::string("/data/ref_LRMP_dynLin_1comp_sensbenchmark1_FV_Z32.h5");
@@ -70,7 +70,7 @@ TEST_CASE("LRMP numerical Benchmark with parameter sensitivities for linear case
 	cadet::test::column::testReferenceBenchmark(modelFilePath, refFilePath, "001", absTol, relTol, disc, true);
 }
 
-TEST_CASE("LRMP numerical Benchmark with parameter sensitivities for SMA LWE case", "[LRMP],[FV],[Simulation],[Reference],[Sensitivity],[CI_sensitivity1]")
+TEST_CASE("LRMP numerical Benchmark with parameter sensitivities for SMA LWE case", "[LRMP],[FV],[Simulation],[Reference],[Sensitivity],[CI_sens10]")
 {
 	const std::string& modelFilePath = std::string("/data/model_LRMP_reqSMA_4comp_benchmark1.json");
 	const std::string& refFilePath = std::string("/data/ref_LRMP_reqSMA_4comp_sensbenchmark1_FV_Z32.h5");

--- a/test/LumpedRateModelWithPoresDG.cpp
+++ b/test/LumpedRateModelWithPoresDG.cpp
@@ -58,7 +58,7 @@ TEST_CASE("LRMP_DG non-binding linear pulse vs analytic solution", "[LRMP],[DG],
 //	}
 //}
 
-TEST_CASE("LRMP_DG numerical Benchmark with parameter sensitivities for linear case", "[LRMP],[DG],[DG1D],[Simulation],[Reference],[Sensitivity],[CI]")
+TEST_CASE("LRMP_DG numerical Benchmark with parameter sensitivities for linear case", "[LRMP],[DG],[DG1D],[Simulation],[Reference],[Sensitivity],[CI_sens14]")
 {
 	const std::string& modelFilePath = std::string("/data/model_LRMP_dynLin_1comp_benchmark1.json");
 	const std::string& refFilePath = std::string("/data/ref_LRMP_dynLin_1comp_sensbenchmark1_DG_P3Z8.h5");
@@ -69,7 +69,7 @@ TEST_CASE("LRMP_DG numerical Benchmark with parameter sensitivities for linear c
 	cadet::test::column::testReferenceBenchmark(modelFilePath, refFilePath, "001", absTol, relTol, disc, true);
 }
 
-TEST_CASE("LRMP_DG numerical Benchmark with parameter sensitivities for SMA LWE case", "[LRMP],[DG],[DG1D],[Simulation],[Reference],[Sensitivity],[CI]")
+TEST_CASE("LRMP_DG numerical Benchmark with parameter sensitivities for SMA LWE case", "[LRMP],[DG],[DG1D],[Simulation],[Reference],[Sensitivity],[CI_sens15]")
 {
 	const std::string& modelFilePath = std::string("/data/model_LRMP_reqSMA_4comp_benchmark1.json");
 	const std::string& refFilePath = std::string("/data/ref_LRMP_reqSMA_4comp_sensbenchmark1_DG_P3Z8.h5");

--- a/test/LumpedRateModelWithoutPores.cpp
+++ b/test/LumpedRateModelWithoutPores.cpp
@@ -58,7 +58,7 @@ TEST_CASE("LRM Jacobian forward vs backward flow", "[LRM],[FV],[UnitOp],[Residua
 	}
 }
 
-TEST_CASE("LRM numerical Benchmark with parameter sensitivities for linear case", "[LRM],[FV],[Simulation],[Reference],[Sensitivity],[CI_sensitivity1]")
+TEST_CASE("LRM numerical Benchmark with parameter sensitivities for linear case", "[LRM],[FV],[Simulation],[Reference],[Sensitivity],[CI_sens5]")
 {
 	const std::string& modelFilePath = std::string("/data/model_LRM_dynLin_1comp_benchmark1.json");
 	const std::string& refFilePath = std::string("/data/ref_LRM_dynLin_1comp_sensbenchmark1_FV_Z32.h5");
@@ -69,7 +69,7 @@ TEST_CASE("LRM numerical Benchmark with parameter sensitivities for linear case"
 	cadet::test::column::testReferenceBenchmark(modelFilePath, refFilePath, "001", absTol, relTol, disc, true);
 }
 
-TEST_CASE("LRM numerical Benchmark with parameter sensitivities for SMA LWE case", "[LRM],[FV],[Simulation],[Reference],[Sensitivity],[CI_sensitivity2]")
+TEST_CASE("LRM numerical Benchmark with parameter sensitivities for SMA LWE case", "[LRM],[FV],[Simulation],[Reference],[Sensitivity],[CI_sens6]")
 {
 	const std::string& modelFilePath = std::string("/data/model_LRM_reqSMA_4comp_benchmark1.json");
 	const std::string& refFilePath = std::string("/data/ref_LRM_reqSMA_4comp_sensbenchmark1_FV_Z32.h5");

--- a/test/LumpedRateModelWithoutPoresDG.cpp
+++ b/test/LumpedRateModelWithoutPoresDG.cpp
@@ -57,7 +57,7 @@ TEST_CASE("LRM_DG non-binding linear pulse vs analytic solution", "[LRM],[DG],[D
 //	}
 //}
 
-TEST_CASE("LRM_DG numerical Benchmark with parameter sensitivities for linear case", "[LRM],[DG],[DG1D],[Simulation],[Reference],[Sensitivity],[CI_sensitivity1]")
+TEST_CASE("LRM_DG numerical Benchmark with parameter sensitivities for linear case", "[LRM],[DG],[DG1D],[Simulation],[Reference],[Sensitivity],[CI_sens7]")
 {
 	const std::string& modelFilePath = std::string("/data/model_LRM_dynLin_1comp_benchmark1.json");
 	const std::string& refFilePath = std::string("/data/ref_LRM_dynLin_1comp_sensbenchmark1_DG_P3Z8.h5");
@@ -68,7 +68,7 @@ TEST_CASE("LRM_DG numerical Benchmark with parameter sensitivities for linear ca
 	cadet::test::column::testReferenceBenchmark(modelFilePath, refFilePath, "001", absTol, relTol, disc, true);
 }
 
-TEST_CASE("LRM_DG numerical Benchmark with parameter sensitivities for SMA LWE case", "[LRM],[DG],[DG1D],[Simulation],[Reference],[Sensitivity],[CI_sensitivity1]")
+TEST_CASE("LRM_DG numerical Benchmark with parameter sensitivities for SMA LWE case", "[LRM],[DG],[DG1D],[Simulation],[Reference],[Sensitivity],[CI_sens8]")
 {
 	const std::string& modelFilePath = std::string("/data/model_LRM_reqSMA_4comp_benchmark1.json");
 	const std::string& refFilePath = std::string("/data/ref_LRM_reqSMA_4comp_sensbenchmark1_DG_P3Z8.h5");

--- a/test/RadialGeneralRateModel.cpp
+++ b/test/RadialGeneralRateModel.cpp
@@ -19,7 +19,7 @@
 #include "Utils.hpp"
 
 
-TEST_CASE("Radial GRM numerical Benchmark with parameter sensitivities for linear case", "[RadGRM],[Simulation],[Reference],[Sensitivity],[CI_sensitivity2]")
+TEST_CASE("Radial GRM numerical Benchmark with parameter sensitivities for linear case", "[RadGRM],[Simulation],[Reference],[Sensitivity],[CI_sens11]")
 {
 	const std::string& modelFilePath = std::string("/data/model_radGRM_dynLin_1comp_sensbenchmark1.json");
 	const std::string& refFilePath = std::string("/data/ref_radGRM_dynLin_1comp_sensbenchmark1_FV_Z32parZ4.h5");

--- a/test/RadialLumpedRateModelWithPores.cpp
+++ b/test/RadialLumpedRateModelWithPores.cpp
@@ -26,7 +26,7 @@
 
 // todo add (more) numerical reference (and EOC) tests
  
-TEST_CASE("Radial LRMP numerical Benchmark with parameter sensitivities for linear case", "[RadLRMP],[Simulation],[Reference],[Sensitivity],[CI_sensitivity1]")
+TEST_CASE("Radial LRMP numerical Benchmark with parameter sensitivities for linear case", "[RadLRMP],[Simulation],[Reference],[Sensitivity],[CI_sens13]")
 {
 	const std::string& modelFilePath = std::string("/data/model_radLRMP_dynLin_1comp_sensbenchmark1.json");
 	const std::string& refFilePath = std::string("/data/ref_radLRMP_dynLin_1comp_sensbenchmark1_FV_Z32.h5");

--- a/test/RadialLumpedRateModelWithoutPores.cpp
+++ b/test/RadialLumpedRateModelWithoutPores.cpp
@@ -25,7 +25,7 @@
 
 // todo add (more) numerical reference (and EOC) tests
 
-TEST_CASE("Radial LRM numerical Benchmark with parameter sensitivities for linear case", "[RadLRM],[Simulation],[Reference],[Sensitivity],[CI_sensitivity1]")
+TEST_CASE("Radial LRM numerical Benchmark with parameter sensitivities for linear case", "[RadLRM],[Simulation],[Reference],[Sensitivity],[CI_sens12]")
 {
 	const std::string& modelFilePath = std::string("/data/model_radLRM_dynLin_1comp_sensbenchmark1.json");
 	const std::string& refFilePath = std::string("/data/ref_radLRM_dynLin_1comp_sensbenchmark1_FV_Z32.h5");


### PR DESCRIPTION
This PR fixes some issues with out testing:
One issue with our CI/tests was that in the Jacobian tests, we checked if the number of required AD directions is below the max allowed number (which is a cmake compile option)  But that check happened after enabling AD for that unit so the numDirs was Zero. Further, one of the crystallization tests required way too many AD directions.
Further, there seem to be some additional  “safety“ zeroes on Windows which is why the test didnt break. Additionally, the absolute tolerance was set VERY high since for that crystallization test we get values of more than 1E+24, which is why some Jacobian deviations went undetected.
Further, Ive decided to separately call the testrunner in the CI for the crystallization and sensitiviy tests since theres still something weird going on with tests influencing each other; which I hope to resolve another time.

