### PR TITLE
Create a testrunner to manually run specific tests

### DIFF
--- a/.github/workflows/testrunner.yml
+++ b/.github/workflows/testrunner.yml
@@ -1,0 +1,61 @@
+name: TestRunner
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Commit hash, branch name, or tag to run the CI pipeline for'
+        required: false
+        default: 'master'
+      test_filter:
+        description: 'testRunner arguments'
+        required: false
+        default: '[CI]'
+
+jobs:
+  Ubuntu-latest:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
+    env:
+      SRC_DIR: ${{ github.workspace }}/src
+      BUILD_DIR: ${{ github.workspace }}/build
+      INSTALL_PREFIX: ${{ github.workspace }}/install
+      BUILD_TYPE: Release
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+          path: src
+          ref: ${{ github.event.inputs.ref || github.ref }}
+      - name: Install Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt -y install \
+            build-essential \
+            libhdf5-dev \
+            liblapack-dev \
+            libblas-dev \
+            libtbb-dev \
+            libsuperlu-dev \
+            libeigen3-dev;
+      - name: Build and Install
+        id: build
+        run: |
+          cmake -E make_directory "${BUILD_DIR}"
+          cmake -E make_directory "${INSTALL_PREFIX}"
+          cd "${BUILD_DIR}"
+          cmake -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" "${SRC_DIR}" -DENABLE_TESTS=ON -DNUM_MAX_AD_DIRS=160
+          make install -j$(nproc)
+      - name: Check executable
+        if: always() && steps.build.conclusion == 'success'
+        run: |
+          export LD_LIBRARY_PATH=${INSTALL_PREFIX}/lib:$LD_LIBRARY_PATH
+          ${INSTALL_PREFIX}/bin/cadet-cli --version
+          ${INSTALL_PREFIX}/bin/createLWE
+          ${INSTALL_PREFIX}/bin/cadet-cli LWE.h5
+      - name: Run testRunner
+        if: always() && steps.build.conclusion == 'success'
+        run: |
+          ${BUILD_DIR}/test/testRunner "${{github.event.inputs.test_filter}}"


### PR DESCRIPTION
Wrote an additional manual Github Runner that executes testsets you can specify. Default is ```CI```. It is basicly a copy of ```CI.yml```, without the windows and mac jobs.

For example you could run ```[CI_cry8]``` without inteferance with any other testset and check wether this specific set is working. You only need to specify the text within the brackets. So the runner only needs "CI_cry8". Maybe it would be better that the user has to write with brackets so he can specify the entire command line argument of the testrunner? Another issue couldbe to check wether the Filter exists but this is a bit complicated because i haven't seen a working list. Testrunner would anwser with can't find a working test and execute with "0"?


Example run with [CI_cry8](https://github.com/daklauss/CADET-Core/actions/runs/19361969950/job/55395857616) and [CI](https://github.com/daklauss/CADET-Core/actions/runs/19361701427).