### PR TITLE
CI: fix run for `ready_for_review` draft PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ on:
       - master
       - dev
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths-ignore:
       - 'doc/**'
       - 'doc/ISSUE_TEMPLATE'
@@ -53,7 +54,7 @@ on:
 jobs:
 
   Win64:
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    if: github.event.pull_request == null || github.event.pull_request.draft == false
     runs-on: windows-latest
     strategy:
       fail-fast: true
@@ -158,7 +159,7 @@ jobs:
           path: ${{ github.workspace }}/cadet-${{ runner.os }}.zip
 
   Ubuntu-latest:
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    if: github.event.pull_request == null || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true
@@ -259,7 +260,7 @@ jobs:
           ${BUILD_DIR}/test/testRunner [CI]
 
   MacOS:
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    if: github.event.pull_request == null || github.event.pull_request.draft == false
     runs-on: macos-latest
     strategy:
       fail-fast: true


### PR DESCRIPTION
Ready for review drafts are not running in the CI since drafts were excluded, which this commit fixes.