### PR TITLE
Fix include build dir

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -3,7 +3,9 @@ coverage:
     project:
       default:
         target: 55%
-
-  ignore:
-    - ".*ThirdParty.*"
-    - ".*/test/.*"
+ignore:
+    - "src/ThirdParty/*"
+    - "ThirdParty"
+    - "test"
+fixes:
+    - "build/src/::src/"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -115,12 +115,10 @@ jobs:
         run: |
           gcovr \
             --root "${{ github.workspace }}" \
-            --filter "${{ github.workspace }}/src" \
-            --filter "${{ github.workspace }}/include" \
-            --filter "$BUILD_DIR/src" \
-            --exclude '.*ThirdParty.*' \
+            --filter "${{ github.workspace }}/(src|include|build/src)" \
+            --exclude-directories '.*ThirdParty.*' \
             --cobertura -o coverage.xml \
-            --print-summary
+            --txt=-
       
       - name: Upload Coverage to Codecov
         uses: codecov/codecov-action@v5


### PR DESCRIPTION
One of the current issues were the build files not covered by codecov #482. With this PR, these reports should be covered by using the fixes option within the ```.codecov.yaml``` option. This should map all ```build/src``` reports to ```src```. Still not sure wether it actually works as intended tbh. As a sideeffect, i also fixed the PR #484. It was part of  ```.codecov.yaml``` not beeing properly configured. Codecov report can be found [here](https://app.codecov.io/gh/cadet/CADET-Core/tree/fix-coverage-report). 

Changed the ```Generate Coverage Report``` step so it spams the whole coverage report to [stdout](https://github.com/cadet/CADET-Core/actions/runs/18194089249/job/51795742798). Used it for bugfixing. I would leave it like this but if someone has a different opinion about to much "meaningless" output it is not a big deal to change it back.

