### PR TITLE
MCT: add sensitivities for channel cross section areas

### DIFF
--- a/src/libcadet/model/exchange/LangumirExchange.cpp
+++ b/src/libcadet/model/exchange/LangumirExchange.cpp
@@ -67,8 +67,24 @@ public:
 	{
 		_parameters.clear();
 		readParameterMatrix(_exchangeMatrix, paramProvider, "EXCHANGE_MATRIX", _nChannel * _nChannel * _nComp, 1); // include parameterPeaderHelp in exchange modul
-		_crossSections = paramProvider.getDoubleArray("CHANNEL_CROSS_SECTION_AREAS");
+		readScalarParameterOrArray(_crossSections, paramProvider,"CHANNEL_CROSS_SECTION_AREAS", 1);
 		readParameterMatrix(_saturationMatrix, paramProvider, "SATURATION_MATRIX", _nChannel * _nComp, 1);
+
+		registerParam3DArray(parameters, _exchangeMatrix, [=](bool multi, unsigned int channelSrc, unsigned int channelDest, unsigned comp)
+		{
+		return makeParamId(hashString("EXCHANGE_MATRIX"), unitOpIdx, multi ? comp : CompIndep, channelDest, channelSrc, ReactionIndep, SectionIndep);
+		}, _nComp, _nChannel); // particleType -> channelDest, BoundState -> channelSrc
+
+		registerParam1DArray(parameters, _crossSections, [=](bool multi, unsigned int channel)
+		{
+		return makeParamId(hashString("CHANNEL_CROSS_SECTION_AREAS"), unitOpIdx, CompIndep, channel, BoundStateIndep, ReactionIndep, SectionIndep); // particleType -> Channel
+		});
+
+		registerParam2DArray(parameters, _saturationMatrix, [=](bool multi, unsigned int channel, unsigned int comp)
+		{
+		return makeParamId(hashString("SATURATION_MATRIX"), unitOpIdx, multi ? comp : CompIndep, channel, BoundStateIndep, ReactionIndep, SectionIndep);
+		}, _nComp); // particleType -> channel
+
 
 		return true;
 	}
@@ -176,7 +192,7 @@ protected:
 	unsigned int _nCol; //!< Number of columns
 
 	std::vector<active> _exchangeMatrix; //!< Matrix of exchange coeffs for the langmuir inter-channel transport
-	std::vector<double> _crossSections; //!< Cross sections of the channels
+	std::vector<active> _crossSections; //!< Cross sections of the channels
 	std::vector<active> _saturationMatrix; //!< Capacity of the channels -> double  ncomp x nchannel
 	//parts::MultiChannelConvectionDispersionOperator _conDis; //!< Convection dispersion operator
 

--- a/src/libcadet/model/exchange/LinearExchange.cpp
+++ b/src/libcadet/model/exchange/LinearExchange.cpp
@@ -65,12 +65,17 @@ public:
 	{
 		_parameters.clear();
 		readParameterMatrix(_exchangeMatrix, paramProvider, "EXCHANGE_MATRIX", _nChannel * _nChannel * _nComp, 1); // TODO include parameterPeaderHelp in exchange modul
-		_crossSections = paramProvider.getDoubleArray("CHANNEL_CROSS_SECTION_AREAS");
+		readScalarParameterOrArray(_crossSections, paramProvider,"CHANNEL_CROSS_SECTION_AREAS", 1);
 
 		registerParam3DArray(parameters, _exchangeMatrix, [=](bool multi, unsigned int channelSrc, unsigned int channelDest, unsigned comp)
 		{
 		return makeParamId(hashString("EXCHANGE_MATRIX"), unitOpIdx, multi ? comp : CompIndep, channelDest, channelSrc, ReactionIndep, SectionIndep);
 		}, _nComp, _nChannel);
+
+		registerParam1DArray(parameters, _crossSections, [=](bool multi, unsigned int channel)
+		{
+		return makeParamId(hashString("CHANNEL_CROSS_SECTION_AREAS"), unitOpIdx, CompIndep, channel, BoundStateIndep, ReactionIndep, SectionIndep); // particleType -> Channel
+		});
 
 		return true;
 	}
@@ -174,7 +179,7 @@ protected:
 	std::vector<int> _reactionQuasistationarity; //!< Determines whether each bound state is quasi-stationary (@c true) or not (@c false)
 
 	std::vector<active> _exchangeMatrix; //!< Matrix of exchange coeffs for the linear inter-channel transport
-	std::vector<double> _crossSections; //!< Cross sections of the channels
+	std::vector<active> _crossSections; //!< Cross sections of the channels
 
 	std::unordered_map<ParameterId, active*> _parameters; //!< Map used to translate ParameterIds to actual variables
 


### PR DESCRIPTION
This PR resolves  #553. 


The cross-section area is also used in the convection-dispersion operator of the MCT model but wasn’t registered here.  Adding the registration makes the plots from the script provided by @hannahlanzrath look much better. 

The sensitivity in the second plot differs slightly at the end, @hannahlanzrath. What do you think is expected?

<img width="600" height="600" alt="Figure_1" src="https://github.com/user-attachments/assets/459e6c94-2b4b-4356-8d8e-6a420b204f17" />
<img width="640" height="480" alt="sens_traj" src="https://github.com/user-attachments/assets/2548934d-646e-48ae-aaac-081eba93240a" />


