### PR TITLE
Fix local variable shadowing issues

### DIFF
--- a/include/common/Driver.hpp
+++ b/include/common/Driver.hpp
@@ -333,8 +333,8 @@ public:
 				// Convert to ParameterIds
 				std::vector<cadet::ParameterId> sensParams;
 				sensParams.reserve(sensName.size());
-				for (std::size_t i = 0; i < sensName.size(); ++i)
-					sensParams.push_back(cadet::makeParamId(sensName[i], sensUnit[i], sensComp[i], sensParType[i], sensBoundState[i], sensReaction[i], sensSection[i]));
+				for (std::size_t sensIdx = 0; sensIdx < sensName.size(); ++sensIdx)
+					sensParams.push_back(cadet::makeParamId(sensName[sensIdx], sensUnit[sensIdx], sensComp[sensIdx], sensParType[sensIdx], sensBoundState[sensIdx], sensReaction[sensIdx], sensSection[sensIdx]));
 
 				double sensTol = 1e-05;
 				if (pp.exists("SENS_ABSTOL"))
@@ -593,7 +593,6 @@ public:
 			const std::vector<double const*> lastY = _sim->getLastSensitivities(len);
 			const std::vector<double const*> lastYdot = _sim->getLastSensitivityDerivatives(len);
 
-			std::ostringstream oss;
 			for (std::size_t i = 0; i < lastY.size(); ++i)
 			{
 				oss.str("");
@@ -624,14 +623,14 @@ public:
 
 			const int nSens = lastSens.size();
 
-			for (int i = 0; i < nSens; i++)
+			for (int sensIdx = 0; sensIdx < nSens; sensIdx++)
 			{
 				oss.str("");
-				oss << std::setfill('0') << std::setw(3) << std::setprecision(0) << i;
+				oss << std::setfill('0') << std::setw(3) << std::setprecision(0) << sensIdx;
 				writer.pushGroup("param_" + oss.str());
 				writer.pushGroup(unitID);
-				writer.template vector<double>("LAST_SENS_Y", sliceEnd - sliceStart, lastSens[i] + sliceStart);
-				writer.template vector<double>("LAST_SENS_YDOT", sliceEnd - sliceStart, lastSensdot[i] + sliceStart);
+				writer.template vector<double>("LAST_SENS_Y", sliceEnd - sliceStart, lastSens[sensIdx] + sliceStart);
+				writer.template vector<double>("LAST_SENS_YDOT", sliceEnd - sliceStart, lastSensdot[sensIdx] + sliceStart);
 				writer.popGroup();
 				writer.popGroup();
 			}

--- a/src/libcadet/model/StirredTankModel.cpp
+++ b/src/libcadet/model/StirredTankModel.cpp
@@ -1468,7 +1468,6 @@ int CSTRModel::residualImpl(double t, unsigned int secIdx, StateType const* cons
 						-1.0, jacFlux.row(0), jacFlux.row(_nComp), subAlloc);
 
 					idx = 0;
-					const double liquidFactor = static_cast<double>(vsolid) * static_cast<double>(_parTypeVolFrac[type]);
 					for (unsigned int comp = 0; comp < _nComp; ++comp)
 					{
 						// Add bulk part of reaction to mobile phase Jacobian
@@ -1478,8 +1477,8 @@ int CSTRModel::residualImpl(double t, unsigned int secIdx, StateType const* cons
 						for (unsigned int bnd = 0; bnd < _nBound[type * _nComp + comp]; ++bnd, ++idx)
 						{
 							// Add Jacobian row to mobile phase
-							jacFlux.addSubmatrixTo(_jac, liquidFactor, _nComp + idx, 0, 1, _nComp, comp, 0);
-							jacFlux.addSubmatrixTo(_jac, liquidFactor, _nComp + idx, _nComp, 1, _strideBound[type], comp, _nComp + _offsetParType[type]);
+							jacFlux.addSubmatrixTo(_jac, static_cast<double>(liquidFactor), _nComp + idx, 0, 1, _nComp, comp, 0);
+							jacFlux.addSubmatrixTo(_jac, static_cast<double>(liquidFactor), _nComp + idx, _nComp, 1, _strideBound[type], comp, _nComp + _offsetParType[type]);
 
 							if (!qsReaction[idx])
 							{
@@ -1795,10 +1794,10 @@ void CSTRModel::consistentInitialSensitivity(const SimulationTime& simTime, cons
 				continue;
 
 			double* const localQdot = sensYdot + 2 * _nComp + _offsetParType[type];
-			int const* const localMask = mask.mask + _offsetParType[type];
+			int const* const localMask2 = mask.mask + _offsetParType[type];
 			for (unsigned int i = 0; i < _strideBound[type]; ++i)
 			{
-				if (!localMask[i])
+				if (!localMask2[i])
 					continue;
 
 				const unsigned int idx = _nComp + _offsetParType[type] + i;

--- a/src/libcadet/model/particle/HomogeneousParticle.cpp
+++ b/src/libcadet/model/particle/HomogeneousParticle.cpp
@@ -119,7 +119,6 @@ namespace model
 			_nBound = std::make_shared<unsigned int[]>(_nComp, 0);
 		else
 		{
-			std::vector<int> nBound = paramProvider.getIntArray("NBOUND");
 			if (nBound.size() != _nComp)
 				throw InvalidParameterException("Field NBOUND does not contain NCOMP = " + std::to_string(_nComp) + " entries for particle type " + std::to_string(_parTypeIdx));
 

--- a/src/libcadet/model/parts/BindingCellKernel.hpp
+++ b/src/libcadet/model/parts/BindingCellKernel.hpp
@@ -209,18 +209,18 @@ namespace cell
 						// static_cast should be sufficient here, but this statement is also analyzed when wantJac = false
 							params.reaction->getDynReactionVector("cross_phase")[ reac]->analyticJacobianCombinedAdd(t, secIdx, colPos, reinterpret_cast<double const*>(y), reinterpret_cast<double const*>(y + params.nComp), -1.0, jacBase, dmv.row(0, params.nComp), buffer);
 
-						unsigned int idx = 0;
+						unsigned int idx2 = 0;
 						for (unsigned int comp = 0; comp < params.nComp; ++comp)
 						{
-							for (unsigned int bnd = 0; bnd < params.nBound[comp]; ++bnd, ++idx)
+							for (unsigned int bnd = 0; bnd < params.nBound[comp]; ++bnd, ++idx2)
 							{
 									// Add Jacobian row to mobile  	inline void addArray(double const* row, int startDiag, int length, double factor)
-									(jacBase + comp).addArray(dmv.rowPtr(idx), -static_cast<int>(comp), dmv.columns(), static_cast<double>(invBetaP[comp]));
+									(jacBase + comp).addArray(dmv.rowPtr(idx2), -static_cast<int>(comp), dmv.columns(), static_cast<double>(invBetaP[comp]));
 
-								if (!params.qsReaction[idx])
+								if (!params.qsReaction[idx2])
 								{
 									// Add Jacobian row to solid phase
-									(jacBase + params.nComp + idx).addArray(dmv.rowPtr(idx), -static_cast<int>(params.nComp + idx), dmv.columns(), 1.0);
+									(jacBase + params.nComp + idx2).addArray(dmv.rowPtr(idx2), -static_cast<int>(params.nComp + idx2), dmv.columns(), 1.0);
 								}
 							}
 						}
@@ -296,17 +296,17 @@ namespace cell
 					// static_cast should be sufficient here, but this statement is also analyzed when wantJac = false
 						params.reaction->getDynReactionVector("solid")[reac]->analyticJacobianAdd(t, secIdx, colPos, params.nTotalBound, reinterpret_cast<double const*>(y + params.nComp), -1.0, dmv.row(0, params.nComp), buffer);
 
-						unsigned int idx = 0;
+						unsigned int idx2 = 0;
 						for (unsigned int comp = 0; comp < params.nComp; ++comp)
 						{
-							for (unsigned int bnd = 0; bnd < params.nBound[comp]; ++bnd, ++idx)
+							for (unsigned int bnd = 0; bnd < params.nBound[comp]; ++bnd, ++idx2)
 							{
-								(jacBase + comp).addArray(dmv.rowPtr(idx), -static_cast<int>(comp), dmv.columns(), static_cast<double>(invBetaP[comp]));
+								(jacBase + comp).addArray(dmv.rowPtr(idx2), -static_cast<int>(comp), dmv.columns(), static_cast<double>(invBetaP[comp]));
 
-								if (!params.qsReaction[idx])
+								if (!params.qsReaction[idx2])
 								{
 									// Add Jacobian row to solid phase
-									(jacBase + params.nComp + idx).addArray(dmv.rowPtr(idx), -static_cast<int>(params.nComp + idx), dmv.columns(), 1.0);
+									(jacBase + params.nComp + idx2).addArray(dmv.rowPtr(idx2), -static_cast<int>(params.nComp + idx2), dmv.columns(), 1.0);
 								}
 							}
 						}


### PR DESCRIPTION
This PR fixes multiple local variable overshadowings.

related PRs, where those were actual errors:
#559 
#560

(I updated to VS 2026 which i guess is more rigorous with such warnings/errors and made me fix this)