### PR TITLE
CI: add `paths-ignore` to coverage workflow

### DIFF
--- a/.github/workflows/ci_coverage.yml
+++ b/.github/workflows/ci_coverage.yml
@@ -1,11 +1,47 @@
 name: CI_coverage
 
 on:
-  pull_request :
-    types : [opened, synchronize, reopened, ready_for_review]
   push:
+    paths-ignore:
+      - 'doc/**'
+      - 'doc/ISSUE_TEMPLATE'
+      - 'doc/PULL_REQUEST_TEMPLATE'
+      - '.zenodo.json'
+      - 'AUTHORS.md'
+      - 'BUILD-LINUX.md'
+      - 'BUILD-WINDOWS.md'
+      - 'BUILD-OSX.md'
+      - 'CITATION.bib'
+      - 'CLA.md'
+      - 'CODE_OF_CONDUCT.md'
+      - 'CONTRIBUTING.md'
+      - 'LICENSE.txt'
+      - 'README.rst'
+      - 'SECURITY.md'
+      - 'ThirdParty-LICENSES.txt'
+      - 'version.txt'
     branches:
       - master
+  pull_request :
+    paths-ignore:
+      - 'doc/**'
+      - 'doc/ISSUE_TEMPLATE'
+      - 'doc/PULL_REQUEST_TEMPLATE'
+      - '.zenodo.json'
+      - 'AUTHORS.md'
+      - 'BUILD-LINUX.md'
+      - 'BUILD-WINDOWS.md'
+      - 'BUILD-OSX.md'
+      - 'CITATION.bib'
+      - 'CLA.md'
+      - 'CODE_OF_CONDUCT.md'
+      - 'CONTRIBUTING.md'
+      - 'LICENSE.txt'
+      - 'README.rst'
+      - 'SECURITY.md'
+      - 'ThirdParty-LICENSES.txt'
+      - 'version.txt'
+    types : [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
     inputs:
       ref:


### PR DESCRIPTION
That just slipped through since we updated the old coverage workflow which was only used for manual dispatch but is now part of the CI as per #640 