### PR TITLE
Exclude test folder from coverage report

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -118,7 +118,7 @@ jobs:
             --filter "${{ github.workspace }}/src" \
             --filter "${{ github.workspace }}/include" \
             --filter "$BUILD_DIR/src" \
-            --exclude "$BUILD_DIR/test" \
+            --exclude "${{ github.workspace }}/test" \
             --exclude '.*ThirdParty.*' \
             --cobertura -o coverage.xml \
             --print-summary

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -118,6 +118,7 @@ jobs:
             --filter "${{ github.workspace }}/src" \
             --filter "${{ github.workspace }}/include" \
             --filter "$BUILD_DIR/src" \
+            --exclude "$BUILD_DIR/test" \
             --exclude '.*ThirdParty.*' \
             --cobertura -o coverage.xml \
             --print-summary


### PR DESCRIPTION
#483 continued here to not pollute codecov with data, which seems to be hard to remove