### PR TITLE
Coverage workflow: exclude thirdparty libraries

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -1,0 +1,9 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 55%
+
+  ignore:
+    - ".*ThirdParty.*"
+    - ".*/test/.*"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -106,8 +106,15 @@ jobs:
 
       - name: Generate Coverage Report
         run: |
-            gcovr --root "${SRC_DIR}" --filter "${SRC_DIR}" --exclude "ThirdParty" --xml -o coverage.xml
-            gcovr --root "${SRC_DIR}" --filter "${SRC_DIR}" --exclude "ThirdParty" --html --html-details -o coverage.html
+          gcovr \
+            --root "${{ github.workspace }}" \
+            --filter "$SRC_DIR/src" \
+            --filter "$SRC_DIR/include" \
+            --filter "$BUILD_DIR/src" \
+            --exclude '.*ThirdParty.*' \
+            --html --html-details -o coverage.html \
+            --xml -o coverage.xml \
+            --print-summary
       
       - name: Upload Coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/doc/developer_guide/testing.rst
+++ b/doc/developer_guide/testing.rst
@@ -118,3 +118,14 @@ Maintenance of the tests
 
 Some changes will break the tests without them being necessarily wrong. A change in the numerics for instance, will most likely break some tests.
 This can be fixed by carefully adapting the absolute and relative tolerances for the broken tests. These changes should not change the magnitude of the tolerances, except if this is within an acceptable and expected new tolerance).
+
+Test coverage
+-------------
+
+``Codecov`` is used to analyze test coverage through an automated workflow (see ``coverage.yml``), which runs on changes to the ``test/coverage`` branch and can also be triggered manually (workflow dispatch).
+Coverage reports are automatically uploaded to ``Codecov``, providing detailed insights into tested code areas, uncovered lines, and coverage trends over time.
+Tests marked with the ``[CI]`` flag are automatically included in the coverage analysis; otherwise, they can be added manually in the workflow file.
+The goal is to maintain complete test coverage by ensuring every new functionality or code change includes corresponding tests executed with Codecov.
+The file ``.codecov.yml`` defines a target coverage percentage. If the coverage falls below that, the workflow fails.
+This percentage should be updated as we continuously expand our test coverage.
+Further, the file defines ignored paths, such as the `ThirdParty` directory as we dont consider test coverage of third party software.

--- a/test/GeneralRateModel2D.cpp
+++ b/test/GeneralRateModel2D.cpp
@@ -10,11 +10,6 @@
 //  is available at http://www.gnu.org/licenses/gpl.html
 // =============================================================================
 
-// we have the following tests:
-// fixGRM2D: test that does not work and is not based on FD
-// CIgrm2d: test that works and is not based on FD
-// FDtestGRM2D: Test based on FD that works on my machine
-// failedFDtestGRM2D: Test based on FD that does not work on my machine
 
 #include <catch.hpp>
 
@@ -65,7 +60,7 @@ TEST_CASE("GRM2D dynamic binding flux Jacobian vs FD", "[GRM2D],[UnitOp],[Residu
 	cadet::test::column::testArrowHeadJacobianFD("GENERAL_RATE_MODEL_2D", true, 1e-6, 2e-9);
 }
 
-TEST_CASE("GRM2D sensitivity Jacobians", "[GRM2D],[UnitOp],[Sensitivity],[CIgrm2d]")
+TEST_CASE("GRM2D sensitivity Jacobians", "[GRM2D],[UnitOp],[Sensitivity],[CI]")
 {
 	cadet::JsonParameterProvider jpp = createColumnWithTwoCompLinearBinding("GENERAL_RATE_MODEL_2D", "FV");
 
@@ -92,7 +87,7 @@ TEST_CASE("GRM2D forward sensitivity forward vs backward flow", "[GRM2D],[Sensit
 	cadet::test::column::testFwdSensSolutionForwardBackward("GENERAL_RATE_MODEL_2D", "FV", absTols, relTols, passRatio);
 }
 
-TEST_CASE("GRM2D consistent initialization with linear binding", "[GRM2D],[ConsistentInit],[CIgrm2d]")
+TEST_CASE("GRM2D consistent initialization with linear binding", "[GRM2D],[ConsistentInit],[CI]")
 {
 	cadet::test::column::testConsistentInitializationLinearBinding("GENERAL_RATE_MODEL_2D", "FV", 1e-12, 1e-12);
 }
@@ -112,7 +107,7 @@ TEST_CASE("GRM2D consistent initialization with SMA binding", "[GRM2D],[Consiste
 	cadet::test::column::testConsistentInitializationSMABinding("GENERAL_RATE_MODEL_2D", "FV", y.data(), 1e-14, 1e-5);
 }
 
-TEST_CASE("GRM2D consistent sensitivity initialization with linear binding", "[GRM2D],[ConsistentInit],[Sensitivity],[CIgrm2d]")
+TEST_CASE("GRM2D consistent sensitivity initialization with linear binding", "[GRM2D],[ConsistentInit],[Sensitivity],[CI]")
 {
 	// Fill state vector with given initial values
 	const unsigned int numDofs = 2 * 3 + 2 * 8 * 3 + 8 * 3 * 3 * (2 + 2) + 2 * 8 * 3;
@@ -124,7 +119,7 @@ TEST_CASE("GRM2D consistent sensitivity initialization with linear binding", "[G
 	cadet::test::column::testConsistentInitializationSensitivity("GENERAL_RATE_MODEL_2D", "FV", y.data(), yDot.data(), true, 1e-14);
 }
 
-TEST_CASE("GRM2D consistent sensitivity initialization with SMA binding", "[GRM2D],[ConsistentInit],[Sensitivity],[CIgrm2d]")
+TEST_CASE("GRM2D consistent sensitivity initialization with SMA binding", "[GRM2D],[ConsistentInit],[Sensitivity],[CI]")
 {
 	// Fill state vector with given initial values
 	const unsigned int numDofs = 4 * 3 + 4 * 8 * 3 + 8 * 3 * 3 * (4 + 4) + 4 * 8 * 3;
@@ -141,22 +136,22 @@ TEST_CASE("GRM2D consistent sensitivity initialization with SMA binding", "[GRM2
 	cadet::test::column::testConsistentInitializationSensitivity("GENERAL_RATE_MODEL_2D", "FV", y.data(), yDot.data(), false, 1e-9);
 }
 
-TEST_CASE("GRM2D inlet DOF Jacobian", "[GRM2D],[UnitOp],[Jacobian],[Inlet],[CIgrm2d]")
+TEST_CASE("GRM2D inlet DOF Jacobian", "[GRM2D],[UnitOp],[Jacobian],[Inlet],[CI]")
 {
 	cadet::test::column::testInletDofJacobian("GENERAL_RATE_MODEL_2D", "FV");
 }
 
-TEST_CASE("GRM2D LWE one vs two identical particle types match", "[GRM2D],[Simulation],[ParticleType],[CIgrm2d]")
+TEST_CASE("GRM2D LWE one vs two identical particle types match", "[GRM2D],[Simulation],[ParticleType],[CI]")
 {
 	cadet::test::particle::testOneVsTwoIdenticalParticleTypes("GENERAL_RATE_MODEL_2D", "FV", 1e-7, 5e-5);
 }
 
-TEST_CASE("GRM2D LWE separate identical particle types match", "[GRM2D],[Simulation],[ParticleType],[CIgrm2d]")
+TEST_CASE("GRM2D LWE separate identical particle types match", "[GRM2D],[Simulation],[ParticleType],[CI]")
 {
 	cadet::test::particle::testSeparateIdenticalParticleTypes("GENERAL_RATE_MODEL_2D", "FV", 1e-15, 1e-15);
 }
 
-TEST_CASE("GRM2D linear binding single particle matches particle distribution", "[GRM2D],[Simulation],[ParticleType],[CIgrm2d]")
+TEST_CASE("GRM2D linear binding single particle matches particle distribution", "[GRM2D],[Simulation],[ParticleType],[CI]")
 {
 	cadet::test::particle::testLinearMixedParticleTypes("GENERAL_RATE_MODEL_2D", "FV", 5e-8, 5e-5);
 }
@@ -171,7 +166,7 @@ TEST_CASE("GRM2D multiple particle types time derivative Jacobian vs FD", "[GRM2
 	cadet::test::particle::testTimeDerivativeJacobianMixedParticleTypesFD("GENERAL_RATE_MODEL_2D", "FV", 1e-6, 0.0, 5e-3);
 }
 
-TEST_CASE("GRM2D linear binding single particle matches spatially dependent particle distribution", "[GRM2D],[Simulation],[ParticleType],[CIgrm2d]")
+TEST_CASE("GRM2D linear binding single particle matches spatially dependent particle distribution", "[GRM2D],[Simulation],[ParticleType],[CI]")
 {
 	cadet::test::particle::testLinearSpatiallyMixedParticleTypes("GENERAL_RATE_MODEL_2D", "FV", 5e-8, 5e-5);
 }
@@ -247,7 +242,7 @@ TEST_CASE("GRM2D multi particle types dynamic reactions time derivative Jacobian
 	cadet::test::reaction::testTimeDerivativeJacobianDynamicReactionsFD(jpp, true, true, true, 1e-6, 1e-14, 8e-4);
 }
 
-TEST_CASE("GRM2D with 1 radial zone matches GRM", "[GRM],[GRM2D],[UnitOp],[Jacobian],[CIgrm2d]")
+TEST_CASE("GRM2D with 1 radial zone matches GRM", "[GRM],[GRM2D],[UnitOp],[Jacobian],[CI]")
 {
 	cadet::IModelBuilder* const mb = cadet::createModelBuilder();
 	REQUIRE(nullptr != mb);


### PR DESCRIPTION
This PR excludes third party libraries and the tests themselves from the test coverage analysis.

Further, a coverage goal is defined in a codecov.yml file so that the workflow fails when our coverage decreases below that.
Also, Ive seen in the report that we had not added the 2DGRM tests to the CI yet, they are added in this PR.

To compare the influence of code optimizations to the coverage report, Ive compared the coverage for Debug and RelWithDebugInfo builds. Since the tests take way too long in Debug mode, i made the comparison for the binding model tests + three GRM test cases. Turns out theres only a slight difference with the Debug coverage being slightly worse (around 2%).