### PR TITLE
CI: upgrade Ubuntu runner to GCC 13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,6 +186,12 @@ jobs:
             libblas-dev \
             libtbb-dev \
             libsuperlu-dev \
+      - name: Show compiler versions
+        run: |
+          which gcc
+          which g++
+          gcc --version
+          g++ --version
       - name: Build Eigen
         run: |
           git clone https://gitlab.com/libeigen/eigen.git


### PR DESCRIPTION
- Install GCC 13 and G++ 13 from the Ubuntu Toolchain PPA.
- Make GCC 13 the default compiler for the CI workflow.
- Enables use of C++20 features on ubuntu-latest runner.