### PR TITLE
Build: fail when warnings are raised in Linux pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,7 +170,7 @@ jobs:
       SRC_DIR: ${{ github.workspace }}/src
       BUILD_DIR: ${{ github.workspace }}/build
       INSTALL_PREFIX: ${{ github.workspace }}/install
-      BUILD_TYPE: Release
+      BUILD_TYPE: Release-strict
     steps:
       - uses: actions/checkout@v4
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -481,9 +481,15 @@ endif()
 
 if (CMAKE_BUILD_TYPE STREQUAL "Debug")
 	target_compile_options(CADET::CompileOptions INTERFACE $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
-		-Wall -pedantic-errors -Wextra -Wno-unused-parameter -Wno-unused-function> #-Wconversion -Wsign-conversion
+		-Wall -pedantic-errors -Wextra -Wno-unused-parameter -Wno-unused-function -Wno-sign-compare -Wno-cpp> #-Wconversion -Wsign-conversion
 	$<$<CXX_COMPILER_ID:MSVC>:
 		/W4 /wd4100 /bigobj /MP>
+)
+elseif (CMAKE_BUILD_TYPE STREQUAL "Release-strict")
+	target_compile_options(CADET::CompileOptions INTERFACE $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
+		-O3 -DNDEBUG -Werror -Wall -pedantic-errors -Wextra -Wno-unused-parameter -Wno-unused-function -Wno-sign-compare -Wno-cpp>#-Wconversion -Wsign-conversion
+	$<$<CXX_COMPILER_ID:MSVC>:
+		/W4 /wd4100 /MP>
 )
 else()
 	target_compile_options(CADET::CompileOptions INTERFACE $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:


### PR DESCRIPTION
As a follow up of #558, this PR changes the build system so that no new warnings (on Linux) can be merged. 
For this, the warnings `-Wcpp` and `-Wsign-compare` are ignored when compiling on Linux and MacOs. This is to make future development and identification of warnings easier. However, this warnings should be fixed down the line (e.g. see #578).

Furthermore, the CI workflow has been modified. The Ubuntu-build now uses a slightly modified build command. All warnings raised are treated as errors and abort the build process.
The MacOS and Windows pipeline remain unchanged.