### PR TITLE
Make exchange matrix registration part of exchange models

### DIFF
--- a/src/libcadet/model/ExchangeModel.hpp
+++ b/src/libcadet/model/ExchangeModel.hpp
@@ -55,7 +55,7 @@ public:
 
 	virtual bool configureModelDiscretization(IParameterProvider& paramProvider, unsigned int nComp, unsigned int nChannel, unsigned int nCol) = 0;
 
-	virtual bool configure(IParameterProvider& paramProvider, UnitOpIdx unitOpIdx) = 0;
+	virtual bool configure(IParameterProvider& paramProvider, UnitOpIdx unitOpIdx,std::unordered_map<ParameterId, active*>& parameters) = 0;
 
 	virtual int residual(active const* y, active* res, WithParamSensitivity, bool wantJac, linalg::BandedSparseRowIterator jacBegin) const = 0;
 	virtual int residual(active const* y, active* res, WithoutParamSensitivity, bool wantJac, linalg::BandedSparseRowIterator jacBegin) const = 0;

--- a/src/libcadet/model/MultiChannelTransportModel.cpp
+++ b/src/libcadet/model/MultiChannelTransportModel.cpp
@@ -532,9 +532,7 @@ bool MultiChannelTransportModel::configure(IParameterProvider& paramProvider)
 	
 	// Reconfigure exchange model
 	bool exchangeConfSuccess = true;
-	exchangeConfSuccess = _exchange[0]->configure(paramProvider, _unitOpIdx);
-	
-
+	exchangeConfSuccess = _exchange[0]->configure( paramProvider, _unitOpIdx, _parameters);
 
 	return transportSuccess && dynReactionConfSuccess && exchangeConfSuccess;
 }

--- a/src/libcadet/model/exchange/LangumirExchange.cpp
+++ b/src/libcadet/model/exchange/LangumirExchange.cpp
@@ -63,7 +63,7 @@ public:
 		return true;
 	}
 
-	virtual bool configure(IParameterProvider& paramProvider, UnitOpIdx unitOpIdx)
+	virtual bool configure(IParameterProvider& paramProvider, UnitOpIdx unitOpIdx,std::unordered_map<ParameterId, active*>& parameters)
 	{
 		_parameters.clear();
 		readParameterMatrix(_exchangeMatrix, paramProvider, "EXCHANGE_MATRIX", _nChannel * _nChannel * _nComp, 1); // include parameterPeaderHelp in exchange modul

--- a/src/libcadet/model/exchange/LinearExchange.cpp
+++ b/src/libcadet/model/exchange/LinearExchange.cpp
@@ -61,11 +61,16 @@ public:
 		return true;
 	}
 
-	virtual bool configure(IParameterProvider& paramProvider, UnitOpIdx unitOpIdx)
+	virtual bool configure(IParameterProvider& paramProvider, UnitOpIdx unitOpIdx,std::unordered_map<ParameterId, active*>& parameters)
 	{
 		_parameters.clear();
 		readParameterMatrix(_exchangeMatrix, paramProvider, "EXCHANGE_MATRIX", _nChannel * _nChannel * _nComp, 1); // TODO include parameterPeaderHelp in exchange modul
 		_crossSections = paramProvider.getDoubleArray("CHANNEL_CROSS_SECTION_AREAS");
+
+		registerParam3DArray(parameters, _exchangeMatrix, [=](bool multi, unsigned int channelSrc, unsigned int channelDest, unsigned comp)
+		{
+		return makeParamId(hashString("EXCHANGE_MATRIX"), unitOpIdx, multi ? comp : CompIndep, channelDest, channelSrc, ReactionIndep, SectionIndep);
+		}, _nComp, _nChannel);
 
 		return true;
 	}

--- a/src/libcadet/model/parts/MultiChannelConvectionDispersionOperator.cpp
+++ b/src/libcadet/model/parts/MultiChannelConvectionDispersionOperator.cpp
@@ -827,7 +827,7 @@ bool MultiChannelConvectionDispersionOperator::configure(UnitOpIdx unitOpIdx, IP
 
 	// Add parameters to map
 	parameters[makeParamId(hashString("COL_LENGTH"), unitOpIdx, CompIndep, ParTypeIndep, BoundStateIndep, ReactionIndep, SectionIndep)] = &_colLength;
-	registerParam3DArray(parameters, _exchangeMatrix, [=](bool multi, unsigned int channelSrc, unsigned int channelDest, unsigned comp) { return makeParamId(hashString("EXCHANGE_MATRIX"), unitOpIdx, multi ? comp : CompIndep, channelDest, channelSrc, ReactionIndep, SectionIndep); }, _nComp, _nChannel);
+
 
 	setSparsityPattern();
 


### PR DESCRIPTION
This PR fixes #519.

This pull request updates the exchange model configuration to allow direct registration of exchange matrix parameters, improving parameter management and consistency across exchange model implementations. The main changes involve modifying the `configure` method signatures and updating their usage to pass the parameters map, as well as registering exchange matrix parameters within the configuration process.

**Parameter registration improvements:**

* Added registration of exchange matrix parameters within the `LinearExchangeBase::configure` method using `registerParam3DArray`, ensuring that all relevant parameters are properly mapped during configuration.

**Integration and usage updates:**

* Updated `MultiChannelTransportModel::configure` to pass the parameters map to the exchange model's `configure` method
* Removed duplicate registration of exchange matrix parameters from `MultiChannelConvectionDispersionOperator::configure`, as this is now handled in the exchange model configuration.