### PR TITLE
Modularize particle model

### DIFF
--- a/src/libcadet/model/GeneralRateModelDG-InitialConditions.cpp
+++ b/src/libcadet/model/GeneralRateModelDG-InitialConditions.cpp
@@ -797,13 +797,10 @@ void GeneralRateModelDG::consistentInitialTimeDerivative(const SimulationTime& s
  */
 void GeneralRateModelDG::leanConsistentInitialState(const SimulationTime& simTime, double* const vecStateY, const AdJacobianParams& adJac, double errorTol, util::ThreadLocalStorage& threadLocalMem)
 {
-	for (int parType = 0; parType < _disc.nParType; parType++)
-	{
-		if (isSectionDependent(_particle[parType].parDiffMode()) || isSectionDependent(_particle[parType].parSurfDiffMode()))
-			LOG(Warning) << "Lean consistent initialization is not appropriate for section-dependent pore and surface diffusion";
+	BENCH_SCOPE(_timerConsistentInit);
 
-		BENCH_SCOPE(_timerConsistentInit);
-	}
+	for (int parType = 0; parType < _disc.nParType; parType++)
+		_particle[parType].leanConsistentInitialStateValidity();
 
 	Indexer idxr(_disc);
 
@@ -888,15 +885,10 @@ void GeneralRateModelDG::leanConsistentInitialState(const SimulationTime& simTim
  */
 void GeneralRateModelDG::leanConsistentInitialTimeDerivative(double t, double const* const vecStateY, double* const vecStateYdot, double* const res, util::ThreadLocalStorage& threadLocalMem)
 {
-	for (int parType = 0; parType < _disc.nParType; parType++)
-	{
-		if (isSectionDependent(_particle[parType].parDiffMode()) || isSectionDependent(_particle[parType].parSurfDiffMode()))
-			LOG(Warning) << "Lean consistent initialization is not appropriate for section-dependent pore and surface diffusion";
-
-		BENCH_SCOPE(_timerConsistentInit);
-	}
-
 	BENCH_SCOPE(_timerConsistentInit);
+
+	for (int parType = 0; parType < _disc.nParType; parType++)
+		_particle[parType].leanConsistentInitialTimeDerivativeValidity();
 
 	Indexer idxr(_disc);
 
@@ -1276,15 +1268,10 @@ void GeneralRateModelDG::solveBulkTimeDerivativeSystem(const SimulationTime& sim
 void GeneralRateModelDG::leanConsistentInitialSensitivity(const SimulationTime& simTime, const ConstSimulationState& simState,
 	std::vector<double*>& vecSensY, std::vector<double*>& vecSensYdot, active const* const adRes, util::ThreadLocalStorage& threadLocalMem)
 {
-	for (int parType = 0; parType < _disc.nParType; parType++)
-	{
-		if (isSectionDependent(_particle[parType].parDiffMode()) || isSectionDependent(_particle[parType].parSurfDiffMode()))
-			LOG(Warning) << "Lean consistent initialization is not appropriate for section-dependent pore and surface diffusion";
-
-		BENCH_SCOPE(_timerConsistentInit);
-	}
-
 	BENCH_SCOPE(_timerConsistentInit);
+
+	for (int parType = 0; parType < _disc.nParType; parType++)
+		_particle[parType].leanConsistentInitialStateValidity();
 
 	Indexer idxr(_disc);
 

--- a/src/libcadet/model/GeneralRateModelDG.cpp
+++ b/src/libcadet/model/GeneralRateModelDG.cpp
@@ -888,7 +888,7 @@ int GeneralRateModelDG::residualImpl(double t, unsigned int secIdx, StateType co
 		linalg::BandedEigenSparseRowIterator jacIt(_globalJac, idxr.offsetCp(ParticleTypeIndex{ parType }, ParticleIndex{ colNode }));
 		ColumnPosition colPos{ _convDispOp.relativeCoordinate(colNode), 0.0, 0.0 }; // Relative position of current node - needed in externally dependent adsorption kinetic
 
-		_particle[parType].residual<wantJac, wantRes>(t, secIdx,
+		_particle[parType].residual(t, secIdx,
 			y + idxr.offsetCp(ParticleTypeIndex{ parType }, ParticleIndex{ colNode }),
 			y + idxr.offsetC() + colNode * idxr.strideColNode(),
 			yDot ? yDot + idxr.offsetCp(ParticleTypeIndex{ parType }, ParticleIndex{ colNode }) : nullptr,
@@ -987,7 +987,7 @@ int GeneralRateModelDG::residualFlux(double t, unsigned int secIdx, StateType co
 		// sec1type0comp0, sec1type0comp1, sec1type0comp2, sec1type1comp0, sec1type1comp1, sec1type1comp2, ...
 		active const* const filmDiff = getSectionDependentSlice(_filmDiffusion, _disc.nComp * _disc.nParType, secIdx) + type * _disc.nComp;
 
-		const ParamType surfaceToVolumeRatio = _particle[type].surfaceToVolumeRatio<ParamType>();
+		const ParamType surfaceToVolumeRatio = static_cast<ParamType>(_particle[type].surfaceToVolumeRatio());
 
 		const ParamType jacCF_val = invBetaC * surfaceToVolumeRatio;
 		const ParamType jacPF_val = -1.0 / epsP;

--- a/src/libcadet/model/GeneralRateModelDG.hpp
+++ b/src/libcadet/model/GeneralRateModelDG.hpp
@@ -488,12 +488,10 @@ protected:
 		for (int type = 0; type < _disc.nParType; type++) {
 			isothermNNZ = (idxr.strideParNode(type)) * _disc.nParPoints[type] * _disc.strideBound[type]; // every bound satte might depend on every bound and liquid state
 			addTimeDer = _disc.nParPoints[type] * _disc.strideBound[type];
-			particleEntries += _particle[type].calcParDiffNNZ() + addTimeDer + isothermNNZ;
+			particleEntries += _disc.nPoints * _particle[type].jacobianNNZperParticle() + addTimeDer + isothermNNZ;
 		}
 
-		int fluxEntries = 4 * _disc.nParType * _disc.nPoints * _disc.nComp;
-
-		tripletList.reserve(fluxEntries + bulkEntries + particleEntries);
+		tripletList.reserve(bulkEntries + particleEntries);
 
 		// NOTE: inlet and jacF flux jacobian are set in calc jacobian function (identity matrices)
 		// Note: flux jacobian (identity matrix) is handled in calc jacobian function

--- a/src/libcadet/model/particle/GeneralRateParticle.cpp
+++ b/src/libcadet/model/particle/GeneralRateParticle.cpp
@@ -387,6 +387,29 @@ namespace model
 		return _parDiffOp->setSensitiveParameter(sensParams, pId, adDirection, adValue);
 	}
 
+	std::unordered_map<ParameterId, double> GeneralRateParticle::getAllParameterValues(std::unordered_map<ParameterId, double>& data) const
+	{
+		model::getAllParameterValues(data, std::vector<IParameterStateDependence*>{getParDepSurfDiffusion()}, singleParDepSurfDiffusion());
+
+		return data;
+	}
+
+	double GeneralRateParticle::getParameterDouble(const ParameterId& pId) const
+	{
+		double val = 0.0;
+
+		if (model::getParameterDouble(pId, std::vector<IParameterStateDependence*>{getParDepSurfDiffusion()}, singleParDepSurfDiffusion(), val))
+			return val;
+		else
+			return static_cast<double>(false);
+	}
+
+	bool GeneralRateParticle::hasParameter(const ParameterId& pId) const
+	{
+		if (model::hasParameter(pId, std::vector<IParameterStateDependence*>{getParDepSurfDiffusion()}, singleParDepSurfDiffusion()))
+			return true;
+	}
+
 }  // namespace model
 
 }  // namespace cadet

--- a/src/libcadet/model/particle/GeneralRateParticle.hpp
+++ b/src/libcadet/model/particle/GeneralRateParticle.hpp
@@ -138,8 +138,6 @@ namespace parts
 
 		inline const active& getPorosity() const CADET_NOEXCEPT { return _parDiffOp->getPorosity(); }
 		inline const active* getPoreAccessfactor() const CADET_NOEXCEPT { return _parDiffOp->getPoreAccessfactor(); }
-		inline IParameterStateDependence* getParDepSurfDiffusion() const CADET_NOEXCEPT { return _parDiffOp->getParDepSurfDiffusion(); }
-		inline bool singleParDepSurfDiffusion() const CADET_NOEXCEPT { return _parDiffOp->singleParDepSurfDiffusion(); }
 		inline MultiplexMode parDiffMode() const CADET_NOEXCEPT { return _parDiffOp->parDiffMode(); }
 		inline MultiplexMode parSurfDiffMode() const CADET_NOEXCEPT { return _parDiffOp->parSurfDiffMode(); }
 
@@ -194,7 +192,14 @@ namespace parts
 		bool setSensitiveParameter(std::unordered_set<active*>& sensParams, const ParameterId& pId, unsigned int adDirection, double adValue);
 		bool setSensitiveParameterValue(const std::unordered_set<active*>& sensParams, const ParameterId& pId, double value);
 
+		bool hasParameter(const ParameterId& pId) const;
+		double getParameterDouble(const ParameterId& pId) const;
+		std::unordered_map<ParameterId, double> getAllParameterValues(std::unordered_map<ParameterId, double>& data) const;
+
 	protected:
+
+		inline IParameterStateDependence* getParDepSurfDiffusion() const CADET_NOEXCEPT { return _parDiffOp->getParDepSurfDiffusion(); }
+		inline bool singleParDepSurfDiffusion() const CADET_NOEXCEPT { return _parDiffOp->singleParDepSurfDiffusion(); }
 
 		template <typename StateType, typename ResidualType, typename ParamType, bool wantJac, bool wantRes>
 		int residualImpl(double t, unsigned int secIdx, StateType const* yPar, StateType const* yBulk, double const* yDotPar, ResidualType* resPar, ColumnPosition colPos, linalg::BandedEigenSparseRowIterator& jacIt, LinearBufferAllocator tlmAlloc);

--- a/src/libcadet/model/particle/ParticleModel.hpp
+++ b/src/libcadet/model/particle/ParticleModel.hpp
@@ -1,0 +1,178 @@
+// =============================================================================
+//  CADET
+//  
+//  Copyright © 2008-present: The CADET-Core Authors
+//            Please see the AUTHORS.md file.
+//  
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the GNU Public License v3.0 (or, at
+//  your option, any later version) which accompanies this distribution, and
+//  is available at http://www.gnu.org/licenses/gpl.html
+// =============================================================================
+
+/**
+ * @file
+ * Defines the particle model interface
+ */
+
+#ifndef LIBCADET_IPARTICLEMODEL_HPP_
+#define LIBCADET_IPARTICLEMODEL_HPP_
+
+#include "model/BindingModel.hpp"
+#include "cadet/StrongTypes.hpp"
+#include "ParamIdUtil.hpp"
+#include "AutoDiff.hpp"
+#include "Memory.hpp"
+#include "model/ModelUtils.hpp"
+#include "SimulationTypes.hpp"
+#include "ParamReaderHelper.hpp"
+#include "linalg/BandedEigenSparseRowIterator.hpp"
+#include "model/ParameterMultiplexing.hpp"
+
+#include "LoggingUtils.hpp"
+#include "Logging.hpp"
+
+#include <unordered_map>
+#include <unordered_set>
+#include <Eigen/Sparse>
+#include <array>
+#include <vector>
+
+using namespace Eigen;
+
+namespace cadet
+{
+
+	class IConfigHelper;
+
+	namespace model
+	{
+
+		class IDynamicReactionModel;
+		class IParameterStateDependence;
+
+		namespace parts
+		{
+			namespace cell
+			{
+				struct CellParameters;
+			}
+		}
+		/**
+		 * @brief Implements the particle model interface
+		 */
+		class IParticleModel
+		{
+		public:
+
+			IParticleModel() : _binding(nullptr), _dynReaction(nullptr)
+			{
+			}
+			virtual ~IParticleModel() CADET_NOEXCEPT
+			{
+				delete _binding;
+				delete _dynReaction;
+			}
+
+			virtual bool configureModelDiscretization(IParameterProvider& paramProvider, const IConfigHelper& helper, const int nComp, const int parTypeIdx, const int nParType, const int strideBulkComp) = 0;
+			virtual bool configure(UnitOpIdx unitOpIdx, IParameterProvider& paramProvider, std::unordered_map<ParameterId, active*>& parameters, const int nParType, const unsigned int* nBoundBeforeType, const int nTotalBound) = 0;
+
+			virtual void updateRadialDisc() = 0;
+
+			virtual parts::cell::CellParameters makeCellResidualParams(int const* qsReaction, unsigned int const* nBound) const = 0;
+			/**
+			 * @brief Notifies the operator that a discontinuous section transition is in progress
+			 * @param [in] t Current time point
+			 * @param [in] secIdx Index of the new section that is about to be integrated
+			 * @return @c true if flow direction has changed, otherwise @c false
+			 */
+			virtual bool notifyDiscontinuousSectionTransition(double t, unsigned int secIdx, active const* const filmDiff, active const* const poreAccessFactor) = 0;
+
+			/**
+			 * @brief Computes the residual of the particle equations
+			 * @param [in] model Model that owns the operator
+			 * @param [in] t Current time point
+			 * @param [in] secIdx Index of the current section
+			 * @param [in] yPar Pointer to particle phase entry in unit state vector
+			 * @param [in] yBulk Pointer to corresponding bulk phase entry in unit state vector
+			 * @param [in] yDotPar Pointer to particle phase derivative entry in unit state vector
+			 * @param [out] resPar Pointer Pointer to particle phase entry in unit residual vector, nullptr if no residual shall be computed
+			 * @param [out] colPos column position of the particle (particle coordinate zero)
+			 * @param [in] jacIt Row iterator pointing to the particle phase entry in the unit Jacobian, uninitialized if no Jacobian shall be computed
+			 * @param [in] tlmAlloc memory allocator
+			 * @return @c 0 on success, @c -1 on non-recoverable error, and @c +1 on recoverable error
+			 */
+			virtual int residual(double t, unsigned int secIdx, double const* yPar, double const* yBulk, double const* yDotPar, double* resPar, ColumnPosition colPos, linalg::BandedEigenSparseRowIterator& jacIt, LinearBufferAllocator tlmAlloc, WithoutParamSensitivity) = 0;
+			virtual int residual(double t, unsigned int secIdx, double const* yPar, double const* yBulk, double const* yDotPar, active* resPar, ColumnPosition colPos, linalg::BandedEigenSparseRowIterator& jacIt, LinearBufferAllocator tlmAlloc, WithParamSensitivity) = 0;
+			virtual int residual(double t, unsigned int secIdx, active const* yPar, active const* yBulk, double const* yDotPar, active* resPar, ColumnPosition colPos, linalg::BandedEigenSparseRowIterator& jacIt, LinearBufferAllocator tlmAlloc, WithoutParamSensitivity) = 0;
+			virtual int residual(double t, unsigned int secIdx, active const* yPar, active const* yBulk, double const* yDotPar, active* resPar, ColumnPosition colPos, linalg::BandedEigenSparseRowIterator& jacIt, LinearBufferAllocator tlmAlloc, WithParamSensitivity) = 0;
+
+			unsigned int _parTypeIdx; //!< Particle type index (wrt the unit operation that owns this particle model)
+
+			unsigned int _nComp; //!< Number of components
+
+			IBindingModel* _binding; //!< Binding model
+			bool _singleBinding; //!< Determines whether only a single binding model is present in the whole unit
+			IDynamicReactionModel* _dynReaction; //!< Dynamic reaction model
+			bool _singleDynReaction; //!< Determines whether only a single particle reaction model is present in the whole unit
+
+			virtual double relativeCoordinate(const unsigned int nodeIdx) const CADET_NOEXCEPT = 0;
+
+			virtual active surfaceToVolumeRatio() const CADET_NOEXCEPT = 0;
+
+			inline IBindingModel* getBinding() const CADET_NOEXCEPT { return _binding; }
+			inline bool singleBinding() const CADET_NOEXCEPT { return _singleBinding; }
+			inline IDynamicReactionModel* getReaction() const CADET_NOEXCEPT { return _dynReaction; }
+			inline bool singleReaction() const CADET_NOEXCEPT { return _singleDynReaction; }
+
+			virtual inline const active& getPorosity() const CADET_NOEXCEPT = 0;
+			virtual inline const active* getPoreAccessfactor() const CADET_NOEXCEPT = 0;
+
+			/**
+			 * @brief total number discrete points per particle
+			 */
+			virtual inline int nDiscPoints() const CADET_NOEXCEPT = 0;
+			/**
+			 * @brief stride over one particle
+			 */
+			virtual inline int strideParBlock() const CADET_NOEXCEPT = 0;
+			/**
+			 * @brief computes the physical particle coordinates for every spatial point
+			 */
+			virtual int getParticleCoordinates(double* coords) const = 0;
+
+			typedef Eigen::Triplet<double> T;
+
+			/**
+			 * @brief sets the particle sparsity pattern wrt the global Jacobian
+			 */
+			virtual void setParJacPattern(std::vector<T>& tripletList, const unsigned int offsetPar, const unsigned int offsetBulk, unsigned int colNode, unsigned int secIdx) const = 0;
+
+			virtual unsigned int jacobianNNZperParticle() const = 0;
+			/**
+			 * @brief analytically calculates the static (per section) particle diffusion Jacobian
+			 * @return 1 if jacobain calculation fits the predefined pattern of the jacobian, 0 if not.
+			 */
+			virtual int calcStaticAnaParticleDiffJacobian(const int secIdx, const int colNode, const int offsetLocalCp, Eigen::SparseMatrix<double, RowMajor>& globalJac) = 0;
+			virtual int calcFilmDiffJacobian(unsigned int secIdx, const int offsetCp, const int offsetC, const int nBulkPoints, const int nParType, const double colPorosity, const active* const parTypeVolFrac, Eigen::SparseMatrix<double, RowMajor>& globalJac, bool outliersOnly = false) = 0;
+
+			virtual bool setParameter(const ParameterId& pId, double value) = 0;
+			virtual bool setParameter(const ParameterId& pId, int value) = 0;
+			virtual bool setParameter(const ParameterId& pId, bool value) = 0;
+			virtual bool setSensitiveParameter(std::unordered_set<active*>& sensParams, const ParameterId& pId, unsigned int adDirection, double adValue) = 0;
+			virtual bool setSensitiveParameterValue(const std::unordered_set<active*>& sensParams, const ParameterId& pId, double value) = 0;
+
+			virtual bool hasParameter(const ParameterId& pId) const = 0;
+			virtual double getParameterDouble(const ParameterId& pId) const = 0;
+			virtual std::unordered_map<ParameterId, double> getAllParameterValues(std::unordered_map<ParameterId, double>& data) const = 0;
+
+			virtual bool leanConsistentInitialStateValidity() const = 0;
+
+			virtual bool leanConsistentInitialTimeDerivativeValidity() const = 0;
+
+		};
+
+	} // namespace model
+} // namespace cadet
+
+#endif  // LIBCADET_IPARTICLEMODEL_HPP_

--- a/src/libcadet/model/particle/ParticleModel.hpp
+++ b/src/libcadet/model/particle/ParticleModel.hpp
@@ -1,7 +1,7 @@
 // =============================================================================
 //  CADET
 //  
-//  Copyright © 2008-present: The CADET-Core Authors
+//  Copyright Â© 2008-present: The CADET-Core Authors
 //            Please see the AUTHORS.md file.
 //  
 //  All rights reserved. This program and the accompanying materials

--- a/src/libcadet/model/parts/ParticleDiffusionOperatorBase.hpp
+++ b/src/libcadet/model/parts/ParticleDiffusionOperatorBase.hpp
@@ -113,7 +113,6 @@ namespace parts
 		 * @param [in] yBulk Pointer to corresponding bulk phase entry in unit state vector
 		 * @param [in] yDotPar Pointer to particle phase derivative entry in unit state vector
 		 * @param [out] resPar Pointer Pointer to particle phase entry in unit residual vector, nullptr if no residual shall be computed
-		 * @param [out] colPos column position of the particle (particle coordinate zero)
 		 * @param [in] jacIt Row iterator pointing to the particle phase entry in the unit Jacobian, uninitialized if no Jacobian shall be computed
 		 * @return @c 0 on success, @c -1 on non-recoverable error, and @c +1 on recoverable error
 		 */
@@ -121,8 +120,6 @@ namespace parts
 		virtual int residual(double t, unsigned int secIdx, double const* yPar, double const* yBulk, double const* yDotPar, active* resPar, linalg::BandedEigenSparseRowIterator& jacIt, WithParamSensitivity) = 0;
 		virtual int residual(double t, unsigned int secIdx, active const* yPar, active const* yBulk, double const* yDotPar, active* resPar, linalg::BandedEigenSparseRowIterator& jacIt, WithoutParamSensitivity) = 0;
 		virtual int residual(double t, unsigned int secIdx, active const* yPar, active const* yBulk, double const* yDotPar, active* resPar, linalg::BandedEigenSparseRowIterator& jacIt, WithParamSensitivity) = 0;
-
-		//virtual residualImpl<StateType, ResidualType, ParamType, wantJac, wantRes>(t, secIdx, yPar, yBulk, yDotPar, resPar, jacBase) = 0;
 
 		virtual int calcFilmDiffJacobian(unsigned int secIdx, const int offsetCp, const int offsetC, const int nBulkPoints, const int nParType, const double colPorosity, const active* const parTypeVolFrac, Eigen::SparseMatrix<double, Eigen::RowMajor>& globalJac, bool outliersOnly = false) = 0;
 		virtual int calcStaticAnaParticleDiffJacobian(const int secIdx, const int colNode, const int offsetLocalCp, Eigen::SparseMatrix<double, Eigen::RowMajor>& globalJac) = 0;
@@ -142,17 +139,16 @@ namespace parts
 		 */
 		virtual double relativeCoordinate(const unsigned int nodeIdx) const = 0;
 
-		template<typename ParamType>
-		ParamType surfaceToVolumeRatio() const CADET_NOEXCEPT
+		active surfaceToVolumeRatio() const CADET_NOEXCEPT
 		{
-			return _parGeomSurfToVol / static_cast<ParamType>(_parRadius);
+			return _parGeomSurfToVol / _parRadius;
 		}
 
 		/**
 		 * @brief Number of non-zero Jacobian entries occuring from a single particle of this type
 		 * @detail includes intra-particle entries and film diffusion entries
 		 */
-		virtual unsigned int jacobianNNZperParticle() = 0;
+		virtual unsigned int jacobianNNZperParticle() const = 0;
 		
 		virtual bool setParameter(const ParameterId& pId, double value);
 		virtual bool setParameter(const ParameterId& pId, int value);

--- a/src/libcadet/model/parts/ParticleDiffusionOperatorBase.hpp
+++ b/src/libcadet/model/parts/ParticleDiffusionOperatorBase.hpp
@@ -148,7 +148,11 @@ namespace parts
 			return _parGeomSurfToVol / static_cast<ParamType>(_parRadius);
 		}
 
-		virtual unsigned int calcParDiffNNZ() = 0;
+		/**
+		 * @brief Number of non-zero Jacobian entries occuring from a single particle of this type
+		 * @detail includes intra-particle entries and film diffusion entries
+		 */
+		virtual unsigned int jacobianNNZperParticle() = 0;
 		
 		virtual bool setParameter(const ParameterId& pId, double value);
 		virtual bool setParameter(const ParameterId& pId, int value);

--- a/src/libcadet/model/parts/ParticleDiffusionOperatorDG.cpp
+++ b/src/libcadet/model/parts/ParticleDiffusionOperatorDG.cpp
@@ -1271,9 +1271,10 @@ namespace parts
 
 	}
 	
-	unsigned int ParticleDiffusionOperatorDG::calcParDiffNNZ()
+	unsigned int ParticleDiffusionOperatorDG::jacobianNNZperParticle()
 	{
-		return _nComp * ((3u * _nParElem - 2u) * _nParNode * _nParNode + (2u * _nParElem - 3u) * _nParNode);
+		// particle Jacobian entries + 4 * nComp entries for film diffusion flux entries (4 for possible interdependence of Cl and Cp)
+		return _nComp * ((3u * _nParElem - 2u) * _nParNode * _nParNode + (2u * _nParElem - 3u) * _nParNode) + 4 * _nComp;
 	}
 	/**
 	 * @brief calculates the DG Jacobian auxiliary block

--- a/src/libcadet/model/parts/ParticleDiffusionOperatorDG.cpp
+++ b/src/libcadet/model/parts/ParticleDiffusionOperatorDG.cpp
@@ -625,7 +625,6 @@ namespace parts
 		active const* const parSurfDiff = getSectionDependentSlice(_parSurfDiffusion, _strideBound, secIdx);
 
 		const int nNodes = _nParNode;
-		const int nElem = _nParElem;
 		const int nPoints = _nParPoints;
 		const int nComp = _nComp;
 
@@ -1271,7 +1270,7 @@ namespace parts
 
 	}
 	
-	unsigned int ParticleDiffusionOperatorDG::jacobianNNZperParticle()
+	unsigned int ParticleDiffusionOperatorDG::jacobianNNZperParticle() const
 	{
 		// particle Jacobian entries + 4 * nComp entries for film diffusion flux entries (4 for possible interdependence of Cl and Cp)
 		return _nComp * ((3u * _nParElem - 2u) * _nParNode * _nParNode + (2u * _nParElem - 3u) * _nParNode) + 4 * _nComp;

--- a/src/libcadet/model/parts/ParticleDiffusionOperatorDG.hpp
+++ b/src/libcadet/model/parts/ParticleDiffusionOperatorDG.hpp
@@ -141,7 +141,7 @@ namespace parts
 
 		void setParticleJacobianPattern(std::vector<T>& tripletList, unsigned int offsetPar, unsigned int offsetBulk, unsigned int colNode, unsigned int secIdx);
 
-		unsigned int calcParDiffNNZ();
+		unsigned int jacobianNNZperParticle();
 
 		int calcStaticAnaParticleDiffJacobian(const int secIdx, const int colNode, const int offsetLocalCp, Eigen::SparseMatrix<double, RowMajor>& globalJac);
 

--- a/src/libcadet/model/parts/ParticleDiffusionOperatorDG.hpp
+++ b/src/libcadet/model/parts/ParticleDiffusionOperatorDG.hpp
@@ -141,7 +141,7 @@ namespace parts
 
 		void setParticleJacobianPattern(std::vector<T>& tripletList, unsigned int offsetPar, unsigned int offsetBulk, unsigned int colNode, unsigned int secIdx);
 
-		unsigned int jacobianNNZperParticle();
+		unsigned int jacobianNNZperParticle() const;
 
 		int calcStaticAnaParticleDiffJacobian(const int secIdx, const int colNode, const int offsetLocalCp, Eigen::SparseMatrix<double, RowMajor>& globalJac);
 


### PR DESCRIPTION
We need a particle model base class in preparation of other particle models to be added to the new module.

todo
-----
- [x] remove particle type specific functions from the GR particle. To this, remove `getParDepSurfDiffusion` and `singleParDepSurfDiffusion` from `hasParameter` in the GRM_DG unit and instead implement and call the functions `hasParameter`, `getParameterDouble`,  `getAllParameterValues` from the particle model
- [x] add base class for particles