### PR TITLE
Make field `CRY_MODE` mandatory for crystallization models

### DIFF
--- a/src/libcadet/model/reaction/CrystallizationReaction.cpp
+++ b/src/libcadet/model/reaction/CrystallizationReaction.cpp
@@ -265,10 +265,7 @@ public:
 
 	virtual bool configure(IParameterProvider& paramProvider, UnitOpIdx unitOpIdx, ParticleTypeIdx parTypeIdx)
 	{
-		if (paramProvider.exists("CRY_MODE"))
-			_mode.SetMode(paramProvider.getInt("CRY_MODE"));
-		else
-			_mode.SetMode(1); // For backwards compatibility: PBM as default
+		_mode.SetMode(paramProvider.getInt("CRY_MODE"));
 
 		if (_mode.hasPBM())
 		{

--- a/test/data/model_cry_CSTR_PBM_growthSizeDep_benchmark1.json
+++ b/test/data/model_cry_CSTR_PBM_growthSizeDep_benchmark1.json
@@ -558,11 +558,11 @@
         "NCOMP": 102,
         "CONST_SOLID_VOLUME": 0.0,
         "NREAC_LIQUID": 1,
-        "CRYSTALLIZATION_MODE": 0,
         "UNIT_TYPE": "CSTR",
         "USE_ANALYTIC_JACOBIAN": 1,
         "liquid_reaction_000": {
           "TYPE": "CRYSTALLIZATION",
+          "CRY_MODE": 1,
           "CRY_A": 1.0,
           "CRY_B": 2.0,
           "CRY_BINS": [
@@ -672,7 +672,7 @@
           "CRY_GROWTH_CONSTANT": 100000000.0,
           "CRY_GROWTH_DISPERSION_RATE": 0.0,
           "CRY_GROWTH_RATE_CONSTANT": 2e-08,
-                "CRY_GROWTH_SCHEME_ORDER": 1,
+          "CRY_GROWTH_SCHEME_ORDER": 1,
           "CRY_K": 1.0,
           "CRY_NUCLEI_MASS_DENSITY": 1200.0,
           "CRY_P": 1.5,

--- a/test/data/model_cry_CSTR_PBM_growth_benchmark1.json
+++ b/test/data/model_cry_CSTR_PBM_growth_benchmark1.json
@@ -558,11 +558,11 @@
         "NCOMP": 102,
         "CONST_SOLID_VOLUME": 0.0,
         "NREAC_LIQUID": 1,
-        "CRYSTALLIZATION_MODE": 0,
         "UNIT_TYPE": "CSTR",
         "USE_ANALYTIC_JACOBIAN": 1,
         "liquid_reaction_000": {
           "TYPE": "CRYSTALLIZATION",
+          "CRY_MODE": 1,
           "CRY_A": 1.0,
           "CRY_B": 2.0,
           "CRY_BINS": [

--- a/test/data/model_cry_CSTR_PBM_primaryNucleationAndGrowth_benchmark1.json
+++ b/test/data/model_cry_CSTR_PBM_primaryNucleationAndGrowth_benchmark1.json
@@ -558,11 +558,11 @@
         "NCOMP": 102,
         "CONST_SOLID_VOLUME": 0.0,
         "NREAC_LIQUID": 1,
-        "CRYSTALLIZATION_MODE": 0,
         "UNIT_TYPE": "CSTR",
         "USE_ANALYTIC_JACOBIAN": 1,
         "liquid_reaction_000": {
-        "TYPE": "CRYSTALLIZATION",
+          "TYPE": "CRYSTALLIZATION",
+          "CRY_MODE": 1,
           "CRY_A": 1.0,
           "CRY_B": 2.0,
           "CRY_BINS": [

--- a/test/data/model_cry_CSTR_PBM_primaryNucleationGrowthGrowthRateDispersion_benchmark1.json
+++ b/test/data/model_cry_CSTR_PBM_primaryNucleationGrowthGrowthRateDispersion_benchmark1.json
@@ -558,11 +558,11 @@
         "NCOMP": 102,
         "CONST_SOLID_VOLUME": 0.0,
         "NREAC_LIQUID": 1,
-        "CRYSTALLIZATION_MODE": 0,
         "UNIT_TYPE": "CSTR",
         "USE_ANALYTIC_JACOBIAN": 1,
         "liquid_reaction_000": {
           "TYPE": "CRYSTALLIZATION",
+          "CRY_MODE": 1,
           "CRY_A": 1.0,
           "CRY_B": 2.0,
           "CRY_BINS": [

--- a/test/data/model_cry_CSTR_PBM_primarySecondaryNucleationAndGrowth_benchmark1.json
+++ b/test/data/model_cry_CSTR_PBM_primarySecondaryNucleationAndGrowth_benchmark1.json
@@ -558,11 +558,11 @@
         "NCOMP": 102,
         "CONST_SOLID_VOLUME": 0.0,
         "NREAC_LIQUID": 1,
-        "CRYSTALLIZATION_MODE": 0,
         "UNIT_TYPE": "CSTR",
         "USE_ANALYTIC_JACOBIAN": 1,
         "liquid_reaction_000": {
           "TYPE": "CRYSTALLIZATION",
+          "CRY_MODE": 1,
           "CRY_A": 1.0,
           "CRY_B": 2.0,
           "CRY_BINS": [

--- a/test/data/model_cry_DPFR_PBM_primarySecondaryNucleationGrowth_benchmark1.json
+++ b/test/data/model_cry_DPFR_PBM_primarySecondaryNucleationGrowth_benchmark1.json
@@ -310,7 +310,6 @@
         ],
         "NCOMP": 52,
         "NREAC_LIQUID": 1,
-        "CRYSTALLIZATION_MODE": 0,
         "TOTAL_POROSITY": 0.21,
         "particle_type_000": {
           "HAS_FILM_DIFFUSION": false,
@@ -387,7 +386,8 @@
           }
         },
         "liquid_reaction_000": {
-            "TYPE": "CRYSTALLIZATION",
+          "TYPE": "CRYSTALLIZATION",
+          "CRY_MODE": 1,
           "CRY_A": 1.0,
           "CRY_B": 2.0,
           "CRY_BINS": [


### PR DESCRIPTION
Explicit is better than implicit