### PR TITLE
Fix 2DGRM multiple particle type surface diffusion strides

### DIFF
--- a/src/libcadet/model/GeneralRateModel2D.cpp
+++ b/src/libcadet/model/GeneralRateModel2D.cpp
@@ -1401,12 +1401,13 @@ int GeneralRateModel2D::residualParticle(double t, unsigned int parType, unsigne
 	LinearBufferAllocator tlmAlloc = threadLocalMem.get();
 
 	// Prepare parameters
-	const int nSec = _parDiffusion.size() / _disc.nComp / _disc.nParType; // 1 if not section dependent
-	active const* const parDiff = getSectionDependentSlice(_parDiffusion, _disc.nComp *nSec, parType) + (nSec > 1 ? secIdx * _disc.nComp : 0);
+	const int nSecPD = _parDiffusion.size() / _disc.nComp / _disc.nParType; // 1 if not section dependent
+	active const* const parDiff = getSectionDependentSlice(_parDiffusion, _disc.nComp * nSecPD, parType) + (nSecPD > 1 ? secIdx * _disc.nComp : 0);
 
 	// Ordering of particle surface diffusion:
 	// bnd0comp0, bnd1comp0, bnd0comp1, bnd1comp1, bnd0comp2, bnd1comp2
-	active const* const parSurfDiff = getSectionDependentSlice(_parSurfDiffusion, _disc.strideBound[_disc.nParType], secIdx) + (nSec > 1 ? _disc.nBoundBeforeType[parType] : 0);
+	const int nSecSD = _parSurfDiffusion.size() / _disc.strideBound[_disc.nParType]; // 1 if not section dependent
+	active const* const parSurfDiff = getSectionDependentSlice(_parSurfDiffusion, _disc.strideBound[_disc.nParType], nSecSD > 1 ? secIdx : 0) + _disc.nBoundBeforeType[parType];
 
 	// Midpoint of current column cell (z, rho coordinate) - needed in externally dependent adsorption kinetic
 	const unsigned int axialCell = colCell / _disc.nRad;
@@ -1704,8 +1705,8 @@ int GeneralRateModel2D::residualFlux(double t, unsigned int secIdx, StateType co
 		{
 			int const* const qsReaction = _binding[type]->reactionQuasiStationarity();
 
-			const int nSec = _parDiffusion.size() / _disc.nComp / _disc.nParType; // 1 if not section dependent
-			active const* const parSurfDiff = getSectionDependentSlice(_parSurfDiffusion, _disc.nBoundBeforeType[type] * nSec, 1) + (nSec > 1 ? secIdx * _disc.strideBound[type] : 0);
+			const int nSecSD = _parSurfDiffusion.size() / _disc.strideBound[_disc.nParType]; // 1 if not section dependent
+			active const* const parSurfDiff = getSectionDependentSlice(_parSurfDiffusion, _disc.strideBound[_disc.nParType], nSecSD > 1 ? secIdx : 0) + _disc.nBoundBeforeType[type];
 			active const* const parCenterRadius = _parCenterRadius.data() + _disc.nParCellsBeforeType[type];
 			const ParamType absOuterShellHalfRadius = 0.5 * static_cast<ParamType>(_parCellSize[_disc.nParCellsBeforeType[type]]);
 
@@ -1850,7 +1851,8 @@ void GeneralRateModel2D::assembleOffdiagJac(double t, unsigned int secIdx)
 
 			// Ordering of particle surface diffusion:
 			// bnd0comp0, bnd1comp0, bnd0comp1, bnd1comp1, bnd0comp2, bnd1comp2
-			active const* const parSurfDiff = getSectionDependentSlice(_parSurfDiffusion, _disc.nBoundBeforeType[type] * nSec, 1) + (nSec > 1 ? secIdx * _disc.strideBound[type] : 0);
+			const int nSecSD = _parSurfDiffusion.size() / _disc.strideBound[_disc.nParType]; // 1 if not section dependent
+			active const* const parSurfDiff = getSectionDependentSlice(_parSurfDiffusion, _disc.strideBound[_disc.nParType], nSecSD > 1 ? secIdx : 0) + _disc.nBoundBeforeType[type];
 			active const* const parCenterRadius = _parCenterRadius.data() + _disc.nParCellsBeforeType[type];
 			const double absOuterShellHalfRadius = 0.5 * static_cast<double>(_parCellSize[_disc.nParCellsBeforeType[type]]);
 


### PR DESCRIPTION
This PR fixes the 2DGRM with multiple particle types and surface diffusion. Apparently #471 introduced wrong strides, which I catched when conducting the convergence tests in cadet-verification. 