### PR TITLE
Change default consistent init solver to composite

### DIFF
--- a/src/libcadet/nonlin/Solver.cpp
+++ b/src/libcadet/nonlin/Solver.cpp
@@ -36,7 +36,10 @@ namespace nonlin
 			return new CompositeSolver();
 
 		// Default solver
-		return new PseudoTransientContinuationSolver();
+		CompositeSolver* cs = new CompositeSolver();
+		cs->addSubsolver(new RobustAdaptiveTrustRegionNewtonSolver());
+		cs->addSubsolver(new LevenbergMarquardtSolver());
+		return cs;
 	}
 
 } // namespace nonlin


### PR DESCRIPTION
in https://github.com/cadet/CADET-Core/pull/459, we only observed that PTC is better sometimes, and had no example of it being worse, which is why we made it he new default.
Turns out some tests are actually failing. Thus, we set the default back to the composite sovler and investigate different init solvers in #494 