### PR TITLE
Interface: rename `RADIAL_COMPARTMENTS` to `RADIAL_DISC_VECTOR`

### DIFF
--- a/doc/interface/unit_operations/axial_flow_column_2D_config.rst
+++ b/doc/interface/unit_operations/axial_flow_column_2D_config.rst
@@ -237,7 +237,7 @@ For further information on the choice of discretization methods and their parame
    **Type:** string  **Length:** 1
    ================  =============
 
-``RADIAL_COMPARTMENTS``
+``RADIAL_DISC_VECTOR``
 
    Coordinates for the radial compartment boundaries (ignored if :math:`\texttt{RADIAL_DISC_TYPE} \neq \texttt{USER_DEFINED}`). The coordinates are absolute and have to include the endpoints 0 and :math:`\texttt{COLUMN_RADIUS}`. The values are expected in ascending order (i.e., 0 is the first and :math:`\texttt{COLUMN_RADIUS}` the last value in the array).
 

--- a/src/libcadet/model/parts/TwoDimensionalConvectionDispersionOperator.cpp
+++ b/src/libcadet/model/parts/TwoDimensionalConvectionDispersionOperator.cpp
@@ -788,12 +788,12 @@ bool TwoDimensionalConvectionDispersionOperator::configure(UnitOpIdx unitOpIdx, 
 	else if (rdt == "USER_DEFINED")
 	{
 		_radialDiscretizationMode = RadialDiscretizationMode::UserDefined;
-		readScalarParameterOrArray(_radialEdges, paramProvider, "RADIAL_COMPARTMENTS", 1);
+		readScalarParameterOrArray(_radialEdges, paramProvider, "RADIAL_DISC_VECTOR", 1);
 
 		if (_radialEdges.size() < _nRad + 1)
-			throw InvalidParameterException("Number of elements in field RADIAL_COMPARTMENTS is less than NRAD + 1 (" + std::to_string(_nRad + 1) + ")");
+			throw InvalidParameterException("Number of elements in field RADIAL_DISC_VECTOR is less than NRAD + 1 (" + std::to_string(_nRad + 1) + ")");
 
-		registerParam1DArray(parameters, _radialEdges, [=](bool multi, unsigned int i) { return makeParamId(hashString("RADIAL_COMPARTMENTS"), unitOpIdx, CompIndep, i, BoundStateIndep, ReactionIndep, SectionIndep); });
+		registerParam1DArray(parameters, _radialEdges, [=](bool multi, unsigned int i) { return makeParamId(hashString("RADIAL_DISC_VECTOR"), unitOpIdx, CompIndep, i, BoundStateIndep, ReactionIndep, SectionIndep); });
 	}
 	else
 		_radialDiscretizationMode = RadialDiscretizationMode::Equidistant;

--- a/src/libcadet/model/parts/TwoDimensionalConvectionDispersionOperatorDG.cpp
+++ b/src/libcadet/model/parts/TwoDimensionalConvectionDispersionOperatorDG.cpp
@@ -659,12 +659,12 @@ bool TwoDimensionalConvectionDispersionOperatorDG::configure(UnitOpIdx unitOpIdx
 	else if (rdt == "USER_DEFINED")
 	{
 		_radialDiscretizationMode = RadialDiscretizationMode::UserDefined;
-		readScalarParameterOrArray(_radialElemInterfaces, paramProvider, "RADIAL_COMPARTMENTS", 1);
+		readScalarParameterOrArray(_radialElemInterfaces, paramProvider, "RADIAL_DISC_VECTOR", 1);
 
 		if (_radialElemInterfaces.size() < _radNElem + 1)
-			throw InvalidParameterException("Number of elements in field RADIAL_COMPARTMENTS is less than radNElem + 1 (" + std::to_string(_radNElem + 1) + ")");
+			throw InvalidParameterException("Number of elements in field RADIAL_DISC_VECTOR is less than radNElem + 1 (" + std::to_string(_radNElem + 1) + ")");
 
-		registerParam1DArray(parameters, _radialElemInterfaces, [=](bool multi, unsigned int i) { return makeParamId(hashString("RADIAL_COMPARTMENTS"), unitOpIdx, CompIndep, i, BoundStateIndep, ReactionIndep, SectionIndep); });
+		registerParam1DArray(parameters, _radialElemInterfaces, [=](bool multi, unsigned int i) { return makeParamId(hashString("RADIAL_DISC_VECTOR"), unitOpIdx, CompIndep, i, BoundStateIndep, ReactionIndep, SectionIndep); });
 	}
 	else
 		_radialDiscretizationMode = RadialDiscretizationMode::Equidistant;


### PR DESCRIPTION
This PR renames `RADIAL_COMPARTMENTS` to `RADIAL_DISC_VECTOR`, which is more consistent with PAR_DISC_VECTOR, where we also have the ...DISC_TYPE field, which might also be added for axial non-eq grids as per #652