### PR TITLE
CI fix: fail and exit on first testRunner error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,6 +200,7 @@ jobs:
           ${BUILD_DIR}/test/testRunner [CI_binding]
       - name: Run CI test set II - sensitivities
         run: |
+          set -e
           ${BUILD_DIR}/test/testRunner [CI_sens1]
           ${BUILD_DIR}/test/testRunner [CI_sens2]
           ${BUILD_DIR}/test/testRunner [CI_sens3]
@@ -217,6 +218,7 @@ jobs:
           ${BUILD_DIR}/test/testRunner [CI_sens16]
       - name: Run CI test set III - crystallization
         run: |
+          set -e
           ${BUILD_DIR}/test/testRunner [CI_cry1]
           ${BUILD_DIR}/test/testRunner [CI_cry2]
           ${BUILD_DIR}/test/testRunner [CI_cry3]


### PR DESCRIPTION
We have CI steps with multiple testrunner calls. Apparently only the result of the last call dictates whther or not the CI fails and stops. This PR adds a command telling the shell to immediately exit if any command returns a non-zero exit status