### PR TITLE
Fix continue on error within pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,6 +187,7 @@ jobs:
             libsuperlu-dev \
             libeigen3-dev;
       - name: Build and Install
+        id: build
         run: |
           cmake -E make_directory "${BUILD_DIR}"
           cmake -E make_directory "${INSTALL_PREFIX}"
@@ -194,22 +195,19 @@ jobs:
           cmake -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" "${SRC_DIR}" -DENABLE_TESTS=ON -DNUM_MAX_AD_DIRS=160
           make install -j$(nproc)
       - name: Check executable
+        if: always() && steps.build.conclusion == 'success'
         run: |
-          continue-on-error: true
-          id: test0
           export LD_LIBRARY_PATH=${INSTALL_PREFIX}/lib:$LD_LIBRARY_PATH
           ${INSTALL_PREFIX}/bin/cadet-cli --version
           ${INSTALL_PREFIX}/bin/createLWE
           ${INSTALL_PREFIX}/bin/cadet-cli LWE.h5
       - name: Run CI test set I - bindings
+        if: always() && steps.build.conclusion == 'success'
         run: |
-          continue-on-error: true
-          id: test1
           ${BUILD_DIR}/test/testRunner [CI_binding]
       - name: Run CI test set II - sensitivities
+        if: always() && steps.build.conclusion == 'success'
         run: |
-          continue-on-error: true
-          id: test2
           ${BUILD_DIR}/test/testRunner [CI_sens1]
           ${BUILD_DIR}/test/testRunner [CI_sens2]
           ${BUILD_DIR}/test/testRunner [CI_sens3]
@@ -234,9 +232,8 @@ jobs:
           ${BUILD_DIR}/test/testRunner [CI_sens23]
           ${BUILD_DIR}/test/testRunner [CI_sens24]
       - name: Run CI test set III - crystallization
+        if: always() && steps.build.conclusion == 'success'
         run: |
-          continue-on-error: true
-          id: test3
           ${BUILD_DIR}/test/testRunner [CI_cry1]
           ${BUILD_DIR}/test/testRunner [CI_cry2]
           ${BUILD_DIR}/test/testRunner [CI_cry3]
@@ -258,18 +255,10 @@ jobs:
           ${BUILD_DIR}/test/testRunner [CI_cry19]
           ${BUILD_DIR}/test/testRunner [CI_cry20]
       - name: Run CI test set IV
+        if: always() && steps.build.conclusion == 'success'
         run: |
-          continue-on-error: true
-          id: test4
           ${BUILD_DIR}/test/testRunner [CI]
-      - name: Fail job if any tests failed
-        if: |
-          steps.test0.outcome == 'failure' ||
-          steps.test1.outcome == 'failure' ||
-          steps.test2.outcome == 'failure' ||
-          steps.test3.outcome == 'failure' ||
-          steps.test4.outcome == 'failure'
-        run: exit 1
+
   MacOS:
     runs-on: macos-latest
     strategy:


### PR DESCRIPTION
#499 fixed the pipeline in the way that macos is now able to fail. While looking trough the pipeline [output](https://github.com/cadet/CADET-Core/actions/runs/18684779157/job/53274385270) looking at check executable or test steps threws:
```
Run continue-on-error: true
/home/runner/work/_temp/4effd6af-c88a-4b42-a3c0-e63bb6c219ee.sh: line 1: continue-on-error:: command not found
/home/runner/work/_temp/4effd6af-c88a-4b42-a3c0-e63bb6c219ee.sh: line 2: id:: command not found
```

This is because the `continue-on-error` and `id` marks are within the `run` step and not separate options of the step. This leads to the action not continuing even if it is supposed to as seen in [here](https://github.com/cadet/CADET-Core/actions/runs/18715891853/job/53375116416) or [here](https://github.com/cadet/CADET-Core/actions/runs/18680243818/job/53259517597).
So `id` and `continue-on-error` are at the wrong place. Otherwise while looking at this [post](https://stackoverflow.com/questions/62045967/is-there-a-way-to-continue-on-error-while-still-getting-correct-feedback), it may even be better not to use `continue-on-error` at all due to steps not counting as failed in the end.

So to fix this issue i removed `continue-on-error`, added an `id` to the build check and let the steps work if build was succesfull with `if: always() && build.outcome=='success'`.

Tested this by deliberately failing test set 1 [here](https://github.com/cadet/CADET-Core/actions/runs/18718803135/job/53385203514?pr=500).