### PR TITLE
Remove Eigen3 version requirement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -421,16 +421,8 @@ if (ENABLE_2D_MODELS)
 	)
 endif()
 
-set(EIGEN_TARGET "")
 find_package(Eigen3 REQUIRED NO_MODULE)
-
-# Disable DG if Eigen is not present
-if (NOT TARGET Eigen3::Eigen)
-	message(STATUS "Disabling DG support because Eigen3 could not be found")
-	set(ENABLE_DG OFF)
-else()
-	set(EIGEN_TARGET "Eigen3::Eigen")
-endif()
+set(EIGEN_TARGET "Eigen3::Eigen")
 
 set(IPO_AVAILABLE OFF)
 if (ENABLE_IPO)


### PR DESCRIPTION
Eigen3 v5 was published recently, I think we should update and thus remove the version requirement, lets hope we do not need to change anything else.