### PR TITLE
Fix escape in ci pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,10 +195,12 @@ jobs:
           make install -j$(nproc)
       - name: Check executable
         run: |
+          continue-on-error: true
+          id: test0
           export LD_LIBRARY_PATH=${INSTALL_PREFIX}/lib:$LD_LIBRARY_PATH
-          ${INSTALL_PREFIX}/bin/cadet-cli --version || true
+          ${INSTALL_PREFIX}/bin/cadet-cli --version
           ${INSTALL_PREFIX}/bin/createLWE
-          ${INSTALL_PREFIX}/bin/cadet-cli LWE.h5 || true
+          ${INSTALL_PREFIX}/bin/cadet-cli LWE.h5
       - name: Run CI test set I - bindings
         run: |
           continue-on-error: true
@@ -262,6 +264,7 @@ jobs:
           ${BUILD_DIR}/test/testRunner [CI]
       - name: Fail job if any tests failed
         if: |
+          steps.test0.outcome == 'failure' ||
           steps.test1.outcome == 'failure' ||
           steps.test2.outcome == 'failure' ||
           steps.test3.outcome == 'failure' ||
@@ -301,7 +304,7 @@ jobs:
           make install -j$(sysctl -n hw.logicalcpu)
       - name: Check if it runs
         run: |
-          ${INSTALL_PREFIX}/bin/cadet-cli --version || true
+          ${INSTALL_PREFIX}/bin/cadet-cli --version
           ${INSTALL_PREFIX}/bin/createLWE
-          ${INSTALL_PREFIX}/bin/cadet-cli LWE.h5 || true
+          ${INSTALL_PREFIX}/bin/cadet-cli LWE.h5
 


### PR DESCRIPTION
As seen in the github [action](https://github.com/cadet/CADET-Core/actions/runs/18677874603), macos job was able to pass the ci pipeline even if failing due to escaping the command. Fixed this behaviour by removing `|| true` within the mac and ubuntu job. Within the ubuntu job i replaced it with `continue-on-error` and catched failure later so the pipeline throws an error only after executing tests.