### PR TITLE
Add exception for inconsistent multi particle initial conditions

### DIFF
--- a/doc/interface/unit_operations/particle_config.rst
+++ b/doc/interface/unit_operations/particle_config.rst
@@ -164,7 +164,7 @@ Group /input/model/unit_XXX/particle_type_XXX
 
 ``NBOUND``
 
-   Number of bound states for each component in each particle type in type-major ordering
+   Number of bound states for each component in each particle type in particle type major ordering
    
    =============  =========================  ==========================================
    **Type:** int  **Range:** :math:`\geq 0`  **Length:** :math:`\texttt{NCOMP}`
@@ -172,7 +172,8 @@ Group /input/model/unit_XXX/particle_type_XXX
 
 ``REACTION_MODEL``
 
-   Specifies the type of reaction model of each particle type (or of all particle types if length is :math:`1`). The model is configured in the subgroup :math:`\texttt{reaction_particle}`, or :math:`\texttt{reaction_particle_XXX}` in case of disabled multiplexing.
+   Specifies the type of reaction model of each particle type (or of all particle types if length is :math:`1`).
+   The model is configured in the subgroup :math:`\texttt{reaction_particle}`, or :math:`\texttt{reaction_particle_XXX}` in case of disabled multiplexing.
    
    ================  ========================================  =============
    **Type:** string  **Range:** See Section :ref:`FFReaction`  **Length:** 1
@@ -180,7 +181,10 @@ Group /input/model/unit_XXX/particle_type_XXX
 
 ``INIT_CP``
 
-   Initial concentrations for each component in the bead liquid phase (optional, :math:`\texttt{INIT_C}` is used if left out). The length of this field can be :math:`\texttt{NCOMP}` (same values for each particle type) or :math:`\texttt{NPARTYPE} \cdot \texttt{NCOMP}`  Values for each particle type can only be given when :math:`\texttt{ADSORPTION_MODEL_MULTIPLEX}` is :math:`0`. The ordering is type-major.
+   Initial concentrations for each component in the bead liquid phase (optional, :math:`\texttt{INIT_C}` is used if left out).
+   The length of this field is :math:`\texttt{NCOMP}`.
+   Only in case of a 2D bulk model, the field length *can* also be :math:`\texttt{NCOMP} \cdot \texttt{NRAD}` to specify radial dependence, in which case the ordering is radial position major.
+   If :math:`\texttt{BINDING_PARTYPE_DEPENDENT}` is :math:`0`, the values across different particle types (if multiple particle types are being used) must be the same.
 
    **Unit:** :math:`\mathrm{mol}\,\mathrm{m}_{\mathrm{MP}}^{-3}`
    
@@ -190,7 +194,10 @@ Group /input/model/unit_XXX/particle_type_XXX
 
 ``INIT_CS``
 
-   Initial concentrations for each bound state of each component in the bead solid phase. If :math:`\texttt{ADSORPTION_MODEL_MULTIPLEX}` is :math:`0`, values for each particle type are required in type-component-major ordering (length is :math:`\texttt{NTOTALBND}`). If :math:`\texttt{ADSORPTION_MODEL_MULTIPLEX}` is :math:`1`, values for one particle type are required in component-major ordering (length is :math:`\sum_{i = 0}^{\texttt{NCOMP} - 1} \texttt{NBND}_i`).
+   Initial concentrations for each bound state of each component in the bead solid phase.
+   The length of this field is :math:`\texttt{NBOUND}`.
+   Only in case of a 2D bulk model, the field length *can* also be :math:`\texttt{NBOUND} \cdot \texttt{NRAD}` to specify radial dependence, in which case the ordering is radial position major.
+   If :math:`\texttt{BINDING_PARTYPE_DEPENDENT}` is :math:`0`, the values across different particle types (if multiple particle types are being used) must be the same.
 
    **Unit:** :math:`\mathrm{mol}\,\mathrm{m}_{\mathrm{SP}}^{-3}`
    
@@ -226,7 +233,7 @@ Group /input/model/unit_XXX/particle_type_XXX/discretization
    Node coordinates for the DG element (or FV cell) boundaries (ignored if :math:`\texttt{PAR_DISC_TYPE} \neq \texttt{USER_DEFINED}`).
    The coordinates are relative and have to include the endpoints :math:`0` and :math:`1`.
    They are later linearly mapped to the true radial range :math:`[r_{c,j}, r_{p,j}]`.
-   The coordinates for each particle type are appended to one long vector in type-major ordering.
+   The coordinates for each particle type are appended to one long vector in particle type major ordering.
    
    ================  ========================  ======================================
    **Type:** double  **Range:** :math:`[0,1]`  **Length:** :math:`\texttt{NELEM} + 1`

--- a/src/libcadet/model/ColumnModel1D-InitialConditions.cpp
+++ b/src/libcadet/model/ColumnModel1D-InitialConditions.cpp
@@ -229,7 +229,7 @@ void ColumnModel1D::readInitialCondition(IParameterProvider& paramProvider)
 				for (unsigned int comp = 0; comp < _disc.nComp; ++comp)
 				{
 					if (initCp.data()[comp] != (_initCp.data() + (parType - 1) * _disc.nComp)[comp])
-						throw InvalidParameterException("Binding models were specified as particle type independent (see field BINDING_PARTYPE_DEPENDENT), but INIT_CP are different for particle type " + std::to_string(parType - 1) + " and " + std::to_string(parType));
+						throw InvalidParameterException("Binding models were specified as particle type independent (see field BINDING_PARTYPE_DEPENDENT), but INIT_CP is different for particle type " + std::to_string(parType - 1) + " and " + std::to_string(parType));
 				}
 			}
 		}
@@ -258,7 +258,7 @@ void ColumnModel1D::readInitialCondition(IParameterProvider& paramProvider)
 			for (unsigned int bnd = 0; bnd < _disc.strideBound[parType]; ++bnd)
 			{
 				if (initCs.data()[bnd] != (_initCs.data() + _disc.nBoundBeforeType[parType - 1])[bnd])
-					throw InvalidParameterException("Binding models were specified as particle type independent (see field BINDING_PARTYPE_DEPENDENT), but INIT_CS are different for particle type " + std::to_string(parType - 1) + " and " + std::to_string(parType));
+					throw InvalidParameterException("Binding models were specified as particle type independent (see field BINDING_PARTYPE_DEPENDENT), but INIT_CS is different for particle type " + std::to_string(parType - 1) + " and " + std::to_string(parType));
 			}
 		}
 

--- a/src/libcadet/model/ColumnModel2D-InitialConditions.cpp
+++ b/src/libcadet/model/ColumnModel2D-InitialConditions.cpp
@@ -452,10 +452,30 @@ void ColumnModel2D::readInitialCondition(IParameterProvider& paramProvider)
 				throw InvalidParameterException("INIT_CP does not contain enough values for all components");
 
 			if (!_singleRadiusInitCp)
+			{
+				if (_singleBinding && parType > 0)
+				{
+					for (int entry = 0; entry < _disc.strideBound[0] * _disc.radNElem; entry++)
+					{
+						if (initC.data()[entry] != _initCp.data()[_disc.nBoundBeforeType[parType - 1] + entry])
+							throw InvalidParameterException("INIT_CP is not the same across particle types but BINDING_PARTYPE_DEPENDENT is False");
+					}
+				}
+
 				for (unsigned int r = 0; r < _disc.radNElem; ++r)
 					ad::copyToAd(initCp.data() + r * _disc.nComp, _initCp.data() + parType * _disc.nComp + r * _disc.nParType * _disc.nComp, _disc.nComp);
+			}
 			else
 			{
+				if (_singleBinding && parType > 0)
+				{
+					for (int entry = 0; entry < _disc.strideBound[0]; entry++)
+					{
+						if (initC.data()[entry] != _initCp.data()[_disc.nBoundBeforeType[parType - 1] + entry])
+							throw InvalidParameterException("INIT_CP is not the same across particle types but BINDING_PARTYPE_DEPENDENT is False");
+					}
+				}
+
 				for (unsigned int r = 0; r < _disc.radNElem; ++r)
 					ad::copyToAd(initCp.data(), _initCp.data() + parType * _disc.nComp + r * _disc.nParType * _disc.nComp, _disc.nComp);
 			}
@@ -466,11 +486,29 @@ void ColumnModel2D::readInitialCondition(IParameterProvider& paramProvider)
 
 			if (!_singleRadiusInitCp)
 			{
+				if (_singleBinding && parType > 0)
+				{
+					for (int entry = 0; entry < _disc.strideBound[0] * _disc.radNElem; entry++)
+					{
+						if (initC.data()[entry] != _initCp.data()[_disc.nBoundBeforeType[parType - 1] + entry])
+							throw InvalidParameterException("INIT_CP is not the same across particle types but BINDING_PARTYPE_DEPENDENT is False");
+					}
+				}
+
 				for (unsigned int r = 0; r < _disc.radNElem; ++r)
 					ad::copyToAd(initC.data() + r * _disc.nComp, _initCp.data() + parType * _disc.nComp + r * _disc.nComp * _disc.nParType, _disc.nComp);
 			}
 			else
 			{
+				if (_singleBinding && parType > 0)
+				{
+					for (int entry = 0; entry < _disc.strideBound[0]; entry++)
+					{
+						if (initC.data()[entry] != _initCp.data()[_disc.nBoundBeforeType[parType - 1] + entry])
+							throw InvalidParameterException("INIT_CP is not the same across particle types but BINDING_PARTYPE_DEPENDENT is False");
+					}
+				}
+
 				for (unsigned int r = 0; r < _disc.radNElem; ++r)
 					ad::copyToAd(initC.data(), _initCp.data() + parType * _disc.nComp + r * _disc.nComp * _disc.nParType, _disc.nComp);
 			}
@@ -497,13 +535,31 @@ void ColumnModel2D::readInitialCondition(IParameterProvider& paramProvider)
 
 		if (!_singleRadiusInitCs)
 		{
+			if (_singleBinding && parType > 0)
+			{
+				for (int entry = 0; entry < _disc.strideBound[0] * _disc.radNElem; entry++)
+				{
+					if (initCs.data()[entry] != _initCs.data()[_disc.nBoundBeforeType[parType - 1] + entry])
+						throw InvalidParameterException("INIT_CS is not the same across particle types but BINDING_PARTYPE_DEPENDENT is False");
+				}
+			}
+
 			for (unsigned int r = 0; r < _disc.radNElem; ++r)
-				ad::copyToAd(initCs.data() + r * _disc.strideBound[parType], _initCs.data() + parType * _disc.strideBound[parType] + r * _disc.strideBound[parType] * _disc.nParType, _disc.strideBound[parType]);
+				ad::copyToAd(initCs.data() + r * _disc.strideBound[0], _initCs.data() + _disc.nBoundBeforeType[parType] + r * _disc.strideBound[_disc.nParType], _disc.strideBound[parType]);
 		}
-		else if (!_singleBinding && _singleRadiusInitCs)
+		else
 		{
+			if (_singleBinding && parType > 0)
+			{
+				for (int entry = 0; entry < _disc.strideBound[0] * _disc.radNElem; entry++)
+				{
+					if (initCs.data()[entry] != _initCs.data()[_disc.nBoundBeforeType[parType - 1] + entry])
+						throw InvalidParameterException("INIT_CS is not the same across particle types but BINDING_PARTYPE_DEPENDENT is False");
+				}
+			}
+
 			for (unsigned int r = 0; r < _disc.radNElem; ++r)
-				ad::copyToAd(initCs.data(), _initCs.data() + parType * _disc.strideBound[parType] + r * _disc.strideBound[parType] * _disc.nParType, _disc.strideBound[parType]);
+				ad::copyToAd(initCs.data(), _initCs.data() + _disc.nBoundBeforeType[parType] + r * _disc.strideBound[_disc.nParType], _disc.strideBound[parType]);
 		}
 	}
 }

--- a/src/libcadet/model/GeneralRateModel2D-InitialConditions.cpp
+++ b/src/libcadet/model/GeneralRateModel2D-InitialConditions.cpp
@@ -451,10 +451,30 @@ void GeneralRateModel2D::readInitialCondition(IParameterProvider& paramProvider)
 				throw InvalidParameterException("INIT_CP does not contain enough values for all components");
 
 			if (!_singleRadiusInitCp)
+			{
+				if (_singleBinding && parType > 0)
+				{
+					for (int entry = 0; entry < _disc.strideBound[0] * _disc.nRad; entry++)
+					{
+						if (initC.data()[entry] != _initCp.data()[_disc.nBoundBeforeType[parType - 1] + entry])
+							throw InvalidParameterException("Binding models were specified as particle type independent (see field BINDING_PARTYPE_DEPENDENT), but INIT_CP is different for particle type " + std::to_string(parType - 1) + " and " + std::to_string(parType));
+					}
+				}
+
 				for (unsigned int r = 0; r < _disc.nRad; ++r)
 					ad::copyToAd(initCp.data() + r * _disc.nComp, _initCp.data() + parType * _disc.nComp + r * _disc.nParType * _disc.nComp, _disc.nComp);
+			}
 			else
 			{
+				if (_singleBinding && parType > 0)
+				{
+					for (int entry = 0; entry < _disc.strideBound[0]; entry++)
+					{
+						if (initC.data()[entry] != _initCp.data()[_disc.nBoundBeforeType[parType - 1] + entry])
+							throw InvalidParameterException("Binding models were specified as particle type independent (see field BINDING_PARTYPE_DEPENDENT), but INIT_CP is different for particle type " + std::to_string(parType - 1) + " and " + std::to_string(parType));
+					}
+				}
+
 				for (unsigned int r = 0; r < _disc.nRad; ++r)
 					ad::copyToAd(initCp.data(), _initCp.data() + parType * _disc.nComp + r * _disc.nParType * _disc.nComp, _disc.nComp);
 			}
@@ -465,11 +485,29 @@ void GeneralRateModel2D::readInitialCondition(IParameterProvider& paramProvider)
 
 			if (!_singleRadiusInitCp)
 			{
+				if (_singleBinding && parType > 0)
+				{
+					for (int entry = 0; entry < _disc.strideBound[0] * _disc.nRad; entry++)
+					{
+						if (initC.data()[entry] != _initCp.data()[_disc.nBoundBeforeType[parType - 1] + entry])
+							throw InvalidParameterException("Binding models were specified as particle type independent (see field BINDING_PARTYPE_DEPENDENT), but INIT_CP is different for particle type " + std::to_string(parType - 1) + " and " + std::to_string(parType));
+					}
+				}
+
 				for (unsigned int r = 0; r < _disc.nRad; ++r)
 					ad::copyToAd(initC.data() + r * _disc.nComp, _initCp.data() + parType * _disc.nComp + r * _disc.nComp * _disc.nParType, _disc.nComp);
 			}
 			else
 			{
+				if (_singleBinding && parType > 0)
+				{
+					for (int entry = 0; entry < _disc.strideBound[0]; entry++)
+					{
+						if (initC.data()[entry] != _initCp.data()[_disc.nBoundBeforeType[parType - 1] + entry])
+							throw InvalidParameterException("Binding models were specified as particle type independent (see field BINDING_PARTYPE_DEPENDENT), but INIT_CP is different for particle type " + std::to_string(parType - 1) + " and " + std::to_string(parType));
+					}
+				}
+
 				for (unsigned int r = 0; r < _disc.nRad; ++r)
 					ad::copyToAd(initC.data(), _initCp.data() + parType * _disc.nComp + r * _disc.nComp * _disc.nParType, _disc.nComp);
 			}
@@ -496,11 +534,29 @@ void GeneralRateModel2D::readInitialCondition(IParameterProvider& paramProvider)
 
 		if (!_singleRadiusInitCs)
 		{
+			if (_singleBinding && parType > 0)
+			{
+				for (int entry = 0; entry < _disc.strideBound[0] * _disc.nRad; entry++)
+				{
+					if (initCs.data()[entry] != _initCs.data()[_disc.nBoundBeforeType[parType - 1] + entry])
+						throw InvalidParameterException("Binding models were specified as particle type independent (see field BINDING_PARTYPE_DEPENDENT), but INIT_CS is different for particle type " + std::to_string(parType - 1) + " and " + std::to_string(parType));
+				}
+			}
+
 			for (unsigned int r = 0; r < _disc.nRad; ++r)
 				ad::copyToAd(initCs.data() + r * _disc.strideBound[0], _initCs.data() + _disc.nBoundBeforeType[parType] + r * _disc.strideBound[_disc.nParType], _disc.strideBound[parType]);
 		}
-		else if (!_singleBinding && _singleRadiusInitCs)
+		else
 		{
+			if (_singleBinding && parType > 0)
+			{
+				for (int entry = 0; entry < _disc.strideBound[0] * _disc.nRad; entry++)
+				{
+					if (initCs.data()[entry] != _initCs.data()[_disc.nBoundBeforeType[parType - 1] + entry])
+						throw InvalidParameterException("Binding models were specified as particle type independent (see field BINDING_PARTYPE_DEPENDENT), but INIT_CS is different for particle type " + std::to_string(parType - 1) + " and " + std::to_string(parType));
+				}
+			}
+
 			for (unsigned int r = 0; r < _disc.nRad; ++r)
 				ad::copyToAd(initCs.data(), _initCs.data() + _disc.nBoundBeforeType[parType] + r * _disc.strideBound[_disc.nParType], _disc.strideBound[parType]);
 		}


### PR DESCRIPTION
When `BINDING_PARTYPE_DEPENDENT` is False, the initial conditions for $c^p, c^s$ have to be the same across particle types. This PR adds a check and exception for inconsistent values.