### PR TITLE
Update newsletter link on github.io and README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,8 +23,8 @@ CADET-Core
 - **Forum:** https://forum.cadet-web.de
 - **Source:** https://github.com/cadet/cadet-core
 - **Bug reports:** https://github.com/cadet/cadet-core/issues
-- **Demo:** https://www.cadet-web.de 
-- **Newsletter:** https://cadet-web.de/newsletter/
+
+To stay up to date on CADET news, development updates, and workshops, please subscribe to our `Newsletter <http://eepurl.com/hzN4EP>`_.
 
 Installation
 ------------

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -35,8 +35,8 @@ The resulting models are solved with state-of-the-art mathematical algorithms an
 
 - **Forum:** https://forum.cadet-web.de
 - **Source:** https://github.com/cadet/cadet-core
-- **Demo:** http://cadet-web.de
-- **Newsletter:** https://cadet-web.de/newsletter/
+
+To stay up to date on CADET news, development updates, and workshops, please subscribe to our `Newsletter <http://eepurl.com/hzN4EP>`_.
 
 Features
 --------


### PR DESCRIPTION
This PR updates the link to the newsletter on the github.io landing page. I put it in a whole sentence since the mailchimp link is not as pretty. 