### PR TITLE
Add Pseudo-Transient Continuation method as nonlinear solver

### DIFF
--- a/doc/interface/consistent_initialization.rst
+++ b/doc/interface/consistent_initialization.rst
@@ -6,17 +6,39 @@ Nonlinear solver for consistent initialization
 Group /input/model/unit_XXX/discretization/consistency_solver - Nonlinear consistency solver paramters
 ------------------------------------------------------------------------------------------------------
 
+The following specifications of the nonlinear solver for consistent initialization are available.
+The default is a ``COMPOSITE`` solver that applies multiple solvers subsequently, where the default is ``ATRN_ERR`` followed by ``LEVMAR``.
+
+
 ``SOLVER_NAME``
 
-Name of the solver. Available solvers are ``LEVMAR``, ``ATRN_RES``, ``ATRN_ERR``, and ``COMPOSITE``.
+Name of the solver.
+Available solvers are
+
+- ``LEVMAR``: Levenberg-Marquardt method (ported from the MATLAB implementation)
+
+- ``ATRN_RES``: Adaptive trust-region Newton solver, implemetation of the NLEQ-RES algorithm described in :cite:`Deuflhard2011` (p. 131)
+
+- ``ATRN_ERR``: Robust adaptive trust-region Newton solver, implemetation of the NLEQ-ERR algorithm described in :cite:`Deuflhard2011` (pp. 148)
+
+- ``COMPOSITE``: Applies multiple solvers subsequently
+
 
   ================== =======================
    **Type:** string  **Length:** :math:`1`     
   ================== =======================
 
+``SUBSOLVERS``
+
+Vector with names of solvers for the ``COMPOSITE`` solver (only required for composite solver). See ``SOLVER_NAME`` for available solvers.
+
+  ================== ==========================
+   **Type:** string  **Length:** :math:`\gt 1`     
+  ================== ==========================
+
 ``INIT_DAMPING``
 
-Initial damping factor (default is :math:`0.01`)
+Initial damping factor (default is :math:`0.01`), only required for ``LEVMAR``, ``ATRN_RES`` and ``ATRN_ERR``. See ``SOLVER_NAME`` for available solvers.
 
    ================  =============================  ==================================
    **Type:** double  **Range:** :math:`\ge 0`       **Length:** :math:`1`
@@ -24,16 +46,8 @@ Initial damping factor (default is :math:`0.01`)
 
 ``MIN_DAMPING``
 
-Minimal damping factor (default is :math:`0.0001`; ignored by ``LEVMAR``)
+Minimal damping factor (default is :math:`0.0001`), only required for ``ATRN_RES`` and ``ATRN_ERR``. See ``SOLVER_NAME`` for available solvers.
 
    ================  =============================  ==================================
    **Type:** double  **Range:** :math:`\ge 0`       **Length:** :math:`1`
    ================  =============================  ==================================
-
-``SUBSOLVERS``
-
-Vector with names of solvers for the composite solver (only required for composite solver). See ``SOLVER_NAME`` for available solvers.
-
-  ================== ==========================
-   **Type:** string  **Length:** :math:`\gt 1`     
-  ================== ==========================

--- a/doc/interface/consistent_initialization.rst
+++ b/doc/interface/consistent_initialization.rst
@@ -21,6 +21,8 @@ Available solvers are
 
 - ``ATRN_ERR``: Robust adaptive trust-region Newton solver, implemetation of the NLEQ-ERR algorithm described in :cite:`Deuflhard2011` (pp. 148)
 
+- ``PCT``: Pseudo-transient continuation method, see :cite:`Deuflhard2011` (section 6.4)
+
 - ``COMPOSITE``: Applies multiple solvers subsequently
 
 

--- a/src/libcadet/CMakeLists.txt
+++ b/src/libcadet/CMakeLists.txt
@@ -174,6 +174,7 @@ set (LIBCADET_NONLINALG_SOURCES
 	${CMAKE_SOURCE_DIR}/src/libcadet/linalg/Gmres.cpp
 	${CMAKE_SOURCE_DIR}/src/libcadet/nonlin/AdaptiveTrustRegionNewton.cpp
 	${CMAKE_SOURCE_DIR}/src/libcadet/nonlin/LevenbergMarquardt.cpp
+	${CMAKE_SOURCE_DIR}/src/libcadet/nonlin/PseudoTransientContinuation.cpp
 	${CMAKE_SOURCE_DIR}/src/libcadet/nonlin/CompositeSolver.cpp
 	${CMAKE_SOURCE_DIR}/src/libcadet/nonlin/Solver.cpp
 )

--- a/src/libcadet/nonlin/AdaptiveTrustRegionNewton.hpp
+++ b/src/libcadet/nonlin/AdaptiveTrustRegionNewton.hpp
@@ -349,7 +349,7 @@ namespace nonlin
 			// Convergence test
 			if (errNorm <= errTol)
 			{
-				// Solution is x + dx = x - (-dx)
+				// Solution is x + dx = x + (-dx)
 				// Note that we have to negate dx here since we didn't do that when solving with the Jacobian above
 				for (unsigned int i = 0; i < size; ++i)
 					point[i] -= dx[i];

--- a/src/libcadet/nonlin/PseudoTransientContinuation.cpp
+++ b/src/libcadet/nonlin/PseudoTransientContinuation.cpp
@@ -1,0 +1,48 @@
+// =============================================================================
+//  CADET
+//  
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
+//  
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the GNU Public License v3.0 (or, at
+//  your option, any later version) which accompanies this distribution, and
+//  is available at http://www.gnu.org/licenses/gpl.html
+// =============================================================================
+
+#include "nonlin/PseudoTransientContinuation.hpp"
+#include "cadet/ParameterProvider.hpp"
+#include "linalg/DenseMatrix.hpp"
+
+namespace cadet
+{
+
+namespace nonlin
+{
+
+PseudoTransientContinuationSolver::PseudoTransientContinuationSolver() : _tau(20.0), _scale(nullptr), _maxIter(100), _numNonMonotone(5), _variant(false) { }
+PseudoTransientContinuationSolver::~PseudoTransientContinuationSolver() { }
+
+bool PseudoTransientContinuationSolver::configure(IParameterProvider& paramProvider)
+{
+	if (paramProvider.exists("INIT_PSEUDOTIMESTEP"))
+		_tau = paramProvider.getDouble("INIT_PSEUDOTIMESTEP");
+	if (paramProvider.exists("MAX_NONMONOTONE_ITERATIONS"))
+		_numNonMonotone = paramProvider.getInt("MAX_NONMONOTONE_ITERATIONS");
+	if (paramProvider.exists("MAX_ITERATIONS"))
+		_maxIter = paramProvider.getInt("MAX_ITERATIONS");
+	if (paramProvider.exists("NUMERIC_VARIANT"))
+		_variant = paramProvider.getBool("NUMERIC_VARIANT");
+	return true;
+}
+
+bool PseudoTransientContinuationSolver::solve(std::function<bool(double const* const, double* const)> residual, std::function<bool(double const* const, linalg::detail::DenseMatrixBase& jac)> jacobian,
+		double tol, double* const point, double* const workingMemory, linalg::detail::DenseMatrixBase& jacMatrix, unsigned int size) const
+{
+	return pseudoTransientContinuation(residual, jacobian, _maxIter, tol, _numNonMonotone,
+		_tau, _scale, _variant, point, jacMatrix, workingMemory, size);
+}
+
+} // namespace nonlin
+
+} // namespace cadet

--- a/src/libcadet/nonlin/PseudoTransientContinuation.hpp
+++ b/src/libcadet/nonlin/PseudoTransientContinuation.hpp
@@ -1,0 +1,254 @@
+// =============================================================================
+//  CADET
+//  
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
+//  
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the GNU Public License v3.0 (or, at
+//  your option, any later version) which accompanies this distribution, and
+//  is available at http://www.gnu.org/licenses/gpl.html
+// =============================================================================
+
+/**
+ * @file 
+ * Provides pseudo-transient continuation method for solving nonlinear equation systems
+ */
+
+#ifndef LIBCADET_PSEUDOTRANSIENTCONTINUATION_HPP_
+#define LIBCADET_PSEUDOTRANSIENTCONTINUATION_HPP_
+
+#include "common/CompilerSpecific.hpp"
+#include "nonlin/Solver.hpp"
+
+#include <cmath>
+#include <functional>
+#include <algorithm>
+#include <vector>
+
+#include "linalg/Norms.hpp"
+#include "linalg/DenseMatrix.hpp"
+
+namespace cadet
+{
+
+namespace nonlin
+{
+
+	/**
+	 * @brief Iterate output policy that does nothing
+	 */
+	struct VoidPTCIterateOutputPolicy
+	{
+		inline static void iteration(unsigned int idxIter, double const* const x, double const* const fx, double residualNorm, double stepSize, unsigned int size) { }
+	};
+
+	/**
+	 * @brief Solves nonlinear equations using a pseudo-transient continuation method
+	 * @details The nonlinear equation system @f$ f(x) = 0 @f$ is solved using pseudo-transient
+     *          continuation (PTC), which introduce pseudo time and computes the steady
+     *          state of the ODE @f$ dx / dt = f(x) @f$.
+     *
+     *          After resolving the transient regime at the beginning of the time
+     *          integration, PTC quickly increases the time step size to arrive at the
+     *          equilibrium. It can be interpreted as a linear-implicit Euler scheme for
+     *          the ODE, which tends to a Newton method as the time step size increases.
+     *
+     *          The step size is adaptively determined by switched evolution relaxation
+     *          (SER).
+     *
+     *          See \cite Deuflhard2011.
+	 *          
+	 *          This algorithm is designed to solve the nonlinear equation system
+	 *          @f[\begin{align} f(x) = 0, \qquad f: \mathbb{R}^n \to \mathbb{R}^n. \end{align}@f]
+	 *          A solution is indicated by the error test
+	 *          @f[\begin{align} \left\lVert f(x) \right\rVert_{\ell^2} \leq \text{tol} \end{align}@f]
+	 *          with a given tolerance (@p resTol).
+	 *          
+	 *          The residuals @f$ f(x) @f$ are evaluated using the given function @p residual.
+	 *          The Jacobian @f$ \frac{\mathrm{d}f}{\mathrm{d}x}(x) @f$ are evaluated using the given
+	 *          function @p jacobian.
+	 *          
+	 *          The initial step size of the linear-implicit Euler scheme is provided in @p tau.
+	 * @param [in] residual Function providing the residual @f$ f(x) @f$ at position @f$ x @f$ of the nonlinear equation 
+	 *             system @f$ f(x) = 0 @f$ to be solved.
+	 *             The signature of the function is
+	 *             `bool residual(double const* const x, double* const r)`
+	 *             where the return value communicates whether the evaluation has been successful.
+	 *             On exit, the residual is returned in-place in @f$ r @f$.
+	 *             If an error is indicated by returning @c false, the algorithm aborts with failure.
+	 * @param [in] jacobian Function calculating the Jacobian matrix @f$ J_f(x) @f$ at position @f$ x @f$. 
+	 *             The signature of the function is
+	 *             `bool jacobian(double const* const x, linalg::detail::DenseMatrixBase& J)`
+	 *             where the return value communicates whether the evaluation has been successful.
+	 *             On exit, the Jacobian is returned in-place in @f$ J @f$.
+	 *             If an error is indicated by returning @c false, the algorithm aborts with failure.
+	 * @param [in] maxIter Maximum number of iterations
+	 * @param [in] resTol Termination criterion on the residual @f$\ell^2@f$-norm
+	 * @param [in] maxNonMonotone Maximum number of non-monotone residual updates before the algorithm aborts
+	 * @param [in] tau Initial time step for the Euler scheme
+	 * @param [in] scale Scaling factors, optional (use @c nullptr to disable)
+	 * @param [in] variant Use a different variant for updating the position, which is possibly numerically more stable
+	 * @param [in,out] point On entry initial guess, on exit solution or last iterate
+	 * @param [in] jacMat Memory for Jacobian matrix
+	 * @param [in] workingMemory Additional memory of size @f$ 4n @f$ required for performing the iterations, where @f$ n @f$ is the problem @p size
+	 * @param [in] size Size of the problem (i.e., number of equations, length of residual, columns of Jacobian etc.)
+	 * @tparam IterateOutputPolicy Policy that handles output of intermediate values (useful for debugging), see VoidPTCIterateOutputPolicy
+	 * @return @c true if a solution meeting the residual tolerance was found, @c false otherwise
+	 */
+	template <typename IterateOutputPolicy = VoidPTCIterateOutputPolicy>
+	bool pseudoTransientContinuation(std::function<bool(double const* const, double* const)> residual, std::function<bool(double const* const, linalg::detail::DenseMatrixBase&)> jacobian,
+		int maxIter, double resTol, int maxNonMonotone, double tau, double const* const scale, bool variant, double* const point, linalg::detail::DenseMatrixBase& jacMat, double* const workingMemory, int size)
+	{
+		// Split working memory into parts
+		double* const residualMem = workingMemory;
+		double* const dx = workingMemory + size;
+		double* const qrMem = workingMemory + 2 * size;
+
+		residual(point, residualMem);
+		double normFk = 0.0;
+		if (scale)
+			normFk = cadet::linalg::l2normWeighted(residualMem, scale, size);
+		else
+			normFk = cadet::linalg::l2Norm(residualMem, size);
+
+		int k = 0;
+		int nNonMonotoneResidual = 0;
+		double inv_tau = 1.0 / tau;
+
+		IterateOutputPolicy::iteration(0, point, residualMem, normFk, tau, size);
+
+		while (k <= maxIter)
+		{
+			if (normFk <= resTol)
+				return true;
+			
+			jacobian(point, jacMat);
+			if (scale)
+				jacMat.scaleRows(scale);
+
+			for (int i = 0; i < size; ++i)
+			{
+				if (scale)
+					dx[i] = residualMem[i] / scale[i];
+				else
+					dx[i] = residualMem[i];
+			}
+
+			if (variant)
+			{
+				// (1/tau * I - F'(x)) * dx = F(x), update x_new = x + dx
+				// -(1/tau * I - F'(x)) * dx = -F(x), update x_new = x + dx
+				// (F'(x) - 1/tau * I) * dx = -F(x), update x_new = x + dx
+				// (F'(x) - 1/tau * I) * (-dx) = F(x), update x_new = x - dx
+
+				if (scale)
+				{
+					for (int i = 0; i < size; ++i)
+						jacMat.native(i, i) -= inv_tau / scale[i];
+				}
+				else
+				{
+					for (int i = 0; i < size; ++i)
+						jacMat.native(i, i) -= inv_tau;
+				}
+
+				jacMat.robustFactorize(qrMem);
+				jacMat.robustSolve(dx, qrMem);
+
+				for (int i = 0; i < size; ++i)
+					point[i] = point[i] - dx[i];
+			}
+			else
+			{
+				// (I - tau * F'(x)) * dx = F(x), update x_new = x + tau * dx
+				for (int i = 0; i < size; ++i)
+				{
+					for (int j = 0; j < size; ++j)
+						jacMat.native(i, j) *= -tau;
+
+					if (scale)
+						jacMat.native(i, i) += 1.0 / scale[i];
+					else
+						jacMat.native(i, i) += 1.0;
+				}
+
+				jacMat.robustFactorize(qrMem);
+				jacMat.robustSolve(dx, qrMem);
+
+				for (int i = 0; i < size; ++i)
+					point[i] = point[i] + tau * dx[i];
+			}
+
+			residual(point, residualMem);
+
+			double normFkp1 = 0.0;
+			if (scale)
+				normFkp1 = cadet::linalg::l2normWeighted(residualMem, scale, size);
+			else
+				normFkp1 = cadet::linalg::l2Norm(residualMem, size);
+
+			// Guard against division by zero
+			if (normFkp1 == 0.0)
+				return true;
+
+			// Update step size
+			tau = tau * normFk / normFkp1;
+			inv_tau = 1.0 / tau;
+
+			// Check monotonicity of residual norm
+			if (normFkp1 < normFk)
+				nNonMonotoneResidual = 0;
+			else
+			{
+				++nNonMonotoneResidual;
+				if (nNonMonotoneResidual >= maxNonMonotone)
+					return false;
+			}
+
+			normFk = normFkp1;
+			++k;
+
+			IterateOutputPolicy::iteration(k, point, residualMem, normFk, tau, size);
+		}
+
+		return true;
+	}
+
+	/**
+	 * @brief Uses a pseudo-transient continuation method for solving nonlinear equations
+	 * @details Wraps pseudoTransientContinuation() function.
+	 */
+	class PseudoTransientContinuationSolver : public Solver
+	{
+	public:
+		PseudoTransientContinuationSolver();
+		virtual ~PseudoTransientContinuationSolver();
+
+		static const char* identifier() { return "PTC"; }
+		virtual const char* name() const { return PseudoTransientContinuationSolver::identifier(); }
+		virtual bool configure(IParameterProvider& paramProvider);
+
+		virtual unsigned int workspaceSize(unsigned int problemSize) const
+		{
+			return 4 * problemSize;
+		}
+		
+		virtual unsigned int numTuningParameters() const { return 5; }
+
+		virtual bool solve(std::function<bool(double const* const, double* const)> residual, std::function<bool(double const* const, linalg::detail::DenseMatrixBase& jac)> jacobian,
+			double tol, double* const point, double* const workingMemory, linalg::detail::DenseMatrixBase& jacMatrix, unsigned int size) const;
+	
+	protected:
+		double _tau; //!< Initial step size
+		double* _scale; //!< Scaling factors
+		int _maxIter; //!< Maximum number of iterations
+		int _numNonMonotone; //!< Maximum number of non-monotone error trajectory
+		bool _variant; //!< Different numeric calculation, but mathematically equivalent
+	};
+
+} // namespace nonlin
+
+} // namespace cadet
+
+#endif  // LIBCADET_PSEUDOTRANSIENTCONTINUATION_HPP_

--- a/src/libcadet/nonlin/Solver.cpp
+++ b/src/libcadet/nonlin/Solver.cpp
@@ -13,6 +13,7 @@
 #include "nonlin/Solver.hpp"
 #include "nonlin/AdaptiveTrustRegionNewton.hpp"
 #include "nonlin/LevenbergMarquardt.hpp"
+#include "nonlin/PseudoTransientContinuation.hpp"
 #include "nonlin/CompositeSolver.hpp"
 
 namespace cadet
@@ -29,6 +30,8 @@ namespace nonlin
 			return new RobustAdaptiveTrustRegionNewtonSolver();
 		if (name == LevenbergMarquardtSolver::identifier())
 			return new LevenbergMarquardtSolver();
+		if (name == PseudoTransientContinuationSolver::identifier())
+			return new PseudoTransientContinuationSolver();
 		if (name == CompositeSolver::identifier())
 			return new CompositeSolver();
 

--- a/src/libcadet/nonlin/Solver.cpp
+++ b/src/libcadet/nonlin/Solver.cpp
@@ -36,10 +36,7 @@ namespace nonlin
 			return new CompositeSolver();
 
 		// Default solver
-		CompositeSolver* cs = new CompositeSolver();
-		cs->addSubsolver(new RobustAdaptiveTrustRegionNewtonSolver());
-		cs->addSubsolver(new LevenbergMarquardtSolver());
-		return cs;
+		return new PseudoTransientContinuationSolver();
 	}
 
 } // namespace nonlin

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -79,6 +79,7 @@ add_executable(testRunner testRunner.cpp JsonTestModels.cpp ColumnTests.cpp Unit
 	ParamDepTests.cpp ParameterDependencies.cpp
 	ModelSystem.cpp
 	BandMatrix.cpp DenseMatrix.cpp SparseMatrix.cpp StringHashing.cpp LogUtils.cpp AD.cpp Subset.cpp Graph.cpp
+	NonlinearSolvers.cpp
 	"${CMAKE_CURRENT_BINARY_DIR}/Paths_$<CONFIG>.cpp" "${CMAKE_SOURCE_DIR}/src/io/JsonParameterProvider.cpp"
 	${TEST_ADDITIONAL_SOURCES}
 	$<TARGET_OBJECTS:libcadet_object>)

--- a/test/NonlinearSolvers.cpp
+++ b/test/NonlinearSolvers.cpp
@@ -1,0 +1,418 @@
+// =============================================================================
+//  CADET
+//  
+//  Copyright © The CADET Authors
+//            Please see the CONTRIBUTORS.md file.
+//  
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the GNU Public License v3.0 (or, at
+//  your option, any later version) which accompanies this distribution, and
+//  is available at http://www.gnu.org/licenses/gpl.html
+// =============================================================================
+
+#include <catch.hpp>
+#include <cmath>
+#include <vector>
+#include <random>
+#include <chrono>
+#include <iostream>
+
+#include "Approx.hpp"
+#include "cadet/cadet.hpp"
+
+#define CADET_LOGGING_DISABLE
+#include "Logging.hpp"
+#include "LoggingUtils.hpp"
+
+#include "linalg/DenseMatrix.hpp"
+#include "AdUtils.hpp"
+#include "AutoDiff.hpp"
+#include "nonlin/PseudoTransientContinuation.hpp"
+
+namespace
+{
+	struct PTCIterateOutputPolicy
+	{
+		inline static void iteration(unsigned int idxIter, double const* const x, double const* const fx, double residualNorm, double stepSize, unsigned int size)
+        {
+            std::cout << "Iter " << idxIter << " Timestep " << stepSize << " residual " << residualNorm << std::endl;
+			std::cout << "  Residual ";
+			for (unsigned int i = 0; i < size; ++i)
+			{
+				std::cout << fx[i] << " ";
+			}
+			std::cout << std::endl;
+        }
+	};
+
+	struct Problem1
+	{
+		static constexpr int problemSize = 2;
+		static constexpr int maxIter = 100;
+		static constexpr double resTol = 1e-8;
+		static constexpr int numNonMonotone = 10;
+		static constexpr double initStep = 20.0;
+
+		template <typename T>
+		static bool residual(T const* const in, T* const out)
+		{
+			using std::sin;
+			out[0] = in[0] * in[1] - 4.0;
+			out[1] = sin(in[1] + in[0]);
+			return true;
+		}
+
+		static void checkInvariants(double const* start, double const* end) { }
+
+		static void initialPoint(double* init)
+		{
+			init[0] = 1.0;
+			init[1] = 3.0;
+		}
+
+		template <typename rand_eng_t>
+		static void randomInitialPoint(double* init, rand_eng_t& generator)
+		{
+			std::normal_distribution<double> distribution(0.0, 10.0);
+			init[0] = distribution(generator);
+			init[1] = distribution(generator);
+		}
+
+		static void scaleFromInitialPoint(double* scale, double const* init)
+		{
+			scale[0] = 0.5;
+			scale[1] = 2.0;
+		}
+
+		static bool shouldRunTest(bool applyScaling, bool useVariant) { return true; }
+	};
+
+	struct SingleThreeCompReaction
+	{
+		static constexpr int problemSize = 3;
+		static constexpr int maxIter = 100;
+		static constexpr double resTol = 1e-8;
+		static constexpr int numNonMonotone = 10;
+		static constexpr double initStep = 20.0;
+
+		template <typename T>
+		static bool residual(T const* const in, T* const out)
+		{
+			// Reaction A + B <-> C, rate function fwd * a * b - bwd * c
+			const double fwd = 2.3;
+			const double bwd = 1.1;
+
+			const T rate = fwd * in[0] * in[1] - bwd * in[2];
+			out[0] = -rate;
+			out[1] = -rate;
+			out[2] = rate;
+			return true;
+		}
+
+		static void checkInvariants(double const* start, double const* end)
+		{
+			const double invariant1Start = start[0] + start[2];
+			const double invariant2Start = start[1] + start[2];
+
+			const double invariant1End = end[0] + end[2];
+			const double invariant2End = end[1] + end[2];
+
+			CHECK(std::abs(invariant1End - invariant1Start) <= resTol);
+			CHECK(std::abs(invariant2End - invariant2Start) <= resTol);
+		}
+
+		static void initialPoint(double* init)
+		{
+			init[0] = 1.0;
+			init[1] = 1.0;
+			init[2] = 0.0;
+		}
+
+		template <typename rand_eng_t>
+		static void randomInitialPoint(double* init, rand_eng_t& generator)
+		{
+			std::normal_distribution<double> distribution(0.0, 10.0);
+			init[0] = std::abs(distribution(generator));
+			init[1] = std::abs(distribution(generator));
+			init[2] = std::abs(distribution(generator));
+		}
+
+		static void scaleFromInitialPoint(double* scale, double const* init)
+		{
+			scale[0] = 0.5;
+			scale[1] = 1.0;
+			scale[2] = 2.0;
+		}
+
+		static bool shouldRunTest(bool applyScaling, bool useVariant) { return true; }
+	};
+
+	struct ThreeCompMassActionLawReaction
+	{
+		static constexpr int problemSize = 3;
+		static constexpr int maxIter = 100;
+		static constexpr double resTol = 1e-8;
+		static constexpr int numNonMonotone = 10;
+		static constexpr double initStep = 20.0;
+
+		template <typename T>
+		static bool residual(T const* const in, T* const out)
+		{
+			// Reaction A + B <-> C, rate function fwd * a * b - bwd * c
+			// Raction A <-> B, rate function fwd * a - bwd * b
+			const double fwd1 = 2.3;
+			const double bwd1 = 1.1;
+
+			const double fwd2 = 1e-2;
+			const double bwd2 = 2.0;
+
+			const T rate1 = fwd1 * in[0] * in[1] - bwd1 * in[2];
+			const T rate2 = fwd2 * in[0] - bwd2 * in[1];
+			out[0] = -rate1 - rate2;
+			out[1] = -rate1 + rate2;
+			out[2] = rate1;
+			return true;
+		}
+
+		static void checkInvariants(double const* start, double const* end)
+		{
+			const double invariant1Start = start[0] + start[1] + 2 * start[2];
+			const double invariant1End = end[0] + end[1] + 2 * end[2];
+
+			CHECK(std::abs(invariant1End - invariant1Start) <= resTol);
+		}
+
+		static void initialPoint(double* init)
+		{
+			init[0] = 1.0;
+			init[1] = 1.0;
+			init[2] = 0.0;
+		}
+
+		template <typename rand_eng_t>
+		static void randomInitialPoint(double* init, rand_eng_t& generator)
+		{
+			std::normal_distribution<double> distribution(0.0, 10.0);
+			init[0] = std::abs(distribution(generator));
+			init[1] = std::abs(distribution(generator));
+			init[2] = std::abs(distribution(generator));
+		}
+
+		static void scaleFromInitialPoint(double* scale, double const* init)
+		{
+			scale[0] = 0.5;
+			scale[1] = 1.0;
+			scale[2] = 2.0;
+		}
+
+		static bool shouldRunTest(bool applyScaling, bool useVariant) { return true; }
+	};
+
+	struct SMAProblem
+	{
+		static constexpr double yCp[4] = {5.8377002519964755e+01, 2.9352296732047269e-03, 1.5061023667222263e-02, 1.3523701213590386e-01};
+		static constexpr double _kA[4] = {0.0, 35.5, 1.59, 7.7};
+		static constexpr double _kD[4] = {0.0, 1000.0, 1000.0, 1000.0};
+		static constexpr double _lambda = 1.2e3;
+		static constexpr double _nu[4] = {0.0, 4.7, 5.29, 3.7};
+		static constexpr double _sigma[4] = {0.0, 11.83, 10.6, 10.0};
+
+		static constexpr int problemSize = 4;
+		static constexpr int maxIter = 1000;
+		static constexpr double resTol = 1e-8;
+		static constexpr int numNonMonotone = 100;
+		static constexpr double initStep = 1e-4;
+
+		template <typename T>
+		static bool residual(T const* const x, T* const res)
+		{
+			using std::pow;
+
+			// Salt equation: q_0 - Lambda + Sum[nu_j * q_j, j] == 0 
+			//           <=>  q_0 == Lambda - Sum[nu_j * q_j, j] 
+			// Also compute \bar{q}_0 = q_0 - Sum[sigma_j * q_j, j]
+			res[0] = x[0] - _lambda;
+			T q0_bar = x[0];
+
+			for (int j = 1; j < 4; ++j)
+			{
+				res[0] += _nu[j] * x[j];
+				q0_bar -= _sigma[j] * x[j];
+			}
+
+			// Protein equations: dq_i / dt - ( k_{a,i} * c_{p,i} * \bar{q}_0^{nu_i} - k_{d,i} * q_i * c_{p,0}^{nu_i} ) == 0
+			//               <=>  dq_i / dt == k_{a,i} * c_{p,i} * \bar{q}_0^{nu_i} - k_{d,i} * q_i * c_{p,0}^{nu_i}
+			for (int i = 1; i < 4; ++i)
+			{
+				const T c0_pow_nu = pow(yCp[0], _nu[i]);
+				const T q0_bar_pow_nu = pow(q0_bar, _nu[i]);
+
+				// Residual
+				res[i] = _kD[i] * x[i] * c0_pow_nu - _kA[i] * yCp[i] * q0_bar_pow_nu;
+			}
+			return true;
+		}
+
+		static void checkInvariants(double const* start, double const* end) { }
+
+		static void initialPoint(double* init)
+		{
+			init[0] = 1.0485785488181000e+03;
+			init[1] = 1.1604726694141368e+01;
+			init[2] = 1.1469542586742687e+01;
+			init[3] = 9.7852311988018670e+00;
+		}
+
+		template <typename rand_eng_t>
+		static void randomInitialPoint(double* init, rand_eng_t& generator) { }
+
+		static void scaleFromInitialPoint(double* scale, double const* init) { }
+
+		static bool shouldRunTest(bool applyScaling, bool useVariant) { return !applyScaling && useVariant; }
+	};
+
+
+	template <typename Func_t>
+	auto makeADJacobian(Func_t func, cadet::active* adIn, cadet::active* adOut, int problemSize)
+	{
+		const auto jacobian = [=](double const* const point, cadet::linalg::detail::DenseMatrixBase& jac) -> bool
+		{
+			cadet::ad::copyToAd(point, adIn, problemSize);
+			func(adIn, adOut);
+			cadet::ad::extractDenseJacobianFromAd(adOut, 0, jac);
+			return true;
+		};
+
+		return jacobian;
+	}
+}
+
+template <typename prob_t, typename init_func_t>
+void testPTCFixedInitialPoint(init_func_t initFunc)
+{
+	const int problemSize = prob_t::problemSize;
+
+	std::vector<double> initPoint(problemSize, 0.0);
+	initFunc(initPoint.data());
+
+	// Copy for checking invariants later
+	std::vector<double> x = initPoint;
+
+	std::vector<double> scaleVals(problemSize, 0.0);
+	prob_t::scaleFromInitialPoint(scaleVals.data(), initPoint.data());
+
+	// Initialize AD and allocate AD vectors
+	cadet::ad::setDirections(problemSize);
+
+	std::vector<cadet::active> adIn(problemSize, 0.0);
+	std::vector<cadet::active> adOut(problemSize, 0.0);
+
+	// Set seed vectors
+	cadet::ad::prepareAdVectorSeedsForDenseMatrix(adIn.data(), 0, problemSize);
+	cadet::ad::fillAd(adIn.data(), problemSize, 0.0);
+
+	// Use AD to compute dense Jacobian
+	const auto jacobian = makeADJacobian(prob_t::template residual<cadet::active>, adIn.data(), adOut.data(), problemSize);
+
+	std::vector<double> mem(4 * problemSize, 0.0);
+	cadet::linalg::DenseMatrix jacMat;
+	jacMat.resize(problemSize, problemSize);
+
+	for (int idxScale = 0; idxScale < 2; ++idxScale)
+	{
+		// Check with and without scaling
+		double const* scale = (idxScale == 0) ? nullptr : scaleVals.data();
+		CAPTURE(idxScale);
+		SECTION("Scaling of rows")
+		{
+			for (int variant = 0; variant < 2; ++variant)
+			{
+				// Check both variants for solving the linear system
+				const bool useVariant = variant;
+				CAPTURE(useVariant);
+
+				// Check if we want to run this particular test
+				if (!prob_t::shouldRunTest(idxScale != 0, useVariant))
+					continue;
+
+				SECTION("Numerical stability")
+				{
+					const bool res = cadet::nonlin::pseudoTransientContinuation(
+						&prob_t::template residual<double>,
+						jacobian,
+						prob_t::maxIter,
+						prob_t::resTol,
+						prob_t::numNonMonotone,
+						prob_t::initStep,
+						scale,
+						useVariant,
+						x.data(),
+						jacMat,
+						mem.data(),
+						problemSize);
+					CHECK(res);
+
+					std::vector<double> residual(problemSize, 0.0);
+					prob_t::residual(x.data(), residual.data());
+
+					CHECK(cadet::linalg::l2Norm(residual.data(), problemSize) <= prob_t::resTol);
+
+					prob_t::checkInvariants(initPoint.data(), x.data());
+				}
+			}
+		}
+	}
+}
+
+template <typename prob_t>
+void testPTCFixedInitialPoint()
+{
+	testPTCFixedInitialPoint<prob_t>(prob_t::initialPoint);
+}
+
+template <typename prob_t>
+void testPTCRandomInitialPoint(int numRounds)
+{
+	unsigned seed = std::chrono::system_clock::now().time_since_epoch().count();
+	std::default_random_engine generator(seed);
+	CAPTURE(seed);
+
+	for (int i = 0; i < numRounds; ++i)
+		testPTCFixedInitialPoint<prob_t>([&](double* init) -> void { prob_t::randomInitialPoint(init, generator); });
+}
+
+
+TEST_CASE("Pseudo-Transient Continuation Problem 1 fixed init", "[NonlinearSolver],[PTC],[CI]")
+{
+	testPTCFixedInitialPoint<Problem1>();
+}
+
+TEST_CASE("Pseudo-Transient Continuation Problem 1 random inits", "[NonlinearSolver],[PTC],[CI],[Flaky]")
+{
+	testPTCRandomInitialPoint<Problem1>(5);
+}
+
+TEST_CASE("Pseudo-Transient Continuation Single Three-Component Reaction fixed init", "[NonlinearSolver],[PTC],[CI]")
+{
+	testPTCFixedInitialPoint<SingleThreeCompReaction>();
+}
+
+TEST_CASE("Pseudo-Transient Continuation Single Three-Component Reaction random inits", "[NonlinearSolver],[PTC],[CI],[Flaky]")
+{
+	testPTCRandomInitialPoint<SingleThreeCompReaction>(5);
+}
+
+TEST_CASE("Pseudo-Transient Continuation Three-Component Mass Action Law Reaction fixed init", "[NonlinearSolver],[PTC],[CI]")
+{
+	testPTCFixedInitialPoint<ThreeCompMassActionLawReaction>();
+}
+
+TEST_CASE("Pseudo-Transient Continuation Three-Component Mass Action Law Reaction random inits", "[NonlinearSolver],[PTC],[CI],[Flaky]")
+{
+	testPTCRandomInitialPoint<ThreeCompMassActionLawReaction>(5);
+}
+
+TEST_CASE("Pseudo-Transient Continuation SMA fixed init", "[NonlinearSolver],[PTC],[CI]")
+{
+	//testPTCFixedInitialPoint<SMAProblem>();
+}


### PR DESCRIPTION
Adds Pseudo-Transient Continuation as nonlinear solver for consistent initialization.

It still appears to be buggy.

fixes #163

- [x] unit test: basic nonlinear systems
- [x] update documentation
- [ ] check if this fixes our SMA initialization tests
- [ ] follow up: test initialization settings that failed in the past