### PR TITLE
Fix indices in the Michaelis-Menten documentation.

### DIFF
--- a/doc/interface/reaction/michaelis_menten_kinetics.rst
+++ b/doc/interface/reaction/michaelis_menten_kinetics.rst
@@ -5,7 +5,7 @@ Michaelis Menten kinetics
 
 **Group /input/model/unit_XXX/reaction - REACTION_MODEL = MICHAELIS_MENTEN**
 
-For information on model equations, refer to :ref:`_michaelis_menten_kinetics_model`.
+For information on model equations, refer to :ref:`michaelis_menten_kinetics_model`.
 
 ``MM_STOICHIOMETRY_BULK``
 
@@ -34,7 +34,7 @@ For information on model equations, refer to :ref:`_michaelis_menten_kinetics_mo
 
 ``MM_KM``
 
-    Michaelis constant :math:`K_{\mathrm{M},{i,j}}` for reaction :math:`j` and substrate :math:`i`.
+    Michaelis constant :math:`K_{\mathrm{M}_{i,j}}` for reaction :math:`j` and substrate :math:`i`.
     This constant represents the substrate concentration at which the reaction rate is half of its maximum value.
    
     **Unit:** :math:`~mol^{-1}~m^{-3}`
@@ -45,7 +45,7 @@ For information on model equations, refer to :ref:`_michaelis_menten_kinetics_mo
 
 ``MM_KI_C``
 
-	Inhibition constant for competitive inhibition :math:`K_{I_{k}}`.
+	Inhibition constant for competitive inhibition :math:`K^{c}_{I_{k}}`.
     The index :math:`k` corresponds to the inhibitors acting on substrate :math:`c_{i,j}` in reaction :math:`j`, i.e. :math:`k = (j,i,k)`, where :math:`k` is the index of the inhibitor.
     If :math:`K^{c}_{I_{k}} > 0`, the component inhibits the reaction.
 	Input as reaction index major.
@@ -58,7 +58,7 @@ For information on model equations, refer to :ref:`_michaelis_menten_kinetics_mo
 
 ``MM_KI_UC``
 
-	Inhibition constant uncompetitive inhibition :math:`K^{u}_{I_{k}}`.
+	Inhibition constant for uncompetitive inhibition :math:`K^{uc}_{I_{k}}`.
     The index :math:`k` corresponds to the inhibitors acting on substrate :math:`c_{i,j}` in reaction :math:`j`, i.e. :math:`k = (j,i,k)`, where :math:`k` is the index of the inhibitor.
 	Input as reaction index major.
 

--- a/doc/modelling/reaction/michaelis_menten_kinetics.rst
+++ b/doc/modelling/reaction/michaelis_menten_kinetics.rst
@@ -16,7 +16,7 @@ where :math:`S` is the stoichiometric matrix and :math:`\nu` a flux vector with
 .. math::
 
     \begin{aligned}
-        \nu_{j} = v_{\mathrm{max},j} \prod_{i = 1}^{N_{sub,j}} \nu_{i,j} = v_{\mathrm{max},j} \prod_{i = 1}^{N_{sub,j}} \frac{ c_{i,j}}{K_{\mathrm{M},i,j} + c_{i,j}}
+        \nu_{j} = v_{\mathrm{max},j} \prod_{i = 1}^{N_{sub,j}} \nu_{i,j} = v_{\mathrm{max},j} \prod_{i = 1}^{N_{sub,j}} \frac{ c_{i,j}}{K_{\mathrm{M}_{i,j}} + c_{i,j}}
     \end{aligned}
 
 where
@@ -40,13 +40,13 @@ In competitive inhibition, the inhibitor binds at the enzyme's active site. The 
 .. math::
 
     \begin{aligned}
-        \nu_{i,j} =  \frac{ c_{i,j}}{K_{\mathrm{M},i,j}\,(1 + \sum_{k \in \mathcal{I}_{i,j}} \frac{c_{k}}{K^{c}_{I_{k}}}) + c_{i,j}},
+        \nu_{i,j} =  \frac{c_{i,j}}{K_{\mathrm{M}_{i,j}}\,(1 + \sum_{k \in \mathcal{I}_{i,j}} \frac{c_{k}}{K^{c}_{I_{k}}}) + c_{i,j}},
     \end{aligned}
 
 where
  - :math:`c_{i,j}` is the substrate component and :math:`c_{k}` is one inhibitor acting on substrate :math:`c_{i,j}`,
  - :math:`K^{c}_{I_{k}}` is the inhibition constant with respect to inhibitor :math:`c_{k}` i.e if :math:`K^{c}_{I_{k}} > 0`, component :math:`c_{k}` acts as an inhibitor to substrate :math:`c_{i,j}`,
- - :math:`\mathcal{I}_{i,j}` is the index set of inhibitors for substrate :math:`c_{i,j}`, i.e the indices :math:`k` where :math:`K^{c}_{I_{k}} > 0`.
+ - :math:`\mathcal{I}^{c}_{i,j}` is the index set of inhibitors for substrate :math:`c_{i,j}`, i.e the indices :math:`k` where :math:`K^{c}_{I_{k}} > 0`.
 
 Uncompetitive Inhibition
 ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -56,29 +56,30 @@ In an uncompetitive inhibition, the inhibitor binds to the enzyme-substrate comp
 .. math::
 
     \begin{aligned}
-        \nu_{i,j} = \frac{c_{i,j}}{K_{\mathrm{M},i,j} + c_{i,j} \, (1 + \sum_{k \in \mathcal{I}_{i,j}} \frac{c_{k}}{\tilde{K}_{k}})},
+        \nu_{i,j} = \frac{c_{i,j}}{K_{\mathrm{M}_{i,j}} + c_{i,j} \, (1 + \sum_{k \in \mathcal{I}_{i,j}} \frac{c_{k}}{K^{uc}_{I_{k}}})},
     \end{aligned}
 
 where
  - :math:`c_{i,j}` is the substrate component and :math:`c_{k}` is one inhibitor acting on substrate :math:`c_{i,j}`.
- - :math:`K^{u}_{I_{k}}` is the inhibition constant with respect to component :math:`c_{k}` in reaction :math:`j` i.e if :math:`K^{u}_{I_{k}} > 0`, component :math:`c_{k}` acts as an inhibitor to substrate :math:`c_{i,j}`.
- - :math:`\mathcal{I}_{i,j}` is the index set of inhibitors in reaction :math:`j`, i.e the indices :math:`k` where :math:`K^{u}_{I_{k}} > 0`.
+ - :math:`K^{uc}_{I_{k}}` is the inhibition constant with respect to component :math:`c_{k}` in reaction :math:`j` i.e if :math:`K^{uc}_{I_{k}} > 0`, component :math:`c_{k}` acts as an inhibitor to substrate :math:`c_{i,j}`.
+ - :math:`\mathcal{I}^{uc}_{i,j}` is the index set of inhibitors in reaction :math:`j`, i.e the indices :math:`k` where :math:`K^{uc}_{I_{k}} > 0`.
 
 Mixed Inhibition
 ^^^^^^^^^^^^^^^^
 
-In non-competitive inhibition, the inhibitor can bind to both the enzyme and the enzyme-substrate complex, preventing the reaction from proceeding. The modified flux expression is:
+In mixed inhibition, the inhibitor can bind to both the enzyme and the enzyme-substrate complex, preventing the reaction from proceeding. The modified flux expression is:
 
 .. math::
 
     \begin{aligned}
-       \nu_{i,j} =  \frac{c_{i,j}}{ K_{\mathrm{M},i,j} \,(1 + \sum_{k \in \mathcal{I}_{i,j}} \frac{c_{k}}{K^{c}_{I_{k}}}) + c_{i,j} \,(1 + \sum_{k \in \mathcal{I}_{i,j}} \frac{c_{k}}{K^{u}_{I_{k}}})},
+       \nu_{i,j} =  \frac{c_{i,j}}{ K_{\mathrm{M}_{i,j}} \,(1 + \sum_{k \in \mathcal{I}_{i,j}} \frac{c_{k}}{K^{c}_{I_{k}}}) + c_{i,j} \,(1 + \sum_{k \in \mathcal{I}_{i,j}} \frac{c_{k}}{K^{uc}_{I_{k}}})},
     \end{aligned}
 
 where
  - :math:`c_{i,j}` is the substrate component and :math:`c_{k}` is one the inhibitor acting on substrate :math:`c_{i,j}`.
- - :math:`K^{c}_{I_{k}}`and :math:`K^{u}_{I_{k}}` are the inhibition constants with respect to component :math:`c_{k}` in reaction :math:`j` i.e if :math:`K^{c}_{I_{k}} > 0`, component :math:`c_{k}` acts as an inhibitor to substrate :math:`c_{i,j}`.
- - :math:`\mathcal{I}_{i,j}` is the index set of inhibitors in reaction :math:`j`, i.e the indices :math:`k` where :math:`K^{c}_{I_{k}} > 0`.
+ - :math:`K^{c}_{I_{k}}` and :math:`K^{uc}_{I_{k}}` are the inhibition constants with respect to component :math:`c_{k}` in reaction :math:`j` i.e if :math:`K^{c}_{I_{k}} > 0`, component :math:`c_{k}` acts as an inhibitor to substrate :math:`c_{i,j}`.
+ - :math:`\mathcal{I}^{c}_{i,j}` is the index set of inhibitors in reaction :math:`j`, i.e the indices :math:`k` where :math:`K^{c}_{I_{k}} > 0`,
+ - :math:`\mathcal{I}^{uc}_{i,j}` is the index set of inhibitors in reaction :math:`j`, i.e the indices :math:`k` where :math:`K^{uc}_{I_{k}} > 0`.
 
 
 Non-Competitive Inhibition
@@ -89,14 +90,14 @@ Non-competitive inhibition is a form of mixed inhibition where the inhibitor bin
 .. math::
 
     \begin{aligned}
-       \nu_{i,j} =  \frac{c_{i,j}}{(K_{\mathrm{M},i,j} + c_{i,j}) \,(1 + \sum_{k \in \mathcal{I}_{i,j}} \frac{c_{k}}{K^{n}_{I_{k}}})}
+       \nu_{i,j} =  \frac{c_{i,j}}{(K_{\mathrm{M}_{i,j}} + c_{i,j}) \,(1 + \sum_{k \in \mathcal{I}_{i,j}} \frac{c_{k}}{K^{n}_{I_{k}}})}
     \end{aligned}
 
 where
  - :math:`c_{i,j}` is the substrate component and :math:`c_{k}` is one the inhibitor acting on substrate :math:`c_{i,j}`.
  - :math:`K^{n}_{I_{k}}` is the inhibition constant with respect to component :math:`c_{k}` in reaction :math:`j` i.e if :math:`K^{n}_{I_{k}} > 0`, component :math:`c_{k}` acts as an inhibitor to substrate :math:`c_{i,j}`.
  - :math:`\mathcal{I}_{i,j}` is the index set of inhibitors in reaction :math:`j`, i.e the indices :math:`k` where :math:`K^{n}_{I_{k}} > 0`.
-Note that the inhibition constant for the non-competitive inhibition is indirectly given if :math:` K^{c}_{I_{k}} = K^{u}_{I_{k}} = K^{n}_{I_{k}}`
+Note that the inhibition constant for the non-competitive inhibition is indirectly given if :math:`K^{c}_{I_{k}} = K^{uc}_{I_{k}} = K^{n}_{I_{k}}`
 
 For configuration information please refer to :ref:`michaelis_menten_kinetics_config`.
 
@@ -123,7 +124,7 @@ where:
 - :math:`K_S` is the saturation constant (half-saturation constant)
 
 By choosing a Michaelis-Menten kinetics configuration with one substrate and setting the the parameter accordingly,
-i.e :math:`\mu_{\mathrm{max}} = v_{\mathrm{max}}`, :math:`K_S = K_{\mathrm{M},0,0}` and :math:`c_S = c_{0,0}`,
+i.e :math:`\mu_{\mathrm{max}} = v_{\mathrm{max}}`, :math:`K_S = K_{\mathrm{M}_{0,0}}` and :math:`c_S = c_{0,0}`,
 the Monod equation can be expressed in the same form as the Michaelis-Menten kinetics.
 
 Literature


### PR DESCRIPTION
This pull request updates the Michaelis-Menten kinetics documentation, especially in the notation of kinetic and inhibition constants. The changes standardize subscript usage, clarify the meaning of various constants, and update the descriptions of inhibition mechanisms.

**Notation and Consistency Improvements:**

* Standardized the Michaelis constant notation throughout, changing from `K_{\mathrm{M},i,j}` to `K_{\mathrm{M}_{i,j}}` in both documentation and equations for consistency.
* Updated the reference link for model equations in the documentation to point to the correct label.

**Inhibition Mechanisms Clarification:**

* Clarified and standardized the notation for inhibition constants:
  - Competitive inhibition: changed from `K_{I_{k}}` to `K^{c}_{I_{k}}`
  - Uncompetitive inhibition: changed from `K^{u}_{I_{k}}` to `K^{uc}_{I_{k}}`
  - Updated the index set notation to distinguish between types of inhibitors, e.g., `\mathcal{I}^{c}_{i,j}` and `\mathcal{I}^{uc}_{i,j}`. 
* Updated the mixed and non-competitive inhibition sections to use the new notation and clarified the relationships between inhibition constants.
These changes make the documentation more precise and easier to follow, especially for users referencing the mathematical formulations of reaction kinetics and inhibition.