### PR TITLE
Update release checklist

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_checklist.md
+++ b/.github/ISSUE_TEMPLATE/release_checklist.md
@@ -19,12 +19,12 @@ The following checklist describes the steps to execute sequentially for creating
 
 ## Preparation
 
-- [ ] Create a release branch `vX.X.X` (typically from `master`) and cherry-pick the commits to include.
+- [ ] Create a release branch `vX.X.X` (typically from `master`) and cherry-pick the commits to include
 - [ ] Create a version bump commit `Bump version to vX.X.X`:
-  - Update the version number in `version.txt`, `zenodo.json` (two places), `cadet.hpp` and `cadet.doxyfile`.
-  - Update the authors list if needed in `CONTRIBUTING.md` and `zenodo.json`.
-  - Update the file format in `driver.hpp` if required.
-  - If the release contains all commits from `master`, merge the bump commit into `master`.
+  - Update the version number in `version.txt`, `zenodo.json` (two places), `cadet.hpp` and `cadet.doxyfile`
+  - Update the authors list if needed in `CONTRIBUTING.md` and `zenodo.json`
+  - Update the file format in `driver.hpp` if required
+  - If the release contains all commits from `master`, merge the bump commit into `master`
 
 ---
 
@@ -42,28 +42,29 @@ The following checklist describes the steps to execute sequentially for creating
 
 - [ ] Run the CD tests as described in the [CADET-Verification README](https://github.com/cadet/CADET-Verification).
 - [ ] In the [CADET-Verification Output repository](https://github.com/cadet/CADET-Verification-Output):
-  - Open the automatically created branch for this release and compare the results with the previous release.
-  - If the numerical engine or code structure changed, check the required simulation times.
+  - Open the automatically created branch for this release and compare the results with the previous release. To this end, there are comparison utility functions as described in the [CADET-Verification README](https://github.com/cadet/CADET-Verification)
+  - If the numerical engine or code structure changed, check the required simulation times
 - [ ] If tests fail or show unexpected behaviour:
-  - Fix the issues on the release branch.
-  - Repeat the tests until results are as expected.
-  - Merge fixes into `master` and resolve conflicts if needed.
-- [ ] Add the new run to the [meta-issue](https://github.com/cadet/CADET-Verification-Output/issues/1).
-- [ ] Link the output branch in the release issue.
+  - Fix the issues on the release branch
+  - Repeat the tests until results are as expected
+  - Merge fixes into `master` and resolve conflicts if needed
+- [ ] Add the new run to the [meta-issue](https://github.com/cadet/CADET-Verification-Output/issues/1) and upload the log generated from the convergence data comparison
+- [ ] Link the output branch in the release issue
 
 ---
 
 ## Creating the release on GitHub
 
 - [ ] Go to [GitHub Releases](https://github.com/cadet/CADET-Core/releases/new):
-  - Set the release branch as the target.
-  - Specify the tag `vX.X.X` according to semantic versioning.
-  - Add release notes with sections for Added, Fixed, Changed, and Updated.
-- [ ] Publish the release.
+  - Set the release branch as the target
+  - Specify the tag `vX.X.X` according to semantic versioning
+  - Add release notes with sections for Added, Fixed, Changed, and Updated
+  - Publish the release.
+- [ ] Check creation of docker image with the new release
 - [ ] Verify Zenodo archiving:
-  - Confirm that a version-specific DOI was created.
-  - Ensure that the source code and associated files are archived.
-  - Note that the [concept DOI](https://doi.org/10.5281/zenodo.8179015) remains constant.
+  - Confirm that a version-specific DOI was created
+  - Ensure that the source code and associated files are archived
+  - Note that the [concept DOI](https://doi.org/10.5281/zenodo.8179015) remains constant
 
 ---
 
@@ -72,19 +73,22 @@ The following checklist describes the steps to execute sequentially for creating
 To ensure CADET-Core is accessible to a broad community, it is available as a Python package on conda-forge.  
 Other software, such as CADET-Process and CADET-Python, import this package.
 
-- [ ] Go to your fork of [cadet-feedstock](https://github.com/conda-forge/cadet-feedstock) or create one if it does not exist.
-- [ ] Create a new branch on your fork and open a pull request.
-- [ ] Change the file `recipe/meta.yaml`:
-  - Generate the SHA256 key:  
+- [ ] Go to your fork of [cadet-feedstock](https://github.com/conda-forge/cadet-feedstock) or create one if it does not exist
+- [ ] Create a new branch on your fork and change the file `recipe/meta.yaml`:
+  - install openSSL
+  - Generate the SHA256 key (replace `{{ version }}` with the semantic version number):  
     ```bash
     curl -sL https://github.com/cadet/CADET-Core/archive/refs/tags/v{{ version }}.tar.gz | openssl sha256
     ```
-    Replace `{{ version }}` with the semantic version number.
-  - Update the version number and SHA256 key.
-  - Set the build number to zero (`build: number: 0`).
-- [ ] After opening the pull request, complete the automatically generated checklist.
-- [ ] Comment in the pull request: `@conda-forge-admin, please rerender`
-- [ ] Wait for the automatic checks to pass.
-- [ ] Merge the pull request to trigger the conda-forge release.
-- [ ] Create or update a CADET forum post announcing the release.
+  - Update the version number and SHA256 key
+  - Set the build number to zero (`build: number: 0`)
+- [ ] Open a PR onto the main branch of the conda-forge repo, and complete the automatically generated checklist
+  - Note: to check if the license file is included, check https://github.com/cadet/CADET-Core/archive/refs/tags/v{{ version }}.tar.gz if the License file is in the location specified in the meta.yml in the variable `license_file`
+- [ ] Wait for the automatic checks to pass
+- [ ] Merge the pull request to trigger the conda-forge release
+- [ ] Double check if the new version of cadet-core is on conda-forge
+
+## Follow-up
+- [ ] Create or update a CADET forum post announcing the release, including release notes
+- [ ] If this release checklist was updated, add these changes to the corresponding issue template
 


### PR DESCRIPTION
Removes pre-releases from the release checklist, with the unncessary manual zenodo unlinking. Manual dispatch of docker workflow instead.
Polishes the description of some other steps