### PR TITLE
Add check for correct size of field NBOUND in CSTR

### DIFF
--- a/src/libcadet/model/StirredTankModel.cpp
+++ b/src/libcadet/model/StirredTankModel.cpp
@@ -113,6 +113,9 @@ bool CSTRModel::configureModelDiscretization(IParameterProvider& paramProvider, 
 	if (paramProvider.exists("NBOUND"))
 	{
 		const std::vector<int> nBound = paramProvider.getIntArray("NBOUND");
+		if (nBound.size() < _nComp)
+			throw InvalidParameterException("Field NBOUND contains too few elements (NCOMP = " + std::to_string(_nComp) + " required)");
+
 		_nParType = nBound.size() / _nComp;
 		
 		_nBound = new unsigned int[_nComp * _nParType];


### PR DESCRIPTION
This PR adds a check for correct size of field NBOUND in CSTR, which is implemented in all the other units.
Not checking this can lead to undefined behaviour even when adsorption is correctly specified.