### PR TITLE
Tests: fix reaction AD Jacobian tests

### DIFF
--- a/src/libcadet/model/GeneralRateModelDG.cpp
+++ b/src/libcadet/model/GeneralRateModelDG.cpp
@@ -1306,9 +1306,9 @@ int GeneralRateModelDG::residualBulk(double t, unsigned int secIdx, StateType co
 		{
 			for (unsigned int col = 0; col < _disc.nPoints; ++col, y += idxr.strideColNode())
 			{
-				const ColumnPosition colPos{ (0.5 + static_cast<double>(col)) / static_cast<double>(_disc.nPoints), 0.0, 0.0 };
+				const ColumnPosition colPos{ _convDispOp.relativeCoordinate(col), 0.0, 0.0 };
 
-				linalg::BandedEigenSparseRowIterator jac(_globalJac, col * idxr.strideColNode());
+				linalg::BandedEigenSparseRowIterator jac(_globalJac, idxr.offsetC() + col * idxr.strideColNode());
 				// static_cast should be sufficient here, but this statement is also analyzed when wantJac = false
 				_dynReactionBulk->analyticJacobianLiquidAdd(t, secIdx, colPos, reinterpret_cast<double const*>(y), -1.0, jac, tlmAlloc);
 			}
@@ -1325,7 +1325,7 @@ int GeneralRateModelDG::residualBulk(double t, unsigned int secIdx, StateType co
 
 			if (wantJac)
 			{
-				linalg::BandedEigenSparseRowIterator jac(_globalJac, col * idxr.strideColNode());
+				linalg::BandedEigenSparseRowIterator jac(_globalJac, idxr.offsetC() + col * idxr.strideColNode());
 				// static_cast should be sufficient here, but this statement is also analyzed when wantJac = false
 				_dynReactionBulk->analyticJacobianLiquidAdd(t, secIdx, colPos, reinterpret_cast<double const*>(y), -1.0, jac, tlmAlloc);
 			}

--- a/src/libcadet/model/LumpedRateModelWithPoresDG.cpp
+++ b/src/libcadet/model/LumpedRateModelWithPoresDG.cpp
@@ -1066,9 +1066,9 @@ int LumpedRateModelWithPoresDG::residualBulk(double t, unsigned int secIdx, Stat
 	{
 		for (unsigned int col = 0; col < _disc.nPoints; ++col, y += idxr.strideColNode())
 		{
-			const ColumnPosition colPos{ (0.5 + static_cast<double>(col)) / static_cast<double>(_disc.nElem), 0.0, 0.0 };
+			const ColumnPosition colPos{ _convDispOp.relativeCoordinate(col), 0.0, 0.0 };
 
-			linalg::BandedEigenSparseRowIterator jac(_globalJacDisc, col * idxr.strideColNode());
+			linalg::BandedEigenSparseRowIterator jac(_globalJac, col * idxr.strideColNode());
 			// static_cast should be sufficient here, but this statement is also analyzed when wantJac = false
 			_dynReactionBulk->analyticJacobianLiquidAdd(t, secIdx, colPos, reinterpret_cast<double const*>(y), -1.0, jac, tlmAlloc);
 		}

--- a/src/libcadet/model/LumpedRateModelWithPoresDG.hpp
+++ b/src/libcadet/model/LumpedRateModelWithPoresDG.hpp
@@ -469,8 +469,8 @@ protected:
 		for (unsigned int blk = 0; blk < _disc.nPoints; blk++) {
 			for (unsigned int comp = 0; comp < _disc.nComp; comp++) {
 				for (unsigned int toComp = 0; toComp < _disc.nComp; toComp++) {
-					tripletList.push_back(T(idxr.offsetC() + blk * idxr.strideColNode() + comp * idxr.strideColComp(),
-						idxr.offsetC() + blk * idxr.strideColNode() + toComp * idxr.strideColComp(),
+					tripletList.push_back(T(blk * idxr.strideColNode() + comp * idxr.strideColComp(),
+						blk * idxr.strideColNode() + toComp * idxr.strideColComp(),
 						0.0));
 				}
 			}

--- a/test/GeneralRateModelDG.cpp
+++ b/test/GeneralRateModelDG.cpp
@@ -301,27 +301,27 @@ TEST_CASE("GRM_DG linear binding single particle matches spatially dependent par
 
 TEST_CASE("GRM_DG dynamic reactions Jacobian vs AD bulk", "[GRM],[DG],[DG1D],[Jacobian],[AD],[ReactionModel],[CI]")
 {
-	cadet::test::reaction::testUnitJacobianDynamicReactionsAD("GENERAL_RATE_MODEL", "DG", true, false, false, 1e-14);
+	cadet::test::reaction::testUnitJacobianDynamicReactionsAD("GENERAL_RATE_MODEL", "DG", true, false, false, 1e-10);
 }
 
 TEST_CASE("GRM_DG dynamic reactions Jacobian vs AD particle", "[GRM],[DG],[DG1D],[Jacobian],[AD],[ReactionModel],[CI]")
 {
-	cadet::test::reaction::testUnitJacobianDynamicReactionsAD("GENERAL_RATE_MODEL", "DG", false, true, false, 1e-14);
+	cadet::test::reaction::testUnitJacobianDynamicReactionsAD("GENERAL_RATE_MODEL", "DG", false, true, false, 1e-10);
 }
 
 TEST_CASE("GRM_DG dynamic reactions Jacobian vs AD modified particle", "[GRM],[DG],[DG1D],[Jacobian],[AD],[ReactionModel],[CI]")
 {
-	cadet::test::reaction::testUnitJacobianDynamicReactionsAD("GENERAL_RATE_MODEL", "DG", false, true, true, 1e-14);
+	cadet::test::reaction::testUnitJacobianDynamicReactionsAD("GENERAL_RATE_MODEL", "DG", false, true, true, 1e-10);
 }
 
 TEST_CASE("GRM_DG dynamic reactions Jacobian vs AD bulk and particle", "[GRM],[DG],[DG1D],[Jacobian],[AD],[ReactionModel],[CI]")
 {
-	cadet::test::reaction::testUnitJacobianDynamicReactionsAD("GENERAL_RATE_MODEL", "DG", true, true, false, 1e-14);
+	cadet::test::reaction::testUnitJacobianDynamicReactionsAD("GENERAL_RATE_MODEL", "DG", true, true, false, 1e-10);
 }
 
 TEST_CASE("GRM_DG dynamic reactions Jacobian vs AD bulk and modified particle", "[GRM],[DG],[DG1D],[Jacobian],[AD],[ReactionModel],[CI]")
 {
-	cadet::test::reaction::testUnitJacobianDynamicReactionsAD("GENERAL_RATE_MODEL", "DG", true, true, true, 1e-14);
+	cadet::test::reaction::testUnitJacobianDynamicReactionsAD("GENERAL_RATE_MODEL", "DG", true, true, true, 1e-10);
 }
 
 TEST_CASE("GRM_DG dynamic reactions time derivative Jacobian vs FD bulk", "[GRM],[DG],[DG1D],[Jacobian],[Residual],[ReactionModel],[CI],[FD]")

--- a/test/LumpedRateModelWithPoresDG.cpp
+++ b/test/LumpedRateModelWithPoresDG.cpp
@@ -291,31 +291,31 @@ inline cadet::JsonParameterProvider createLRMPColumnWithTwoCompLinearBindingThre
 TEST_CASE("LRMP_DG multi particle types dynamic reactions Jacobian vs AD bulk", "[LRMP],[DG],[DG1D],[Jacobian],[AD],[ReactionModel],[ParticleType],[CI]")
 {
 	cadet::JsonParameterProvider jpp = createLRMPColumnWithTwoCompLinearBindingThreeParticleTypes();
-	cadet::test::reaction::testUnitJacobianDynamicReactionsAD(jpp, true, false, false, 1e-11);
+	cadet::test::reaction::testUnitJacobianDynamicReactionsAD(jpp, true, false, false, 1e-10);
 }
 
 TEST_CASE("LRMP_DG multi particle types dynamic reactions Jacobian vs AD particle", "[LRMP],[DG],[DG1D],[Jacobian],[AD],[ReactionModel],[ParticleType],[CI]")
 {
 	cadet::JsonParameterProvider jpp = createLRMPColumnWithTwoCompLinearBindingThreeParticleTypes();
-	cadet::test::reaction::testUnitJacobianDynamicReactionsAD(jpp, false, true, false, 1e-11);
+	cadet::test::reaction::testUnitJacobianDynamicReactionsAD(jpp, false, true, false, 1e-10);
 }
 
 TEST_CASE("LRMP_DG multi particle types dynamic reactions Jacobian vs AD modified particle", "[LRMP],[DG],[DG1D],[Jacobian],[AD],[ReactionModel],[ParticleType],[CI]")
 {
 	cadet::JsonParameterProvider jpp = createLRMPColumnWithTwoCompLinearBindingThreeParticleTypes();
-	cadet::test::reaction::testUnitJacobianDynamicReactionsAD(jpp, false, true, true, 1e-11);
+	cadet::test::reaction::testUnitJacobianDynamicReactionsAD(jpp, false, true, true, 1e-10);
 }
 
 TEST_CASE("LRMP_DG multi particle types dynamic reactions Jacobian vs AD bulk and particle", "[LRMP],[DG],[DG1D],[Jacobian],[AD],[ReactionModel],[ParticleType],[CI]")
 {
 	cadet::JsonParameterProvider jpp = createLRMPColumnWithTwoCompLinearBindingThreeParticleTypes();
-	cadet::test::reaction::testUnitJacobianDynamicReactionsAD(jpp, true, true, false, 1e-11);
+	cadet::test::reaction::testUnitJacobianDynamicReactionsAD(jpp, true, true, false, 1e-10);
 }
 
 TEST_CASE("LRMP_DG multi particle types dynamic reactions Jacobian vs AD bulk and modified particle", "[LRMP],[DG],[DG1D],[Jacobian],[AD],[ReactionModel],[ParticleType],[CI]")
 {
 	cadet::JsonParameterProvider jpp = createLRMPColumnWithTwoCompLinearBindingThreeParticleTypes();
-	cadet::test::reaction::testUnitJacobianDynamicReactionsAD(jpp, true, true, true, 1e-11);
+	cadet::test::reaction::testUnitJacobianDynamicReactionsAD(jpp, true, true, true, 1e-10);
 }
 
 TEST_CASE("LRMP_DG multi particle types dynamic reactions time derivative Jacobian vs FD bulk", "[LRMP],[DG],[DG1D],[Jacobian],[Residual],[ReactionModel],[ParticleType],[CI]")

--- a/test/ReactionModelTests.cpp
+++ b/test/ReactionModelTests.cpp
@@ -198,6 +198,7 @@ namespace reaction
 
 		if (!isLRMP && bulk)
 		{
+			jpp.set("REACTION_MODEL", "MASS_ACTION_LAW");
 			char const* const scopeName = "reaction_bulk";
 			jpp.addScope(scopeName);
 			auto gs2 = util::makeGroupScope(jpp, scopeName);
@@ -226,6 +227,7 @@ namespace reaction
 		if ((!isLRMP && particle) || (isLRMP && bulk))
 		{
 			const int nReactions = 3;
+			jpp.set("REACTION_MODEL_PARTICLE", "MASS_ACTION_LAW");
 
 			for (int i = 0; i < nParType; ++i)
 			{


### PR DESCRIPTION
I came to realize that some reaction tests are not actually functional, i.e. the settings configured dont employ any reaction due to the missing field `REACTION_MODEL`.
That might have been the case ever since these tests were implemented, not sure, but at least for a long time now.