### PR TITLE
Fix: set gcov-executable

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -138,6 +138,7 @@ jobs:
             --filter "${{ github.workspace }}/(src|include|build/src)" \
             --exclude-directories '.*ThirdParty.*' \
             --cobertura -o coverage.xml \
+            --gcov-executable gcov-14 \
             --txt=-
       
       - name: Upload Coverage to Codecov


### PR DESCRIPTION
Currently the coverage pipeline is failing during the generating report step. Setting the gcov version fixes this issue within a manual [run](https://github.com/cadet/CADET-Core/actions/runs/23210518741).