### PR TITLE
Docs: fix LRM `TOTAL_POROSITY` interface documentation

### DIFF
--- a/doc/interface/unit_operations/axial_flow_column_1D_config.rst
+++ b/doc/interface/unit_operations/axial_flow_column_1D_config.rst
@@ -43,7 +43,17 @@ Group /input/model/unit_XXX - UNIT_TYPE - COLUMN_MODEL_1D
 
 ``COL_POROSITY``
 
-   Column porosity
+   Column porosity of the interstitial volume.
+   Used only if model is not a Lumped Rate Model without Pores, in which case ``TOTAL_POROSITY`` is used instead.
+   
+   ================  ========================  =============
+   **Type:** double  **Range:** :math:`(0,1]`  **Length:** 1
+   ================  ========================  =============
+
+``TOTAL_POROSITY``
+
+   Total porosity of including the porosity of the particles.
+   Only applicable for the Lumped Rate Model without pores, i.e. when ``NPARTYPE = 1`` **AND** ``particle_type_000\HAS_FILM_DIFFUSION = 0``
    
    ================  ========================  =============
    **Type:** double  **Range:** :math:`(0,1]`  **Length:** 1


### PR DESCRIPTION
We did not properly document the total porosity with the new interface, which this PR fixes