### PR TITLE
Add simulation step function to C-API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,9 @@ jobs:
           .\cadet-cli.exe --version
           .\createLWE.exe
           .\cadet-cli.exe LWE.h5
+      - name: Run CI test CAPI
+        run: |
+          & "${env:BUILD_DIR}\test\testCAPIv1.exe"
       - name: Upload Artifacts
         uses: actions/upload-artifact@v7
         with:
@@ -274,6 +277,10 @@ jobs:
         if: always() && steps.build.conclusion == 'success'
         run: |
           ${BUILD_DIR}/test/testRunner [CI]
+      - name: Run CI test CAPI
+        if: always() && steps.build.conclusion == 'success'
+        run: |
+          ${BUILD_DIR}/test/testCAPIv1
 
   MacOS:
     if: github.event.pull_request == null || github.event.pull_request.draft == false
@@ -313,4 +320,7 @@ jobs:
           ${INSTALL_PREFIX}/bin/cadet-cli --version
           ${INSTALL_PREFIX}/bin/createLWE
           ${INSTALL_PREFIX}/bin/cadet-cli LWE.h5
+      - name: Run CI test CAPI
+        run: |
+          ${BUILD_DIR}/test/testCAPIv1
 

--- a/.github/workflows/ci_coverage.yml
+++ b/.github/workflows/ci_coverage.yml
@@ -172,6 +172,10 @@ jobs:
         if: always() && steps.build.conclusion == 'success'
         run: |
           ${BUILD_DIR}/test/testRunner [CI]
+      - name: Run CI test CAPI
+        if: always() && steps.build.conclusion == 'success'
+        run: |
+          ${BUILD_DIR}/test/testCAPIv1
 
       - name: Generate Coverage Report
         run: |

--- a/include/cadet/Simulator.hpp
+++ b/include/cadet/Simulator.hpp
@@ -727,6 +727,12 @@ public:
 	 * @param[in] nc Object to receive notifications or @c nullptr to disable notifications
 	 */
 	virtual void setNotificationCallback(INotificationCallback* nc) CADET_NOEXCEPT = 0;
+
+	virtual void  prepareIntegrator() = 0;
+
+    virtual int integrateStep(double tEnd, double& tReached) = 0;
+
+	virtual int reinitialize(double currentTime) = 0;
 };
 
 } // namespace cadet

--- a/include/cadet/cadet.h
+++ b/include/cadet/cadet.h
@@ -1064,7 +1064,7 @@ extern "C"
 	CADET_API cdtResult cdtGetAPIv1_0_0(cdtAPIv1_0_0* ptr);
 
 	/**
-	 * Holds function pointers to API version 1
+	 * Holds function pointers to API version 1.1a1
 	 */
 	typedef struct
 	{
@@ -1766,6 +1766,711 @@ extern "C"
 	 * @return     Success (>= 0) if the API is available, otherwise error (< 0)
 	 */
 	CADET_API cdtResult cdtGetAPIv1_1_0a1(cdtAPIv1_1_0a1* ptr);
+
+	/**
+	 * Holds function pointers to API version 1.1a2
+	 */
+	typedef struct
+	{
+		/**
+		 * @brief Return the current file format version
+		 * @param [out] fileFormat The current file format
+		 */
+		cdtResult(*getFileFormat)(int* fileFormat);
+
+		/**
+		 * @brief Creates a driver that handles simulation on a high level
+		 * @return Driver handle or @c NULL if an error occurred
+		 */
+		cdtDriver* (*createDriver)(void);
+
+		/**
+		 * @brief Deletes a driver created by createDriver
+		 * @param[in] drv Driver handle
+		 */
+		void (*deleteDriver)(cdtDriver* drv);
+
+		/**
+		 * @brief Runs a full simulation using the given driver and parameter provider
+		 * @param[in] drv Driver handle
+		 * @param[in] paramProvider Callback parameter provider
+		 * @return @c cdtOK on success, a negative value indicating the error otherwise
+		 */
+		cdtResult(*runSimulation)(cdtDriver* drv, cdtParameterProvider const* paramProvider);
+
+		/**
+		 * @brief Returns the number of unit operations
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 * @param [in] drv Driver handle
+		 * @param [out] nUnits Number of unit operations
+		 * @return @c cdtOK on success, a negative value indicating the error otherwise
+		 */
+		cdtResult(*getNumUnitOp)(cdtDriver* drv, int* nUnits);
+
+		/**
+		 * @brief Returns the number of particle types
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 * @param [in] drv Driver handle
+		 * @param [in] unitOpId ID of the unit operation whose solution is returned
+		 * @param [out] nParTypes Number of particle types
+		 * @return @c cdtOK on success, a negative value indicating the error otherwise
+		 */
+		cdtResult(*getNumParTypes)(cdtDriver* drv, int unitOpId, int* nParTypes);
+
+		/**
+		 * @brief Returns the number of parameter sensitivities
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 * @param [in] drv Driver handle
+		 * @param [out] nSens Number of parameter sensitivities
+		 * @return @c cdtOK on success, a negative value indicating the error otherwise
+		 */
+		cdtResult(*getNumSensitivities)(cdtDriver* drv, int* nSens);
+
+		/**
+		 * @brief Returns the solution of the last simulation at unit inlet
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 *          The array pointers are only valid until a new simulation is started.
+		 * @param [in] drv Driver handle
+		 * @param [in] unitOpId ID of the unit operation whose solution is returned
+		 * @param [out] time Time array pointer
+		 * @param [out] data Data array pointer
+		 * @param [out] nTime Number of time points
+		 * @param [out] nPort Number of ports
+		 * @param [out] nComp Number of components
+		 * @return @c cdtOK on success, a negative value indicating the error otherwise
+		 */
+		cdtResult(*getSolutionInlet)(cdtDriver* drv, int unitOpId, double const** time, double const** data, int* nTime, int* nPort, int* nComp);
+
+		/**
+		 * @brief Returns the solution of the last simulation at unit outlet
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 *          The array pointers are only valid until a new simulation is started.
+		 * @param [in] drv Driver handle
+		 * @param [in] unitOpId ID of the unit operation whose solution is returned
+		 * @param [out] time Time array pointer
+		 * @param [out] data Data array pointer
+		 * @param [out] nTime Number of time points
+		 * @param [out] nPort Number of ports
+		 * @param [out] nComp Number of components
+		 * @return @c cdtOK on success, a negative value indicating the error otherwise
+		 */
+		cdtResult(*getSolutionOutlet)(cdtDriver* drv, int unitOpId, double const** time, double const** data, int* nTime, int* nPort, int* nComp);
+
+		/**
+		 * @brief Returns the solution of the last simulation of the column bulk phase
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 *          The array pointers are only valid until a new simulation is started.
+		 * @param [in] drv Driver handle
+		 * @param [in] unitOpId ID of the unit operation whose solution is returned
+		 * @param [out] time Time array pointer
+		 * @param [out] data Data array pointer
+		 * @param [out] nTime Number of time points
+		 * @param [out] nAxialCells Number of axial cells
+		 * @param [out] nRadialCells Number of radial cells
+		 * @param [out] nComp Number of components
+		 * @param [out] keepAxialSingletonDimension Keep axial singleton dimension
+		 * @return @c cdtOK on success, a negative value indicating the error otherwise
+		 */
+		cdtResult(*getSolutionBulk)(cdtDriver* drv, int unitOpId, double const** time, double const** data, int* nTime, int* nAxialCells, int* nRadialCells, int* nComp, bool* keepAxialSingletonDimension);
+
+		/**
+		 * @brief Returns the solution of the last simulation of the column particle liquid phase
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 *          The array pointers are only valid until a new simulation is started.
+		 * @param [in] drv Driver handle
+		 * @param [in] unitOpId ID of the unit operation whose solution is returned
+		 * @param [out] parType Particle type index
+		 * @param [out] time Time array pointer
+		 * @param [out] data Data array pointer
+		 * @param [out] nTime Number of time points
+		 * @param [out] nAxialCells Number of axial cells
+		 * @param [out] nRadialCells Number of ports
+		 * @param [out] nParShells Number of particle shells
+		 * @param [out] nComp Number of components
+		 * @param [out] keepAxialSingletonDimension Keep axial singleton dimension
+		 * @param [out] keepParticleSingletonDimension Keep particle singleton dimension
+		 * @return @c cdtOK on success, a negative value indicating the error otherwise
+		 */
+		cdtResult(*getSolutionParticle)(cdtDriver* drv, int unitOpId, int parType, double const** time, double const** data, int* nTime, int* nAxialCells, int* nRadialCells, int* nParShells, int* nComp, bool* keepAxialSingletonDimension, bool* keepParticleSingletonDimension);
+		/**
+		 * @brief Returns the solution of the last simulation of the column particle solid phase
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 *          The array pointers are only valid until a new simulation is started.
+		 * @param [in] drv Driver handle
+		 * @param [in] unitOpId ID of the unit operation whose solution is returned
+		 * @param [out] parType Particle type index
+		 * @param [out] time Time array pointer
+		 * @param [out] data Data array pointer
+		 * @param [out] nTime Number of time points
+		 * @param [out] nAxialCells Number of axial cells
+		 * @param [out] nRadialCells Number of ports
+		 * @param [out] nParShells Number of particle shells
+		 * @param [out] nBound Number of bound states
+		 * @param [out] keepAxialSingletonDimension Keep axial singleton dimension
+		 * @param [out] keepParticleSingletonDimension Keep particle singleton dimension
+		 * @return @c cdtOK on success, a negative value indicating the error otherwise
+		 */
+		cdtResult(*getSolutionSolid)(cdtDriver* drv, int unitOpId, int parType, double const** time, double const** data, int* nTime, int* nAxialCells, int* nRadialCells, int* nParShells, int* nBound, bool* keepAxialSingletonDimension, bool* keepParticleSingletonDimension);
+
+		/**
+		 * @brief Returns the solution of the last simulation of the column particle flux
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 *          The array pointers are only valid until a new simulation is started.
+		 * @param [in] drv Driver handle
+		 * @param [in] unitOpId ID of the unit operation whose solution is returned
+		 * @param [out] time Time array pointer
+		 * @param [out] data Data array pointer
+		 * @param [out] nTime Number of time points
+		 * @param [out] nAxialCells Number of axial cells
+		 * @param [out] nRadialCells Number of ports
+		 * @param [out] nParticleTypes Number of particle types
+		 * @param [out] nComp Number of components
+		 * @param [out] keepAxialSingletonDimension Keep axial singleton dimension
+		 * @return @c cdtOK on success, a negative value indicating the error otherwise
+		 */
+		cdtResult(*getSolutionFlux)(cdtDriver* drv, int unitOpId, double const** time, double const** data, int* nTime, int* nAxialCells, int* nRadialCells, int* nParticleTypes, int* nComp, bool* keepAxialSingletonDimension);
+
+		/**
+		 * @brief Returns the solution of the last simulation of the unit volume
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 *          The array pointers are only valid until a new simulation is started.
+		 * @param [in] drv Driver handle
+		 * @param [in] unitOpId ID of the unit operation whose solution is returned
+		 * @param [out] time Time array pointer
+		 * @param [out] data Data array pointer
+		 * @return @c cdtOK on success, a negative value indicating the error otherwise
+		 */
+		cdtResult(*getSolutionVolume)(cdtDriver* drv, int unitOpId, double const** time, double const** data, int* nTime);
+
+		/**
+		 * @brief Returns the solution derivative of the last simulation at unit inlet
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 *          The array pointers are only valid until a new simulation is started.
+		 * @param [in] drv Driver handle
+		 * @param [in] unitOpId ID of the unit operation whose solution is returned
+		 * @param [out] time Time array pointer
+		 * @param [out] data Data array pointer
+		 * @param [out] nTime Number of time points
+		 * @param [out] nPort Number of ports
+		 * @param [out] nComp Number of components
+		 * @return @c cdtOK on success, a negative value indicating the error otherwise
+		 */
+		cdtResult(*getSolutionDerivativeInlet)(cdtDriver* drv, int unitOpId, double const** time, double const** data, int* nTime, int* nPort, int* nComp);
+
+		/**
+		 * @brief Returns the solution derivative of the last simulation at unit outlet
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 *          The array pointers are only valid until a new simulation is started.
+		 * @param [in] drv Driver handle
+		 * @param [in] unitOpId ID of the unit operation whose solution is returned
+		 * @param [out] time Time array pointer
+		 * @param [out] data Data array pointer
+		 * @param [out] nTime Number of time points
+		 * @param [out] nPort Number of ports
+		 * @param [out] nComp Number of components
+		 * @return @c cdtOK on success, a negative value indicating the error otherwise
+		 */
+		cdtResult(*getSolutionDerivativeOutlet)(cdtDriver* drv, int unitOpId, double const** time, double const** data, int* nTime, int* nPort, int* nComp);
+
+		/**
+		 * @brief Returns the solution derivative of the last simulation of the column bulk phase
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 *          The array pointers are only valid until a new simulation is started.
+		 * @param [in] drv Driver handle
+		 * @param [in] unitOpId ID of the unit operation whose solution is returned
+		 * @param [out] time Time array pointer
+		 * @param [out] data Data array pointer
+		 * @param [out] nTime Number of time points
+		 * @param [out] nAxialCells Number of axial cells
+		 * @param [out] nRadialCells Number of radial cells
+		 * @param [out] nComp Number of components
+		 * @param [out] keepAxialSingletonDimension Keep axial singleton dimension
+		 * @return @c cdtOK on success, a negative value indicating the error otherwise
+		 */
+		cdtResult(*getSolutionDerivativeBulk)(cdtDriver* drv, int unitOpId, double const** time, double const** data, int* nTime, int* nAxialCells, int* nRadialCells, int* nComp, bool* keepAxialSingletonDimension);
+
+		/**
+		 * @brief Returns the solution derivative of the last simulation of the column particle liquid phase
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 *          The array pointers are only valid until a new simulation is started.
+		 * @param [in] drv Driver handle
+		 * @param [in] unitOpId ID of the unit operation whose solution is returned
+		 * @param [out] parType Particle type index
+		 * @param [out] time Time array pointer
+		 * @param [out] data Data array pointer
+		 * @param [out] nTime Number of time points
+		 * @param [out] nAxialCells Number of axial cells
+		 * @param [out] nRadialCells Number of ports
+		 * @param [out] nParShells Number of particle shells
+		 * @param [out] nComp Number of components
+		 * @param [out] keepAxialSingletonDimension Keep axial singleton dimension
+		 * @param [out] keepParticleSingletonDimension Keep particle singleton dimension
+		 * @return @c cdtOK on success, a negative value indicating the error otherwise
+		 */
+		cdtResult(*getSolutionDerivativeParticle)(cdtDriver* drv, int unitOpId, int parType, double const** time, double const** data, int* nTime, int* nAxialCells, int* nRadialCells, int* nParShells, int* nComp, bool* keepAxialSingletonDimension, bool* keepParticleSingletonDimension);
+
+		/**
+		 * @brief Returns the solution derivative of the last simulation of the column particle solid phase
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 *          The array pointers are only valid until a new simulation is started.
+		 * @param [in] drv Driver handle
+		 * @param [in] unitOpId ID of the unit operation whose solution is returned
+		 * @param [out] parType Particle type index
+		 * @param [out] time Time array pointer
+		 * @param [out] data Data array pointer
+		 * @param [out] nTime Number of time points
+		 * @param [out] nAxialCells Number of axial cells
+		 * @param [out] nRadialCells Number of ports
+		 * @param [out] nParShells Number of particle shells
+		 * @param [out] nBound Number of bound states
+		 * @param [out] keepAxialSingletonDimension Keep axial singleton dimension
+		 * @param [out] keepParticleSingletonDimension Keep particle singleton dimension
+		 * @return @c cdtOK on success, a negative value indicating the error otherwise
+		 */
+		cdtResult(*getSolutionDerivativeSolid)(cdtDriver* drv, int unitOpId, int parType, double const** time, double const** data, int* nTime, int* nAxialCells, int* nRadialCells, int* nParShells, int* nBound, bool* keepAxialSingletonDimension, bool* keepParticleSingletonDimension);
+
+		/**
+		 * @brief Returns the solution derivative of the last simulation of the column particle flux
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 *          The array pointers are only valid until a new simulation is started.
+		 * @param [in] drv Driver handle
+		 * @param [in] unitOpId ID of the unit operation whose solution is returned
+		 * @param [out] time Time array pointer
+		 * @param [out] data Data array pointer
+		 * @param [out] nTime Number of time points
+		 * @param [out] nAxialCells Number of axial cells
+		 * @param [out] nRadialCells Number of ports
+		 * @param [out] nParticleTypes Number of particle types
+		 * @param [out] nComp Number of components
+		 * @param [out] keepAxialSingletonDimension Keep axial singleton dimension
+		 * @return @c cdtOK on success, a negative value indicating the error otherwise
+		 */
+		cdtResult(*getSolutionDerivativeFlux)(cdtDriver* drv, int unitOpId, double const** time, double const** data, int* nTime, int* nAxialCells, int* nRadialCells, int* nParticleTypes, int* nComp, bool* keepAxialSingletonDimension);
+
+		/**
+		 * @brief Returns the solution derivative of the last simulation of the unit volume
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 *          The array pointers are only valid until a new simulation is started.
+		 * @param [in] drv Driver handle
+		 * @param [in] unitOpId ID of the unit operation whose solution is returned
+		 * @param [out] time Time array pointer
+		 * @param [out] data Data array pointer
+		 * @return @c cdtOK on success, a negative value indicating the error otherwise
+		 */
+		cdtResult(*getSolutionDerivativeVolume)(cdtDriver* drv, int unitOpId, double const** time, double const** data, int* nTime);
+
+		/**
+		 * @brief Returns the parameter sensitivity of the last simulation at unit inlet
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 *          The array pointers are only valid until a new simulation is started.
+		 * @param [in] drv Driver handle
+		 * @param [in] unitOpId ID of the unit operation whose solution is returned
+		 * @param [out] time Time array pointer
+		 * @param [out] data Data array pointer
+		 * @param [out] nTime Number of time points
+		 * @param [out] nPort Number of ports
+		 * @param [out] nComp Number of components
+		 * @return @c cdtOK on success, a negative value indicating the error otherwise
+		 */
+		cdtResult(*getSensitivityInlet)(cdtDriver* drv, int unitOpId, int sensIdx, double const** time, double const** data, int* nTime, int* nPort, int* nComp);
+
+		/**
+		 * @brief Returns the parameter sensitivity of the last simulation at unit outlet
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 *          The array pointers are only valid until a new simulation is started.
+		 * @param [in] drv Driver handle
+		 * @param [in] unitOpId ID of the unit operation whose solution is returned
+		 * @param [in] sensIdx Sensitivity ID
+		 * @param [out] time Time array pointer
+		 * @param [out] data Data array pointer
+		 * @param [out] nTime Number of time points
+		 * @param [out] nPort Number of ports
+		 * @param [out] nComp Number of components
+		 * @return @c cdtOK on success, a negative value indicating the error otherwise
+		 */
+		cdtResult(*getSensitivityOutlet)(cdtDriver* drv, int unitOpId, int sensIdx, double const** time, double const** data, int* nTime, int* nPort, int* nComp);
+
+		/**
+		 * @brief Returns the parameter sensitivity of the last simulation of the column bulk phase
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 *          The array pointers are only valid until a new simulation is started.
+		 * @param [in] drv Driver handle
+		 * @param [in] unitOpId ID of the unit operation whose solution is returned
+		 * @param [in] sensIdx Sensitivity ID
+		 * @param [out] time Time array pointer
+		 * @param [out] data Data array pointer
+		 * @param [out] nTime Number of time points
+		 * @param [out] nAxialCells Number of axial cells
+		 * @param [out] nRadialCells Number of radial cells
+		 * @param [out] nComp Number of components
+		 * @param [out] keepAxialSingletonDimension Keep axial singleton dimension
+		 * @return @c cdtOK on success, a negative value indicating the error otherwise
+		 */
+		cdtResult(*getSensitivityBulk)(cdtDriver* drv, int unitOpId, int sensIdx, double const** time, double const** data, int* nTime, int* nAxialCells, int* nRadialCells, int* nComp, bool* keepAxialSingletonDimension);
+
+		/**
+		 * @brief Returns the parameter sensitivity of the last simulation of the column particle liquid phase
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 *          The array pointers are only valid until a new simulation is started.
+		 * @param [in] drv Driver handle
+		 * @param [in] unitOpId ID of the unit operation whose solution is returned
+		 * @param [in] sensIdx Sensitivity ID
+		 * @param [out] parType Particle type index
+		 * @param [out] time Time array pointer
+		 * @param [out] data Data array pointer
+		 * @param [out] nTime Number of time points
+		 * @param [out] nAxialCells Number of axial cells
+		 * @param [out] nRadialCells Number of ports
+		 * @param [out] nParShells Number of particle shells
+		 * @param [out] nComp Number of components
+		 * @param [out] keepAxialSingletonDimension Keep axial singleton dimension
+		 * @param [out] keepParticleSingletonDimension Keep particle singleton dimension
+		 * @return @c cdtOK on success, a negative value indicating the error otherwise
+		 */
+		cdtResult(*getSensitivityParticle)(cdtDriver* drv, int unitOpId, int sensIdx, int parType, double const** time, double const** data, int* nTime, int* nAxialCells, int* nRadialCells, int* nParShells, int* nComp, bool* keepAxialSingletonDimension, bool* keepParticleSingletonDimension);
+
+		/**
+		 * @brief Returns the parameter sensitivity of the last simulation of the column particle solid phase
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 *          The array pointers are only valid until a new simulation is started.
+		 * @param [in] drv Driver handle
+		 * @param [in] unitOpId ID of the unit operation whose solution is returned
+		 * @param [in] sensIdx Sensitivity ID
+		 * @param [out] parType Particle type index
+		 * @param [out] time Time array pointer
+		 * @param [out] data Data array pointer
+		 * @param [out] nTime Number of time points
+		 * @param [out] nAxialCells Number of axial cells
+		 * @param [out] nRadialCells Number of ports
+		 * @param [out] nParShells Number of particle shells
+		 * @param [out] nBound Number of bound states
+		 * @param [out] keepAxialSingletonDimension Keep axial singleton dimension
+		 * @param [out] keepParticleSingletonDimension Keep particle singleton dimension
+		 * @return @c cdtOK on success, a negative value indicating the error otherwise
+		 */
+		cdtResult(*getSensitivitySolid)(cdtDriver* drv, int unitOpId, int sensIdx, int parType, double const** time, double const** data, int* nTime, int* nAxialCells, int* nRadialCells, int* nParShells, int* nBound, bool* keepAxialSingletonDimension, bool* keepParticleSingletonDimension);
+
+		/**
+		 * @brief Returns the parameter sensitivity of the last simulation of the column particle flux
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 *          The array pointers are only valid until a new simulation is started.
+		 * @param [in] drv Driver handle
+		 * @param [in] unitOpId ID of the unit operation whose solution is returned
+		 * @param [in] sensIdx Sensitivity ID
+		 * @param [out] time Time array pointer
+		 * @param [out] data Data array pointer
+		 * @param [out] nTime Number of time points
+		 * @param [out] nAxialCells Number of axial cells
+		 * @param [out] nRadialCells Number of ports
+		 * @param [out] nParticleTypes Number of particle types
+		 * @param [out] nComp Number of components
+		 * @param [out] keepAxialSingletonDimension Keep axial singleton dimension
+		 * @return @c cdtOK on success, a negative value indicating the error otherwise
+		 */
+		cdtResult(*getSensitivityFlux)(cdtDriver* drv, int unitOpId, int sensIdx, double const** time, double const** data, int* nTime, int* nAxialCells, int* nRadialCells, int* nParticleTypes, int* nComp, bool* keepAxialSingletonDimension);
+
+		/**
+		 * @brief Returns the parameter sensitivity of the last simulation of the unit volume
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 *          The array pointers are only valid until a new simulation is started.
+		 * @param [in] drv Driver handle
+		 * @param [in] unitOpId ID of the unit operation whose solution is returned
+		 * @param [in] sensIdx Sensitivity ID
+		 * @param [out] time Time array pointer
+		 * @param [out] data Data array pointer
+		 * @return @c cdtOK on success, a negative value indicating the error otherwise
+		 */
+		cdtResult(*getSensitivityVolume)(cdtDriver* drv, int unitOpId, int sensIdx, double const** time, double const** data, int* nTime);
+
+		/**
+		 * @brief Returns the parameter sensitivity derivative of the last simulation at unit inlet
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 *          The array pointers are only valid until a new simulation is started.
+		 * @param [in] drv Driver handle
+		 * @param [in] unitOpId ID of the unit operation whose solution is returned
+		 * @param [in] sensIdx Sensitivity ID
+		 * @param [out] time Time array pointer
+		 * @param [out] data Data array pointer
+		 * @param [out] nTime Number of time points
+		 * @param [out] nPort Number of ports
+		 * @param [out] nComp Number of components
+		 * @return @c cdtOK on success, a negative value indicating the error otherwise
+		 */
+		cdtResult(*getSensitivityDerivativeInlet)(cdtDriver* drv, int unitOpId, int sensIdx, double const** time, double const** data, int* nTime, int* nPort, int* nComp);
+
+		/**
+		 * @brief Returns the parameter sensitivity derivative of the last simulation at unit outlet
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 *          The array pointers are only valid until a new simulation is started.
+		 * @param [in] drv Driver handle
+		 * @param [in] unitOpId ID of the unit operation whose solution is returned
+		 * @param [in] sensIdx Sensitivity ID
+		 * @param [out] time Time array pointer
+		 * @param [out] data Data array pointer
+		 * @param [out] nTime Number of time points
+		 * @param [out] nPort Number of ports
+		 * @param [out] nComp Number of components
+		 * @return @c cdtOK on success, a negative value indicating the error otherwise
+		 */
+		cdtResult(*getSensitivityDerivativeOutlet)(cdtDriver* drv, int unitOpId, int sensIdx, double const** time, double const** data, int* nTime, int* nPort, int* nComp);
+
+		/**
+		 * @brief Returns the parameter sensitivity derivative of the last simulation of the column bulk phase
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 *          The array pointers are only valid until a new simulation is started.
+		 * @param [in] drv Driver handle
+		 * @param [in] unitOpId ID of the unit operation whose solution is returned
+		 * @param [in] sensIdx Sensitivity ID
+		 * @param [out] time Time array pointer
+		 * @param [out] data Data array pointer
+		 * @param [out] nTime Number of time points
+		 * @param [out] nAxialCells Number of axial cells
+		 * @param [out] nRadialCells Number of radial cells
+		 * @param [out] nComp Number of components
+		 * @param [out] keepAxialSingletonDimension Keep axial singleton dimension
+		 * @return @c cdtOK on success, a negative value indicating the error otherwise
+		 */
+		cdtResult(*getSensitivityDerivativeBulk)(cdtDriver* drv, int unitOpId, int sensIdx, double const** time, double const** data, int* nTime, int* nAxialCells, int* nRadialCells, int* nComp, bool* keepAxialSingletonDimension);
+
+		/**
+		 * @brief Returns the parameter sensitivity derivative of the last simulation of the column particle liquid phase
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 *          The array pointers are only valid until a new simulation is started.
+		 * @param [in] drv Driver handle
+		 * @param [in] unitOpId ID of the unit operation whose solution is returned
+		 * @param [in] sensIdx Sensitivity ID
+		 * @param [out] parType Particle type index
+		 * @param [out] time Time array pointer
+		 * @param [out] data Data array pointer
+		 * @param [out] nTime Number of time points
+		 * @param [out] nAxialCells Number of axial cells
+		 * @param [out] nRadialCells Number of ports
+		 * @param [out] nParShells Number of particle shells
+		 * @param [out] nComp Number of components
+		 * @param [out] keepAxialSingletonDimension Keep axial singleton dimension
+		 * @param [out] keepParticleSingletonDimension Keep particle singleton dimension
+		 * @return @c cdtOK on success, a negative value indicating the error otherwise
+		 */
+		cdtResult(*getSensitivityDerivativeParticle)(cdtDriver* drv, int unitOpId, int sensIdx, int parType, double const** time, double const** data, int* nTime, int* nAxialCells, int* nRadialCells, int* nParShells, int* nComp, bool* keepAxialSingletonDimension, bool* keepParticleSingletonDimension);
+
+		/**
+		 * @brief Returns the parameter sensitivity derivative of the last simulation of the column particle solid phase
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 *          The array pointers are only valid until a new simulation is started.
+		 * @param [in] drv Driver handle
+		 * @param [in] unitOpId ID of the unit operation whose solution is returned
+		 * @param [in] sensIdx Sensitivity ID
+		 * @param [out] parType Particle type index
+		 * @param [out] time Time array pointer
+		 * @param [out] data Data array pointer
+		 * @param [out] nTime Number of time points
+		 * @param [out] nAxialCells Number of axial cells
+		 * @param [out] nRadialCells Number of ports
+		 * @param [out] nParShells Number of particle shells
+		 * @param [out] nBound Number of bound states
+		 * @param [out] keepAxialSingletonDimension Keep axial singleton dimension
+		 * @param [out] keepParticleSingletonDimension Keep particle singleton dimension
+		 * @return @c cdtOK on success, a negative value indicating the error otherwise
+		 */
+		cdtResult(*getSensitivityDerivativeSolid)(cdtDriver* drv, int unitOpId, int sensIdx, int parType, double const** time, double const** data, int* nTime, int* nAxialCells, int* nRadialCells, int* nParShells, int* nBound, bool* keepAxialSingletonDimension, bool* keepParticleSingletonDimension);
+
+		/**
+		 * @brief Returns the parameter sensitivity derivative of the last simulation of the column particle flux
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 *          The array pointers are only valid until a new simulation is started.
+		 * @param [in] drv Driver handle
+		 * @param [in] unitOpId ID of the unit operation whose solution is returned
+		 * @param [in] sensIdx Sensitivity ID
+		 * @param [out] time Time array pointer
+		 * @param [out] data Data array pointer
+		 * @param [out] nTime Number of time points
+		 * @param [out] nAxialCells Number of axial cells
+		 * @param [out] nRadialCells Number of ports
+		 * @param [out] nParticleTypes Number of particle types
+		 * @param [out] nComp Number of components
+		 * @param [out] keepAxialSingletonDimension Keep axial singleton dimension
+		 * @return @c cdtOK on success, a negative value indicating the error otherwise
+		 */
+		cdtResult(*getSensitivityDerivativeFlux)(cdtDriver* drv, int unitOpId, int sensIdx, double const** time, double const** data, int* nTime, int* nAxialCells, int* nRadialCells, int* nParticleTypes, int* nComp, bool* keepAxialSingletonDimension);
+
+		/**
+		 * @brief Returns the parameter sensitivity derivative of the last simulation of the unit volume
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 *          The array pointers are only valid until a new simulation is started.
+		 * @param [in] drv Driver handle
+		 * @param [in] unitOpId ID of the unit operation whose solution is returned
+		 * @param [in] sensIdx Sensitivity ID
+		 * @param [out] time Time array pointer
+		 * @param [out] data Data array pointer
+		 * @param [out] nTime Number of time points
+		 * @return @c cdtOK on success, a negative value indicating the error otherwise
+		 */
+		cdtResult(*getSensitivityDerivativeVolume)(cdtDriver* drv, int unitOpId, int sensIdx, double const** time, double const** data, int* nTime);
+
+		/**
+		 * @brief Returns the last state of the simulation
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 * @param [in] drv Driver handle
+		 * @param [out] state State vector pointer
+		 * @param [out] nStates Number of entries in the state vector
+		 * @return @c cdtOK on success, a negative value indicating the error otherwise
+		*/
+		cdtResult(*getLastState)(cdtDriver* drv, double const** state, int* nStates);
+
+		/**
+		 * @brief Returns the last time derivative state of the simulation
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 * @param [in] drv Driver handle
+		 * @param [out] state State vector pointer
+		 * @param [out] nStates Number of entries in the state vector
+		 * @return @c cdtOK on success, a negative value indicating the error otherwise
+		*/
+		cdtResult(*getLastStateTimeDerivative)(cdtDriver* drv, double const** state, int* nStates);
+
+		/**
+		 * @brief Returns the last state of the unit operation of the simulation
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 * @param [in] drv Driver handle
+		 * @param [in] unitOpId ID of the unit operation whose solution is returned
+		 * @param [out] state State vector pointer
+		 * @param [out] nStates Number of entries in the state vector
+		 * @return @c cdtOK on success, a negative value indicating the error otherwise
+		*/
+		cdtResult(*getLastUnitState)(cdtDriver* drv, int unitOpId, double const** state, int* nStates);
+
+		/**
+		 * @brief Returns the last time derivative state of the unit operation of the simulation
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 * @param [in] drv Driver handle
+		 * @param [in] unitOpId ID of the unit operation whose solution is returned
+		 * @param [out] state State vector pointer
+		 * @param [out] nStates Number of entries in the state vector
+		 * @return @c cdtOK on success, a negative value indicating the error otherwise
+		*/
+		cdtResult(*getLastUnitStateTimeDerivative)(cdtDriver* drv, int unitOpId, double const** state, int* nStates);
+
+		/**
+		 * @brief Returns the last sensitivity state of the simulation
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 * @param [in] drv Driver handle
+		 * @param [in] sensIdx Sensitivity ID
+		 * @param [out] state State vector pointer
+		 * @param [out] nStates Number of entries in the state vector
+		 * @return @c cdtOK on success, a negative value indicating the error otherwise
+		*/
+		cdtResult(*getLastSensitivityState)(cdtDriver* drv, int sensIdx, double const** state, int* nStates);
+
+		/**
+		 * @brief Returns the last time derivative sensitivity state of the simulation
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 * @param [in] drv Driver handle
+		 * @param [in] sensIdx Sensitivity ID
+		 * @param [out] state State vector pointer
+		 * @param [out] nStates Number of entries in the state vector
+		 * @return @c cdtOK on success, a negative value indicating the error otherwise
+		*/
+		cdtResult(*getLastSensitivityStateTimeDerivative)(cdtDriver* drv, int sensIdx, double const** state, int* nStates);
+
+		/**
+		 * @brief Returns the last sensitivity state of the unit operation of the simulation
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 * @param [in] drv Driver handle
+		 * @param [in] sensIdx Sensitivity ID
+		 * @param [in] unitOpId ID of the unit operation whose solution is returned
+		 * @param [out] state State vector pointer
+		 * @param [out] nStates Number of entries in the state vector
+		 * @return @c cdtOK on success, a negative value indicating the error otherwise
+		*/
+		cdtResult(*getLastSensitivityUnitState)(cdtDriver* drv, int sensIdx, int unitOpId, double const** state, int* nStates);
+
+		/**
+		 * @brief Returns the last time derivative sensitivity state of the unit operation of the simulation
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 * @param [in] drv Driver handle
+		 * @param [in] sensIdx Sensitivity ID
+		 * @param [in] unitOpId ID of the unit operation whose solution is returned
+		 * @param [out] state State vector pointer
+		 * @param [out] nStates Number of entries in the state vector
+		 * @return @c cdtOK on success, a negative value indicating the error otherwise
+		*/
+		cdtResult(*getLastSensitivityUnitStateTimeDerivative)(cdtDriver* drv, int sensIdx, int unitOpId, double const** state, int* nStates);
+
+		/**
+		 * @brief Returns the primary coordinates of the given unit operation
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 *          The array pointers are only valid until a new simulation is started.
+		 * @param [in] drv Driver handle
+		 * @param [in] unitOpId ID of the unit operation whose solution is returned
+		 * @param [out] data Data array pointer
+		 * @param [out] nCoords Number of coordinates
+		 * @return @c cdtOK on success, a negative value indicating the error otherwise
+		 */
+		cdtResult(*getPrimaryCoordinates)(cdtDriver* drv, int unitOpId, double const** data, int* nCoords);
+
+		/**
+		 * @brief Returns the secondary coordinates of the given unit operation
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 *          The array pointers are only valid until a new simulation is started.
+		 * @param [in] drv Driver handle
+		 * @param [in] unitOpId ID of the unit operation whose solution is returned
+		 * @param [out] data Data array pointer
+		 * @param [out] nCoords Number of coordinates
+		 * @return @c cdtOK on success, a negative value indicating the error otherwise
+		 */
+		cdtResult(*getSecondaryCoordinates)(cdtDriver* drv, int unitOpId, double const** data, int* nCoords);
+
+		/**
+		 * @brief Returns the secondary coordinates of the given unit operation
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 *          The array pointers are only valid until a new simulation is started.
+		 * @param [in] drv Driver handle
+		 * @param [in] unitOpId ID of the unit operation whose solution is returned
+		 * @param [in] parType Particle type index
+		 * @param [out] data Data array pointer
+		 * @param [out] nCoords Number of coordinates
+		 * @return @c cdtOK on success, a negative value indicating the error otherwise
+		 */
+		cdtResult(*getParticleCoordinates)(cdtDriver* drv, int unitOpId, int parType, double const** data, int* nCoords);
+
+		/**
+		 * @brief Returns the time points at which the solution was computed
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 *          The array pointers are only valid until a new simulation is started.
+		 * @param [in] drv Driver handle
+		 * @param [out] time Time array pointer
+		 * @param [out] nTime Number of time points
+		 * @return @c cdtOK on success, a negative value indicating the error otherwise
+		 */
+		cdtResult(*getSolutionTimes)(cdtDriver* drv, double const** time, int* nTime);
+
+		/**
+		 * @brief Returns the run time of the simulation
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 * @param [in] drv Driver handle
+		 * @param [out] timeSim Simulation run time pointer
+		 * @return @c cdtOK on success, a negative value indicating the error otherwise
+		 */
+		cdtResult(*getTimeSim)(cdtDriver* drv, double* timeSim);
+
+		/**
+		 * @brief Set a timeout on the current simulator
+		 * @details The timeout persists for the full lifetime of the simulator.
+		 * @param [in] drv Driver handle
+		 * @param [in] timeoutSec Timeout for a time integration process in seconds. A value
+		 *                     smaller or equal to @c 0.0 means no timeout (default).
+		 * @return @c cdtOK on success, a negative value indicating the error otherwise
+		 */
+		cdtResult(*setTimeout)(cdtDriver* drv, double timeoutSec);
+
+		cdtResult (*initializeSimulation)(cdtDriver* drv, cdtParameterProvider const* paramProvider);
+		cdtResult (*performSimulationStep)(cdtDriver* drv, double tEnd, double* tReached);
+		cdtResult (*endSimulation)(cdtDriver* drv);
+
+
+	} cdtAPIv1_1_0a2;
+	
+	
+	CADET_API cdtResult cdtGetAPIv1_1_0a2(cdtAPIv1_1_0a2* ptr);
 
 }
 

--- a/src/libcadet/SimulatorImpl.cpp
+++ b/src/libcadet/SimulatorImpl.cpp
@@ -1757,4 +1757,273 @@ namespace cadet
 		_notification = nc;
 	}
 
+	void Simulator::prepareIntegrator()
+	{
+
+#ifdef CADET_PARALLELIZE
+	#ifdef CADET_TBB_GLOBALCTRL
+		tbb::global_control tbbGlobalControl(tbb::global_control::max_allowed_parallelism, (_nThreads > 0) ? _nThreads : tbb::this_task_arena::max_concurrency());
+	#else
+		tbb::task_scheduler_init init(tbb::task_scheduler_init::deferred);
+		if (_nThreads > 0)
+			init.initialize(_nThreads);
+		else
+			init.initialize(tbb::task_scheduler_init::default_num_threads());
+	#endif
+		_model->setupParallelization(tbb::this_task_arena::max_concurrency());
+#else
+		_model->setupParallelization(1);
+#endif
+
+		// Set number of threads in SUNDIALS OpenMP-enabled implementation
+#ifdef CADET_SUNDIALS_OPENMP
+		if (_vecStateY)
+			NVec_SetThreads(_vecStateY, _nThreads);
+		if (_vecStateYdot)
+			NVec_SetThreads(_vecStateYdot, _nThreads);
+
+		for (unsigned int i = 0; i < _sensitiveParams.slices(); ++i)
+		{
+			NVec_SetThreads(_vecFwdYs[i], _nThreads);
+			NVec_SetThreads(_vecFwdYsDot[i], _nThreads);
+		}
+#endif
+
+		// Set number of AD directions
+		// @todo This is problematic if multiple Simulators are run concurrently!
+#if defined(ACTIVE_SFAD) || defined(ACTIVE_SETFAD)
+		LOG(Debug) << "Setting AD directions from " << ad::getDirections() << " to " << numSensitivityAdDirections() + _model->requiredADdirs();
+		if (numSensitivityAdDirections() + _model->requiredADdirs() > ad::getMaxDirections())
+			throw InvalidParameterException("Requested " + std::to_string(numSensitivityAdDirections() + _model->requiredADdirs()) + " AD directions, but only "
+				+ std::to_string(ad::getMaxDirections()) + " are supported");
+
+		ad::setDirections(numSensitivityAdDirections() + _model->requiredADdirs());
+#endif
+
+		// Setup AD vectors by model
+		_model->prepareADvectors(AdJacobianParams{_vecADres, _vecADy, numSensitivityAdDirections()});
+
+		if (_solRecorder)
+		{
+			_solRecorder->notifyIntegrationStart(NVEC_LENGTH(_vecStateY), _sensitiveParams.slices(), _solutionTimes.size());
+			_model->reportSolutionStructure(*_solRecorder);
+		}
+
+		double startTime = static_cast<double>(_sectionTimes[0]);
+		_curSec = 0;
+
+		// Update Jacobian
+		_model->notifyDiscontinuousSectionTransition(startTime, _curSec, ConstSimulationState{NVEC_DATA(_vecStateY), NVEC_DATA(_vecStateYdot)}, AdJacobianParams{_vecADres, _vecADy, numSensitivityAdDirections()});
+
+		// Compute consistent initial values
+		LOG(Debug) << "---====--- CONSISTENCY ---====--- ";
+		const double consPrev = _model->residualNorm(SimulationTime{startTime, _curSec}, ConstSimulationState{NVEC_DATA(_vecStateY), NVEC_DATA(_vecStateYdot)});
+		LOG(Debug) << " ==========> Consistency error prev: " << consPrev;
+
+		if (!_skipConsistencyStateY && (_consistentInitMode != ConsistentInitialization::None))
+		{
+			const ConsistentInitialization mode = currentConsistentInitMode(_consistentInitMode, 0);
+			if (mode == ConsistentInitialization::Full)
+			{
+				_model->consistentInitialConditions( SimulationTime{startTime, _curSec}, SimulationState{NVEC_DATA(_vecStateY), NVEC_DATA(_vecStateYdot)}, 
+				AdJacobianParams{_vecADres, _vecADy, numSensitivityAdDirections()}, _algTol);
+			}
+			else if (mode == ConsistentInitialization::Lean)
+			{
+				_model->leanConsistentInitialConditions( SimulationTime{startTime, _curSec}, SimulationState{NVEC_DATA(_vecStateY), NVEC_DATA(_vecStateYdot)}, 
+				AdJacobianParams{_vecADres, _vecADy, numSensitivityAdDirections()}, _algTol);
+			}
+		}
+		_skipConsistencyStateY = false;
+
+		const bool wantSensitivities = _sensitiveParams.slices() > 0;
+		if (wantSensitivities && !_skipConsistencySensitivity && 
+			(_consistentInitModeSens != ConsistentInitialization::None))
+		{
+			const ConsistentInitialization mode = currentConsistentInitMode(_consistentInitModeSens, 0);
+			if (mode == ConsistentInitialization::Full)
+			{
+				std::vector<double*> sensY = convertNVectorToStdVectorPtrs<double*>(_vecFwdYs, _sensitiveParams.slices());
+				std::vector<double*> sensYdot = convertNVectorToStdVectorPtrs<double*>(_vecFwdYsDot, _sensitiveParams.slices());
+				_model->consistentInitialSensitivity(SimulationTime{startTime, 0}, 
+					ConstSimulationState{NVEC_DATA(_vecStateY), NVEC_DATA(_vecStateYdot)},
+					sensY, sensYdot, _vecADres, _vecADy);
+			}
+			else if (mode == ConsistentInitialization::Lean)
+			{
+				std::vector<double*> sensY = convertNVectorToStdVectorPtrs<double*>(_vecFwdYs, _sensitiveParams.slices());
+				std::vector<double*> sensYdot = convertNVectorToStdVectorPtrs<double*>(_vecFwdYsDot, _sensitiveParams.slices());
+				_model->leanConsistentInitialSensitivity(SimulationTime{startTime, 0}, 
+					ConstSimulationState{NVEC_DATA(_vecStateY), NVEC_DATA(_vecStateYdot)},
+					sensY, sensYdot, _vecADres, _vecADy);
+			}
+		}
+		_skipConsistencySensitivity = false;
+
+		// IDAS Step 5.2: Re-initialization of the solver
+		IDAReInit(_idaMemBlock, startTime, _vecStateY, _vecStateYdot);
+		if (wantSensitivities)
+			IDASensReInit(_idaMemBlock, IDA_STAGGERED, _vecFwdYs, _vecFwdYsDot);
+
+		const double stepSize = _initStepSize.size() > 1 ? _initStepSize[0] : _initStepSize[0];
+		IDASetInitStep(_idaMemBlock, stepSize);
+
+		LOG(Info) << "Integration prepared successfully at t = " << startTime; 
+	}
+
+	int Simulator::reinitialize(double currentTime)
+	{
+		if (!_idaMemBlock)
+			return -1;
+
+		// Determine current section
+		_curSec = 0; 
+		for (unsigned int i = 0; i < _sectionTimes.size()-1; ++i)
+		{
+			if (currentTime >= static_cast<double>(_sectionTimes[i]) && currentTime < static_cast<double>(_sectionTimes[i + 1]) )
+			{
+				_curSec = i;
+				break;
+			}
+		}
+
+		// Get pointers to state vectors
+		double* yData = NVEC_DATA(_vecStateY);
+		double* yDotData = NVEC_DATA(_vecStateYdot);
+
+		// Zero yDot
+		const unsigned int numDof = numDofs();
+		for (unsigned int i = 0; i < numDof; ++i)
+			yDotData[i] = 0.0;
+
+		// Notify model about section/time change
+		_model->notifyDiscontinuousSectionTransition(
+			currentTime,
+			_curSec,
+			ConstSimulationState{yData, yDotData},
+			AdJacobianParams{_vecADres, _vecADy, numSensitivityAdDirections()}
+		);
+
+
+		// Use LEAN consistent initialization to fixes algebraic variables
+		_model->leanConsistentInitialConditions(
+			SimulationTime{currentTime, _curSec},
+			SimulationState{yData, yDotData},
+			AdJacobianParams{_vecADres, _vecADy, numSensitivityAdDirections()},
+			_algTol
+		);
+
+		// IDAS Reinitialization
+		int solverFlag = IDAReInit(_idaMemBlock, currentTime, _vecStateY, _vecStateYdot);
+		if (solverFlag != IDA_SUCCESS)
+			return solverFlag;
+
+		// Handle sensitivities
+		const bool wantSensitivities = _sensitiveParams.slices() > 0;
+		if (wantSensitivities)
+		{
+			solverFlag = IDASensReInit(_idaMemBlock, IDA_STAGGERED, _vecFwdYs, _vecFwdYsDot);
+			if (solverFlag != IDA_SUCCESS)
+				return solverFlag;
+		}
+
+		// Set step size
+		const double stepSize = _initStepSize.size() > _curSec ? _initStepSize[_curSec] : _initStepSize[0];
+		IDASetInitStep(_idaMemBlock, stepSize);
+
+		// Increase max steps
+		IDASetMaxNumSteps(_idaMemBlock, 100000);
+
+		// Set stop time
+		const double tEnd = static_cast<double>(_sectionTimes.back());
+		if (tEnd > currentTime)
+		{
+			IDASetStopTime(_idaMemBlock, tEnd);
+		}
+
+		_lastIntTime = currentTime;
+
+
+		return 0;
+	}
+
+	int Simulator::integrateStep(double tEnd, double& tReached)
+	{
+		if(!_idaMemBlock)
+		{
+			LOG(Error) << "IDAS not initialized.";
+			return -1;
+		}
+
+		// Get current time from IDAS
+		double curT = 0.0;
+		IDAGetCurrentTime(_idaMemBlock, &curT);
+
+		// Check if tEnd is too close to current time
+		const double minTimeStep = 1e-12;
+		if (std::abs(tEnd - curT) < minTimeStep)
+		{
+			LOG(Warning) << "tEnd (" << tEnd << ") too close to current time (" << curT << "). Skipping integration step.";
+			tReached = curT;
+			return 0;
+		}
+
+		// Check if tEnd is in the past
+		if (tEnd <= curT)
+		{
+			LOG(Warning) << "tEnd (" << tEnd << ") is not greater than current time (" << curT << "). Skipping integration step.";
+			tReached = curT;
+			return 0;
+		}
+
+		// integrateStep() only supports single-section integration
+		if (_sectionTimes.size() > 2)
+		{
+			LOG(Error) << "integrateStep() only supports single-section integration."
+					   << "Found " << _sectionTimes.size() - 1 << " sections.";
+			return -1;
+		}
+
+		_curSec = getCurrentSection(curT);
+
+		LOG(Debug) << " ###### INTEGRATION sec " << _curSec << " from " << curT << " to " << tEnd;
+
+		const double stepSize = _initStepSize.size() > _curSec ? _initStepSize[_curSec] : _initStepSize[0];
+		IDASetInitStep(_idaMemBlock, stepSize);
+		IDASetStopTime(_idaMemBlock, tEnd);
+
+		// Use endTime for IDASolve, not tEnd
+		const int solverFlag = IDASolve(_idaMemBlock, tEnd, &tReached, _vecStateY, _vecStateYdot, IDA_NORMAL);
+
+		// Extract sensitivity information if available
+		const bool wantSensitivities = _sensitiveParams.slices() > 0;
+		if (wantSensitivities && (solverFlag == IDA_SUCCESS || solverFlag == IDA_TSTOP_RETURN))
+		{
+			IDAGetSens(_idaMemBlock, &tReached, _vecFwdYs);
+			IDAGetSensDky(_idaMemBlock, tReached, 1, _vecFwdYsDot);
+		}
+
+		if (solverFlag == IDA_ROOT_RETURN)
+		{
+			_lastIntTime = tReached;
+			LOG(Warning) << "Root found at t = " << tReached;
+			return 1;
+		}
+
+		if (solverFlag != IDA_SUCCESS && solverFlag != IDA_TSTOP_RETURN)
+		{
+			LOG(Error) << "IDASolve failed with code " << solverFlag
+					<< ": " << getIDAReturnFlagName(solverFlag);
+			return solverFlag;
+		}
+
+		_lastIntTime = tReached;
+		curT = tReached;
+
+		writeSolution(curT);
+
+		tReached = curT;
+		return 0;
+
+	}
 } // namespace cadet

--- a/src/libcadet/SimulatorImpl.hpp
+++ b/src/libcadet/SimulatorImpl.hpp
@@ -215,6 +215,28 @@ protected:
 	 */
 	void updateMainErrorTolerances();
 
+	/**
+	 * @brief Prepares the simulator for step-by-step integration
+	 * @details Performs all initialization steps normally done in integrate(),
+	 *          but stops before the actual time integration loop.
+	 */
+	virtual void prepareIntegrator();
+
+	/**
+	 * @brief Performs one integration step until target time
+	 * @param [in] tEnd Target time
+	 * @param [out] tReached Actually reached time
+	 * @return 0 on success, negative error code otherwise
+	 */
+	virtual int integrateStep(double tEnd, double& tReached);
+
+	/**
+	 * @brief Reinitializes the integrator at the given time
+	 * @param [in] currentTime Current simulation time
+	 * @return 0 on success, negative error code otherwise
+	 */
+	virtual int reinitialize(double currentTime) override;
+
 	friend int ::cadet::residualDaeWrapper(double t, N_Vector y, N_Vector yDot, N_Vector res, void* userData);
 
 	friend int ::cadet::linearSolveWrapper(IDAMem IDA_mem, N_Vector rhs, N_Vector weight, N_Vector yCur, N_Vector yDotCur, N_Vector resCur);

--- a/src/libcadet/VersionInfo.cpp.in
+++ b/src/libcadet/VersionInfo.cpp.in
@@ -23,7 +23,7 @@ namespace cadet
 	const char COMPILER[] = "@CMAKE_CXX_COMPILER_ID@ @CMAKE_CXX_COMPILER_VERSION@";
 	const char BUILD_HOST[] = "@CMAKE_SYSTEM@";
 	const char COMPILER_FLAGS[] = "@CMAKE_CXX_FLAGS@";
-	const char LATEST_CAPI_VERSION[] = "1.1.0a1";
+	const char LATEST_CAPI_VERSION[] = "1.1.0a2";
 
 	const char* getLibraryVersion() CADET_NOEXCEPT
 	{

--- a/src/libcadet/api/CAPIv1.cpp
+++ b/src/libcadet/api/CAPIv1.cpp
@@ -1055,6 +1055,110 @@ namespace v1
 		return cdtOK;
 	}
 
+	cdtResult initializeSimulation(cdtDriver* drv, cdtParameterProvider const* paramProvider)
+	{
+		Driver* const realDrv = drv->driver;
+		if (!realDrv)
+			return cdtErrorInvalidInputs;
+		if (!paramProvider)
+			return cdtErrorInvalidInputs;
+
+		try
+		{
+			LOG(Info) << "C-API: Configuring driver";
+			CallbackParameterProvider cpp(*paramProvider);
+			realDrv->configure(cpp);
+
+			LOG(Info) << "C-API: Getting simulator";
+			cadet::ISimulator* const sim = realDrv->simulator();
+			if(!sim)
+			{
+				LOG(Error) << "C-API: Failed to create simulator after configure";
+				return cdtError;
+			}
+
+			LOG(Info) << "C-API: Preparing integrator";
+			sim->prepareIntegrator();
+
+			LOG(Info) << "C-API: Simulation initialized successfully";
+		}
+		catch(const std::exception& e)
+		{
+			LOG(Error) << "C-API: Initialization failed: " << e.what();
+			return cdtError;
+		}
+
+		return cdtOK;
+	}
+
+	cdtResult performSimulationStep(cdtDriver* drv, double tEnd, double* tReached)
+	{
+		Driver* const realDrv = drv->driver;
+
+		if (!realDrv)
+		{
+			LOG(Error) << "C-API: Invalid driver pointer";
+			return cdtErrorInvalidInputs;
+		}
+
+		try
+		{
+			cadet::ISimulator* const sim = realDrv->simulator();
+
+			if (!sim)
+			{
+				LOG(Error) << "C-API: Simulator not initialized";
+				return cdtError;
+			}
+
+			double reached = 0.0;
+			const int result = sim->integrateStep(tEnd, reached);
+
+			if (tReached)
+				*tReached = reached;
+
+			if (result < 0)
+			{
+				LOG(Error) << "C-API: Integration step failed with code " << result;
+				return cdtError;
+			}
+
+			if (result > 0)
+				LOG(Info) << "C-API: Root found at t = " << reached;
+			else
+				LOG(Info) << "C-API: Integrated to t = " << reached;
+		}
+		catch(const std::exception& e)
+		{
+			LOG(Error) << "C-API: Exception in performSimulationStep: " << e.what();
+			return cdtError;
+		}
+
+		LOG(Info) << "C-API: performSimulationStep END";
+		return cdtOK;
+
+	}
+
+	cdtResult endSimulation(cdtDriver* drv)
+	{
+		Driver* const realDrv = drv->driver;
+		if(!realDrv)
+			return cdtErrorInvalidInputs;
+
+		try
+		{
+			realDrv->clear();
+		}
+		catch(const std::exception& e)
+		{
+			LOG(Error) << "C-API: Ending simulation failed " << e.what();
+			return cdtError;
+		}
+
+		return cdtOK;
+	}
+
+
 	template <typename cdtAPIv1_x>
 	cdtResult cdtGetAPIv1_x(cdtAPIv1_x* ptr)
 	{
@@ -1144,6 +1248,20 @@ extern "C"
 			return cdtErrorInvalidInputs;
 
 		ptr->setTimeout = &cadet::api::v1::setTimeout;
+
+		return cadet::api::v1::cdtGetAPIv1_x(ptr);
+	}
+
+	CADET_API cdtResult cdtGetAPIv1_1_0a2(cdtAPIv1_1_0a2* ptr)
+	{
+		if (!ptr)
+			return cdtErrorInvalidInputs;
+
+		ptr->setTimeout = &cadet::api::v1::setTimeout;
+
+		ptr->initializeSimulation = &cadet::api::v1::initializeSimulation;
+		ptr->performSimulationStep = &cadet::api::v1::performSimulationStep;
+		ptr->endSimulation = &cadet::api::v1::endSimulation;
 
 		return cadet::api::v1::cdtGetAPIv1_x(ptr);
 	}

--- a/test/testCAPIv1.cpp
+++ b/test/testCAPIv1.cpp
@@ -22,6 +22,7 @@
 #include <vector>
 #include <stack>
 #include <string>
+#include <cmath>
 
 #include <json.hpp>
 using json = nlohmann::json;
@@ -31,6 +32,7 @@ using json = nlohmann::json;
 const char* getLibBinaryPath();
 
 typedef cdtResult (*cdtGetAPIv1_0_0_t)(cdtAPIv1_0_0* ptr);
+typedef cdtResult (*cdtGetAPIv1_1_0a2_t)(cdtAPIv1_1_0a2* ptr);
 
 typedef void (*cdtSetLogReceiver_t)(cdtLogHandler recv);
 typedef void (*cdtSetLogLevel_t)(int lvl);
@@ -113,55 +115,66 @@ json createColumnWithSMAJson(const std::string& uoType)
 	json config;
 	config["UNIT_TYPE"] = uoType;
 	config["NCOMP"] = 4;
+	config["NPARTYPE"] = 1;
 	config["VELOCITY"] = 5.75e-4;
 	config["COL_DISPERSION"] = 5.75e-8;
 	config["COL_DISPERSION_RADIAL"] = 1e-6;
-	config["FILM_DIFFUSION"] = {6.9e-6, 6.9e-6, 6.9e-6, 6.9e-6};
-	config["PORE_DIFFUSION"] = {7e-10, 6.07e-11, 6.07e-11, 6.07e-11};
-	config["SURFACE_DIFFUSION"] = {0.0, 0.0, 0.0, 0.0};
 
 	// Geometry
 	config["COL_LENGTH"] = 0.014;
 	config["COL_RADIUS"] = 0.01;
-	config["PAR_RADIUS"] = 4.5e-5;
 	config["COL_POROSITY"] = 0.37;
-	config["PAR_POROSITY"] = 0.75;
-	config["TOTAL_POROSITY"] = 0.37 + (1.0 - 0.37) * 0.75;
 
 	// Initial conditions
 	config["INIT_C"] = {50.0, 0.0, 0.0, 0.0};
-	config["INIT_CS"] = {1.2e3, 0.0, 0.0, 0.0};
 
-	// Adsorption
-	config["ADSORPTION_MODEL"] = std::string("STERIC_MASS_ACTION");
-	config["NBOUND"] = { 1, 1, 1, 1 };
+	// Particle type 000
 	{
-		json ads;
-		ads["IS_KINETIC"] = 1;
-		ads["SMA_LAMBDA"] = 1.2e3;
-		ads["SMA_KA"] = {0.0, 35.5, 1.59, 7.7};
-		ads["SMA_KD"] = {0.0, 1000.0, 1000.0, 1000.0};
-		ads["SMA_NU"] = {0.0, 4.7, 5.29, 3.7};
-		ads["SMA_SIGMA"] = {0.0, 11.83, 10.6, 10.0};
-		config["adsorption"] = ads;
+		json parType;
+		parType["NBOUND"] = { 1, 1, 1, 1 };
+		parType["PAR_RADIUS"] = 4.5e-5;
+		parType["PAR_POROSITY"] = 0.75;
+		parType["FILM_DIFFUSION"] = {6.9e-6, 6.9e-6, 6.9e-6, 6.9e-6};
+		parType["PORE_DIFFUSION"] = {7e-10, 6.07e-11, 6.07e-11, 6.07e-11};
+		parType["SURFACE_DIFFUSION"] = {0.0, 0.0, 0.0, 0.0};
+		parType["INIT_CP"] = {50.0, 0.0, 0.0, 0.0};
+		parType["INIT_CS"] = {1.2e3, 0.0, 0.0, 0.0};
+
+		parType["ADSORPTION_MODEL"] = std::string("STERIC_MASS_ACTION");
+		{
+			json ads;
+			ads["IS_KINETIC"] = 1;
+			ads["SMA_LAMBDA"] = 1.2e3;
+			ads["SMA_KA"] = {0.0, 35.5, 1.59, 7.7};
+			ads["SMA_KD"] = {0.0, 1000.0, 1000.0, 1000.0};
+			ads["SMA_NU"] = {0.0, 4.7, 5.29, 3.7};
+			ads["SMA_SIGMA"] = {0.0, 11.83, 10.6, 10.0};
+			parType["adsorption"] = ads;
+		}
+
+		{
+			json disc;
+			disc["NCELLS"] = 4;
+			disc["PAR_DISC_TYPE"] = std::string("EQUIDISTANT");
+			parType["discretization"] = disc;
+		}
+
+		config["particle_type_000"] = parType;
 	}
 
 	// Discretization
 	{
 		json disc;
 
+		disc["SPATIAL_METHOD"] = std::string("FV");
 		disc["NCOL"] = 16;
-		disc["NCELLS"] = 4;
 
 		if (uoType == "GENERAL_RATE_MODEL_2D")
 		{
 			disc["NCOL"] = 8;
 			disc["NRAD"] = 3;
-			disc["NCELLS"] = 3;
 			disc["RADIAL_DISC_TYPE"] = "EQUIDISTANT";
 		}
-
-		disc["PAR_DISC_TYPE"] = std::string("EQUIDISTANT");
 
 		disc["USE_ANALYTIC_JACOBIAN"] = true;
 		disc["MAX_KRYLOV"] = 0;
@@ -374,6 +387,185 @@ json createLWEJson(const std::string& uoType)
 
 		config["solver"] = solver;
 	}
+	return config;
+}
+
+json createStepColumnWithSMAJson(const std::string& uoType)
+{
+	json config;
+	config["UNIT_TYPE"] = uoType;
+	config["NCOMP"] = 4;
+	config["NPARTYPE"] = 1;
+	config["VELOCITY"] = 5.75e-4;
+	config["COL_DISPERSION"] = 5.75e-8;
+
+	// Geometry
+	config["COL_LENGTH"] = 0.014;
+	config["COL_POROSITY"] = 0.37;
+
+	// Initial conditions
+	config["INIT_C"] = {50.0, 0.0, 0.0, 0.0};
+
+	// Column-level discretization
+	{
+		json disc;
+		disc["SPATIAL_METHOD"] = std::string("FV");
+		disc["NCOL"] = 4;
+		disc["USE_ANALYTIC_JACOBIAN"] = true;
+		disc["MAX_KRYLOV"] = 0;
+		disc["GS_TYPE"] = 1;
+		disc["MAX_RESTARTS"] = 10;
+		disc["SCHUR_SAFETY"] = 1e-8;
+
+		{
+			json weno;
+			weno["WENO_ORDER"] = 3;
+			weno["BOUNDARY_MODEL"] = 0;
+			weno["WENO_EPS"] = 1e-10;
+			disc["weno"] = weno;
+		}
+		config["discretization"] = disc;
+	}
+
+	// Particle type 000
+	{
+		json parType;
+		parType["NBOUND"] = { 1, 1, 1, 1 };
+		parType["PAR_RADIUS"] = 4.5e-5;
+		parType["PAR_POROSITY"] = 0.75;
+		parType["FILM_DIFFUSION"] = {6.9e-6, 6.9e-6, 6.9e-6, 6.9e-6};
+		parType["PORE_DIFFUSION"] = {7e-10, 6.07e-11, 6.07e-11, 6.07e-11};
+		parType["SURFACE_DIFFUSION"] = {0.0, 0.0, 0.0, 0.0};
+		parType["INIT_CP"] = {50.0, 0.0, 0.0, 0.0};
+		parType["INIT_CS"] = {1.2e3, 0.0, 0.0, 0.0};
+
+		parType["ADSORPTION_MODEL"] = std::string("STERIC_MASS_ACTION");
+		{
+			json ads;
+			ads["IS_KINETIC"] = 1;
+			ads["SMA_LAMBDA"] = 1.2e3;
+			ads["SMA_KA"] = {0.0, 35.5, 1.59, 7.7};
+			ads["SMA_KD"] = {0.0, 1000.0, 1000.0, 1000.0};
+			ads["SMA_NU"] = {0.0, 4.7, 5.29, 3.7};
+			ads["SMA_SIGMA"] = {0.0, 11.83, 10.6, 10.0};
+			parType["adsorption"] = ads;
+		}
+
+		{
+			json disc;
+			disc["NCELLS"] = 2;
+			disc["PAR_DISC_TYPE"] = std::string("EQUIDISTANT");
+			parType["discretization"] = disc;
+		}
+
+		config["particle_type_000"] = parType;
+	}
+
+	return config;
+}
+
+json createSingleSectionLWEJson()
+{
+	json config;
+
+	// Model
+	{
+		json model;
+		model["NUNITS"] = 2;
+		model["unit_000"] = createStepColumnWithSMAJson("GENERAL_RATE_MODEL");
+
+		// Inlet - unit 001, single section (load phase)
+		{
+			json inlet;
+			inlet["UNIT_TYPE"] = std::string("INLET");
+			inlet["INLET_TYPE"] = std::string("PIECEWISE_CUBIC_POLY");
+			inlet["NCOMP"] = 4;
+
+			{
+				json sec;
+				sec["CONST_COEFF"] = {50.0, 1.0, 1.0, 1.0};
+				sec["LIN_COEFF"] = {0.0, 0.0, 0.0, 0.0};
+				sec["QUAD_COEFF"] = {0.0, 0.0, 0.0, 0.0};
+				sec["CUBE_COEFF"] = {0.0, 0.0, 0.0, 0.0};
+				inlet["sec_000"] = sec;
+			}
+
+			model["unit_001"] = inlet;
+		}
+
+		// Valve switches
+		{
+			json con;
+			con["NSWITCHES"] = 1;
+			con["CONNECTIONS_INCLUDE_PORTS"] = true;
+
+			{
+				json sw;
+				sw["SECTION"] = 0;
+				sw["CONNECTIONS"] = {1.0, 0.0, -1.0, -1.0, -1.0, -1.0, 1.0};
+				con["switch_000"] = sw;
+			}
+			model["connections"] = con;
+		}
+
+		{
+			json solver;
+			solver["MAX_KRYLOV"] = 0;
+			solver["GS_TYPE"] = 1;
+			solver["MAX_RESTARTS"] = 10;
+			solver["SCHUR_SAFETY"] = 1e-8;
+			model["solver"] = solver;
+		}
+
+		config["model"] = model;
+	}
+
+	// Return
+	{
+		json ret;
+		ret["WRITE_SOLUTION_TIMES"] = true;
+		ret["WRITE_SOLUTION_LAST"] = true;
+
+		json grm;
+		grm["WRITE_SOLUTION_BULK"] = false;
+		grm["WRITE_SOLUTION_PARTICLE"] = false;
+		grm["WRITE_SOLUTION_FLUX"] = false;
+		grm["WRITE_SOLUTION_INLET"] = true;
+		grm["WRITE_SOLUTION_OUTLET"] = true;
+		ret["unit_000"] = grm;
+
+		config["return"] = ret;
+	}
+
+	// Solver - single section [0, 10]
+	{
+		json solver;
+
+		{
+			json sec;
+			sec["NSEC"] = 1;
+			sec["SECTION_TIMES"] = {0.0, 10.0};
+			solver["sections"] = sec;
+		}
+
+		solver["NTHREADS"] = 1;
+
+		{
+			json ti;
+			ti["ABSTOL"] = 1e-8;
+			ti["RELTOL"] = 1e-6;
+			ti["ALGTOL"] = 1e-12;
+			ti["INIT_STEP_SIZE"] = 1e-6;
+			ti["MAX_STEPS"] = 10000;
+			ti["MAX_STEP_SIZE"] = 0.0;
+			ti["CONSISTENT_INIT_MODE"] = 1;
+			ti["CONSISTENT_INIT_MODE_SENS"] = 1;
+			solver["time_integrator"] = ti;
+		}
+
+		config["solver"] = solver;
+	}
+
 	return config;
 }
 
@@ -741,6 +933,296 @@ cdtResult popScope(void* userData)
 	return cdtOK;
 }
 
+cdtParameterProvider makeParamProvider(JsonNavigator* jn)
+{
+	cdtParameterProvider pp
+	{
+		jn,
+		&getDouble,
+		&getInt,
+		&getBool,
+		&getString,
+		nullptr,
+		nullptr,
+		nullptr,
+		nullptr,
+		&getDoubleArrayItem,
+		&getIntArrayItem,
+		&getBoolArrayItem,
+		&getStringArrayItem,
+		&exists,
+		&isArray,
+		&numElements,
+		&pushScope,
+		&popScope
+	};
+	return pp;
+}
+
+int testErrors = 0;
+
+void check(bool condition, const char* msg)
+{
+	if (!condition)
+	{
+		std::cout << "FAIL: " << msg << std::endl;
+		++testErrors;
+	}
+	else
+	{
+		std::cout << "PASS: " << msg << std::endl;
+	}
+}
+
+
+//    v1.1.0a2 API tests
+int testInitAndEnd(cdtAPIv1_1_0a2& api)
+{
+	std::cout << "\n=== Test: initializeSimulation + endSimulation ===" << std::endl;
+
+	const json simSpec = createSingleSectionLWEJson();
+	JsonNavigator jn(simSpec);
+	cdtParameterProvider pp = makeParamProvider(&jn);
+
+	std::unique_ptr<cdtDriver, std::function<void(cdtDriver*)>> drv(api.createDriver(), [&api](cdtDriver* ptr)
+		{
+			api.deleteDriver(ptr);
+		}
+	);
+
+	const cdtResult resInit = api.initializeSimulation(drv.get(), &pp);
+	check(!CADET_ERR(resInit), "initializeSimulation returns cdtOK");
+
+	const cdtResult resEnd = api.endSimulation(drv.get());
+	check(!CADET_ERR(resEnd), "endSimulation returns cdtOK");
+
+	return (CADET_ERR(resInit) || CADET_ERR(resEnd)) ? 1 : 0;
+}
+
+int testStepToEnd(cdtAPIv1_1_0a2& api)
+{
+	const json simSpec = createSingleSectionLWEJson();
+	JsonNavigator jn(simSpec);
+	cdtParameterProvider pp = makeParamProvider(&jn);
+
+	std::unique_ptr<cdtDriver, std::function<void(cdtDriver*)>> drv(api.createDriver(), [&api](cdtDriver* ptr)
+		{
+			api.deleteDriver(ptr);
+		}
+	);
+
+	cdtResult res = api.initializeSimulation(drv.get(), &pp);
+	check(!CADET_ERR(res), "initializeSimulation returns cdtOK");
+	if (CADET_ERR(res))
+		return 1;
+
+	const double totalTime = 10.0;
+	const int nSteps = 5;
+	const double stepSize = totalTime / static_cast<double>(nSteps);
+	double tCurrent = 0.0;
+	int stepCount = 0;
+
+	while (totalTime - tCurrent > 1e-10)
+	{
+		const double tTarget = std::min(tCurrent + stepSize, totalTime);
+		double tReached = 0.0;
+
+		res = api.performSimulationStep(drv.get(), tTarget, &tReached);
+		check(!CADET_ERR(res), "performSimulationStep returns cdtOK");
+		if (CADET_ERR(res))
+		{
+			api.endSimulation(drv.get());
+			return 1;
+		}
+
+		check(tReached > tCurrent || std::abs(tReached - totalTime) < 1e-10,
+			"tReached advances or equals totalTime");
+
+		tCurrent = tReached;
+		++stepCount;
+	}
+
+	check(std::abs(tCurrent - totalTime) < 1e-8, "final time matches totalTime");
+
+	double const* lastState = nullptr;
+	int nStates = 0;
+	res = api.getLastState(drv.get(), &lastState, &nStates);
+	check(!CADET_ERR(res), "getLastState returns cdtOK");
+	check(lastState != nullptr, "lastState pointer is valid");
+	check(nStates > 0, "nStates > 0");
+
+	res = api.endSimulation(drv.get());
+	check(!CADET_ERR(res), "endSimulation returns cdtOK");
+
+	return 0;
+}
+
+int testStepMatchesFullSim(cdtAPIv1_1_0a2& api)
+{
+	const json simSpec = createSingleSectionLWEJson();
+
+	{
+		json fullSpec = simSpec;
+		std::vector<double> solTimes;
+		solTimes.reserve(11);
+		for (double t = 0.0; t <= 10.0; t += 1.0)
+			solTimes.push_back(t);
+		fullSpec["solver"]["USER_SOLUTION_TIMES"] = solTimes;
+
+		JsonNavigator jnFull(fullSpec);
+		cdtParameterProvider ppFull = makeParamProvider(&jnFull);
+
+		std::unique_ptr<cdtDriver, std::function<void(cdtDriver*)>> drvFull(api.createDriver(), [&api](cdtDriver* ptr)
+			{
+				api.deleteDriver(ptr);
+			}
+		);
+
+		cdtResult res = api.runSimulation(drvFull.get(), &ppFull);
+		check(!CADET_ERR(res), "runSimulation returns cdtOK");
+		if (CADET_ERR(res))
+			return 1;
+
+		double const* lastStateFull = nullptr;
+		int nStatesFull = 0;
+		api.getLastState(drvFull.get(), &lastStateFull, &nStatesFull);
+
+		double const* lastStateDotFull = nullptr;
+		int nStatesDotFull = 0;
+		api.getLastStateTimeDerivative(drvFull.get(), &lastStateDotFull, &nStatesDotFull);
+
+		//  Stepped simulation
+		JsonNavigator jnStep(simSpec);
+		cdtParameterProvider ppStep = makeParamProvider(&jnStep);
+
+		std::unique_ptr<cdtDriver, std::function<void(cdtDriver*)>> drvStep(api.createDriver(), [&api](cdtDriver* ptr)
+			{
+				api.deleteDriver(ptr);
+			}
+		);
+
+		res = api.initializeSimulation(drvStep.get(), &ppStep);
+		check(!CADET_ERR(res), "initializeSimulation returns cdtOK");
+
+		double tReached = 0.0;
+		res = api.performSimulationStep(drvStep.get(), 10.0, &tReached);
+		check(!CADET_ERR(res), "performSimulationStep returns cdtOK");
+
+		double const* lastStateStep = nullptr;
+		int nStatesStep = 0;
+		api.getLastState(drvStep.get(), &lastStateStep, &nStatesStep);
+
+		double const* lastStateDotStep = nullptr;
+		int nStatesDotStep = 0;
+		api.getLastStateTimeDerivative(drvStep.get(), &lastStateDotStep, &nStatesDotStep);
+
+		// Compare states
+		check(nStatesFull == nStatesStep, "state vector sizes match");
+		check(nStatesDotFull == nStatesDotStep, "state derivative vector sizes match");
+
+		if (nStatesFull == nStatesStep && lastStateFull && lastStateStep)
+		{
+			double maxDiff = 0.0;
+			for (int i = 0; i < nStatesFull; ++i)
+			{
+				const double diff = std::abs(lastStateFull[i] - lastStateStep[i]);
+				maxDiff = std::max(maxDiff, diff);
+			}
+			check(maxDiff < 1e-6, "last_state_y matches between full and stepped simulation");
+		}
+
+		if (nStatesDotFull == nStatesDotStep && lastStateDotFull && lastStateDotStep)
+		{
+			double maxDiff = 0.0;
+			for (int i = 0; i < nStatesDotFull; ++i)
+			{
+				const double diff = std::abs(lastStateDotFull[i] - lastStateDotStep[i]);
+				maxDiff = std::max(maxDiff, diff);
+			}
+			check(maxDiff < 1e-6, "last_state_ydot matches between full and stepped simulation");
+		}
+
+		api.endSimulation(drvStep.get());
+	}
+
+	return 0;
+}
+
+int testIntermediateStateAccess(cdtAPIv1_1_0a2& api)
+{
+
+	const json simSpec = createSingleSectionLWEJson();
+	JsonNavigator jn(simSpec);
+	cdtParameterProvider pp = makeParamProvider(&jn);
+
+	std::unique_ptr<cdtDriver, std::function<void(cdtDriver*)>> drv(api.createDriver(), [&api](cdtDriver* ptr)
+		{
+			api.deleteDriver(ptr);
+		}
+	);
+
+	cdtResult res = api.initializeSimulation(drv.get(), &pp);
+	check(!CADET_ERR(res), "initializeSimulation returns cdtOK");
+	if (CADET_ERR(res))
+		return 1;
+
+	const double totalTime = 10.0;
+	const double fractions[] = {0.1, 0.25, 0.5, 0.75};
+	double prevT = 0.0;
+
+	for (double frac : fractions)
+	{
+		double tReached = 0.0;
+		res = api.performSimulationStep(drv.get(), totalTime * frac, &tReached);
+		check(!CADET_ERR(res), "performSimulationStep returns cdtOK");
+
+		check(tReached > prevT, "time progresses monotonically");
+
+		double const* lastState = nullptr;
+		int nStates = 0;
+		res = api.getLastState(drv.get(), &lastState, &nStates);
+		check(!CADET_ERR(res), "getLastState returns cdtOK at intermediate time");
+		check(lastState != nullptr, "lastState pointer is valid at intermediate time");
+		check(nStates > 0, "nStates > 0 at intermediate time");
+
+		prevT = tReached;
+	}
+
+	res = api.endSimulation(drv.get());
+	check(!CADET_ERR(res), "endSimulation returns cdtOK");
+
+	return 0;
+}
+
+int testEndWithoutInit(cdtAPIv1_1_0a2& api)
+{
+	std::unique_ptr<cdtDriver, std::function<void(cdtDriver*)>> drv(api.createDriver(), [&api](cdtDriver* ptr)
+		{
+			api.deleteDriver(ptr);
+		}
+	);
+
+	const cdtResult res = api.endSimulation(drv.get());
+	check(!CADET_ERR(res), "endSimulation on fresh driver returns cdtOK");
+
+	return 0;
+}
+
+int testStepWithoutInit(cdtAPIv1_1_0a2& api)
+{
+	std::unique_ptr<cdtDriver, std::function<void(cdtDriver*)>> drv(api.createDriver(), [&api](cdtDriver* ptr)
+		{
+			api.deleteDriver(ptr);
+		}
+	);
+
+	double tReached = 0.0;
+	const cdtResult res = api.performSimulationStep(drv.get(), 5.0, &tReached);
+	check(CADET_ERR(res), "performSimulationStep without init returns error");
+
+	return 0;
+}
+
 
 int main(int argc, char** argv)
 {
@@ -832,8 +1314,37 @@ int main(int argc, char** argv)
 	int nPort = 0;
 	int nComp = 0;
 	const cdtResult resSol = api.getSolutionOutlet(drv.get(), 0, &time, &outlet, &nTime, &nPort, &nComp);
+	std::cout << "getSolutionOutlet() = " << resSol << " nTime = " << nTime << " nPort = " << nPort << " nComp = " <<nComp << std::endl;
 
-	std::cout << "getSolutionOutlet() = " << resSol << " nTime = " << nTime << " nPort = " << nPort << " nComp = " << nComp << std::endl;
+	//  v1.1.0a2 API tests
+	const cdtGetAPIv1_1_0a2_t apiLoaderStep = loader.load<cdtGetAPIv1_1_0a2_t>("cdtGetAPIv1_1_0a2");
+	if (!apiLoaderStep)
+	{
+		return 1;
+	}
+
+	cdtAPIv1_1_0a2 apiStep;
+	const cdtResult resApiLoadStep = apiLoaderStep(&apiStep);
+
+	if (CADET_ERR(resApiLoadStep))
+		return 1;
+
+	check(apiStep.initializeSimulation != nullptr, "initializeSimulation is set");
+	check(apiStep.performSimulationStep != nullptr, "performSimulationStep is set");
+	check(apiStep.endSimulation != nullptr, "endSimulation is set");
+	check(apiStep.setTimeout != nullptr, "setTimeout is set");
+
+	setLogLevel(cdtLogLevelInfo);
+
+	testInitAndEnd(apiStep);
+	testStepToEnd(apiStep);
+	testStepMatchesFullSim(apiStep);
+	testIntermediateStateAccess(apiStep);
+	testEndWithoutInit(apiStep);
+	testStepWithoutInit(apiStep);
+
+	if (testErrors > 0)
+		return 1;
 
 	return 0;
 }


### PR DESCRIPTION
This PR adda new C-API simulation functions

- `initializeSimulation`: initializes IDAS, performs consistent init, sets AD directions, sets up solution recorder, notfies discontinuous section transition
- `performSimulationStep`: integrate to a given timepoints. only supports models with one section
- `endSimulation`: cleans up the driver 

modilarizes the simulator implementation:
- `prepareIntegrator`: initializes IDAS, performs consistent init, sets AD directions, sets up solution recorder, notfies discontinuous section transition
- `reinitialize`: reinitializes IDAS
- `integrateStep`: integrate to a given timepoint

Additionally, we bumb a new pre-release version of  the C-API.
and add testCAPI.exe to CI (https://github.com/cadet/CADET-Core/issues/676)
Follow ups:
- [ ] https://github.com/cadet/CADET-Core/issues/674