### PR TITLE
Update `FILE_FORMAT` to comply with SemVer (start at 1.0.0-pre-release)

### DIFF
--- a/include/common/Driver.hpp
+++ b/include/common/Driver.hpp
@@ -663,7 +663,7 @@ public:
 		writer.scalar("TIME_SIM", _sim->lastSimulationDuration());
 
 		if (!writer.exists("FILE_FORMAT"))
-			writer.scalar("FILE_FORMAT", "1.0.0-alpha.1");
+			writer.scalar("FILE_FORMAT", std::string("1.0.0-alpha.1"));
 
 		writer.popGroup();
 	}


### PR DESCRIPTION
With the interface changes in preparation of v6, we have to update the file format, which this commit rectifies, shouldve been done already as per v6.0.0-alpha.1.

@schmoelder what do you think would be a good format number here?
I wanted to reserve 6xxxx for when version 6 is actually published. Technically the file format and cadet-core versions dont have to match but to avoid ambiguity I though we should not use 51000 since this does not correspond to cadet-core v5.1.x.
Instead, I thought we can use 5900x and increase the number by one every time the file format changes as part of a core v6 pre-release?
