### PR TITLE
Fix: coverage.yml used invalid syntax

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
-          ref: ${{ github.event.inputs.ref || github.ref }}
+          ref: "${{ github.event.inputs.ref || github.ref }}"
       - name: Install GCC-14
         run: |
           sudo apt-get update


### PR DESCRIPTION
Currently the coverage pipeline does not work due to a syntax error within the yaml file. This pull request should fix it.

The error occured due to a now more stricktly rule of interpreting null. In line 34 there was:
```
ref: ${{ github.event.inputs.ref || github.ref }}
```
Running this manually leads github.event.inputs.ref to return master which does [work](https://github.com/cadet/CADET-Core/actions/runs/22843106354). Running via push on master or leads it to return null, which seems to cause a syntax error?
Not sure how to interpret this behaviour due to it working for some time and why it occurs since last month, but fixed it by using quotes.
Test it by setting `fix/ci-codecove` as a on push branch, but removed the commit causing this behaviour:
[report](https://github.com/cadet/CADET-Core/actions/runs/22843749512/job/66255178127).