### PR TITLE
Test: add timeout tests

### DIFF
--- a/include/cadet/Simulator.hpp
+++ b/include/cadet/Simulator.hpp
@@ -728,6 +728,8 @@ public:
 	 */
 	virtual void setNotificationCallback(INotificationCallback* nc) CADET_NOEXCEPT = 0;
 
+	virtual bool stoppedByNotificationCallback() CADET_NOEXCEPT = 0;
+
 	virtual void  prepareIntegrator() = 0;
 
     virtual int integrateStep(double tEnd, double& tReached) = 0;

--- a/include/cadet/Simulator.hpp
+++ b/include/cadet/Simulator.hpp
@@ -728,12 +728,37 @@ public:
 	 */
 	virtual void setNotificationCallback(INotificationCallback* nc) CADET_NOEXCEPT = 0;
 
+	/**
+	 * @brief Checks whether the simulation was stopped by the notification callback
+	 */
 	virtual bool stoppedByNotificationCallback() CADET_NOEXCEPT = 0;
 
+	/**		
+	 * @brief Prepares the simulator for step-by-step integration
+	 * @details Performs initialization steps normally done in integrate(), including:
+	 *          parallelization setup, AD vector preparation, consistent initial conditions,
+	 *          and IDAS initialization. Stops before the actual time integration loop.
+	 */
 	virtual void  prepareIntegrator() = 0;
 
+	/**
+	 * @brief Performs one integration step to the specified target time
+	 * @details Only supports single-section integration. Uses IDAS solver to advance
+	 *          the simulation and extracts sensitivity information if available.
+	 * @param [in] tEnd Target time to integrate to
+	 * @param [out] tReached Actually reached time (may differ from tEnd)
+	 * @return 0 on success, negative error code on failure
+	 */
     virtual int integrateStep(double tEnd, double& tReached) = 0;
 
+	/**
+	 * @brief Reinitializes the integrator at the specified time
+	 * @details Determines the current section, zeros yDot, notifies model of discontinuous
+	 *          section transition, applies lean consistent initialization, and reinitializes
+	 *          IDAS solver with the new state.
+	 * @param [in] currentTime Simulation time to reinitialize at
+	 * @return 0 on success, negative error code on failure (e.g., -1 if IDAS not initialized)
+	 */
 	virtual int reinitialize(double currentTime) = 0;
 };
 

--- a/include/cadet/cadet.h
+++ b/include/cadet/cadet.h
@@ -183,7 +183,11 @@ extern "C"
 		/**
 		 * @brief Success
 		 */
-		cdtOK = 0
+		cdtOK = 0,
+		/**
+		 * @brief Stopped by callback
+		 */
+		cdtStoppedByCallback = 1
 	};
 
 	/**

--- a/include/common/TimeoutCallback.hpp
+++ b/include/common/TimeoutCallback.hpp
@@ -18,9 +18,10 @@
 
 #ifndef CADET_TIMEOUT_CALLBACK_HPP_
 #define CADET_TIMEOUT_CALLBACK_HPP_
- 
+
 #include "common/Timer.hpp"
 #include "cadet/Notification.hpp"
+#include "cadet/Logging.hpp"
 
 namespace cadet
 {

--- a/include/common/TimeoutCallback.hpp
+++ b/include/common/TimeoutCallback.hpp
@@ -21,7 +21,6 @@
 
 #include "common/Timer.hpp"
 #include "cadet/Notification.hpp"
-#include "cadet/Logging.hpp"
 
 namespace cadet
 {

--- a/src/cadet-cli/cadet-cli.cpp
+++ b/src/cadet-cli/cadet-cli.cpp
@@ -258,6 +258,9 @@ int run(const std::string& inFileName, const std::string& outFileName, bool show
 	try
 	{
 		drv.run();
+
+		if (drv.simulator()->stoppedByNotificationCallback())
+			returnCode = 4;
 	}
 	catch (const cadet::IntegrationException& e)
 	{

--- a/src/libcadet/SimulatorImpl.cpp
+++ b/src/libcadet/SimulatorImpl.cpp
@@ -329,7 +329,10 @@ namespace cadet
 		if (sim->_notification)
 		{
 			const unsigned int secIdx = sim->getCurrentSection(t);
-			if (!sim->_notification->timeIntegrationLinearSolve(secIdx, t, NVEC_DATA(y), NVEC_DATA(yDot)))
+
+			sim->_stoppedByCallback = !sim->_notification->timeIntegrationLinearSolve(secIdx, t, NVEC_DATA(y), NVEC_DATA(yDot));
+
+			if (sim->_stoppedByCallback)
 				return IDA_TOO_MUCH_WORK;
 		}
 
@@ -373,7 +376,7 @@ namespace cadet
 		_nThreads(0), _sensErrorTestEnabled(true), _maxNewtonIter(4), _maxErrorTestFail(10), _maxConvTestFail(10),
 		_maxNewtonIterSens(4), _curSec(0), _skipConsistencyStateY(false), _skipConsistencySensitivity(false),
 		_consistentInitMode(ConsistentInitialization::Full), _consistentInitModeSens(ConsistentInitialization::Full),
-		_vecADres(nullptr), _vecADy(nullptr), _lastIntTime(0.0), _notification(nullptr)
+		_vecADres(nullptr), _vecADy(nullptr), _lastIntTime(0.0), _notification(nullptr), _stoppedByCallback(false)
 	{
 #if defined(ACTIVE_SFAD) || defined(ACTIVE_SETFAD)
 		LOG(Debug) << "Resetting AD directions from " << ad::getDirections() << " to default " << ad::getMaxDirections();
@@ -1048,6 +1051,8 @@ namespace cadet
 		ad::setDirections(numSensitivityAdDirections() + _model->requiredADdirs());
 #endif
 
+		_stoppedByCallback = false;
+
 		if (_notification)
 			_notification->timeIntegrationStart();
 
@@ -1225,7 +1230,10 @@ namespace cadet
 			if (_notification)
 			{
 				const double progress = (curT - static_cast<double>(_sectionTimes[0])) / (tEnd - static_cast<double>(_sectionTimes[0]));
-				if (!_notification->timeIntegrationSection(_curSec, curT, NVEC_DATA(_vecStateY), NVEC_DATA(_vecStateYdot), progress))
+
+				_stoppedByCallback = !_notification->timeIntegrationSection(_curSec, curT, NVEC_DATA(_vecStateY), NVEC_DATA(_vecStateYdot), progress);
+
+				if (_stoppedByCallback)
 				{
 					_lastIntTime = _timerIntegration.stop();
 					return;
@@ -1347,7 +1355,10 @@ namespace cadet
 					if (_notification)
 					{
 						const double progress = (curT - static_cast<double>(_sectionTimes[0])) / (tEnd - static_cast<double>(_sectionTimes[0]));
-						if (!_notification->timeIntegrationStep(_curSec, curT, NVEC_DATA(_vecStateY), NVEC_DATA(_vecStateYdot), progress))
+
+						_stoppedByCallback = !_notification->timeIntegrationStep(_curSec, curT, NVEC_DATA(_vecStateY), NVEC_DATA(_vecStateYdot), progress);
+
+						if (_stoppedByCallback)
 						{
 							_lastIntTime = _timerIntegration.stop();
 							return;
@@ -1379,13 +1390,25 @@ namespace cadet
 					if (_notification)
 					{
 						const double progress = (curT - static_cast<double>(_sectionTimes[0])) / (tEnd - static_cast<double>(_sectionTimes[0]));
-						if (!_notification->timeIntegrationStep(_curSec, curT, NVEC_DATA(_vecStateY), NVEC_DATA(_vecStateYdot), progress))
+						
+						_stoppedByCallback = !_notification->timeIntegrationStep(_curSec, curT, NVEC_DATA(_vecStateY), NVEC_DATA(_vecStateYdot), progress);
+						
+						if (_stoppedByCallback)
 						{
 							_lastIntTime = _timerIntegration.stop();
 							return;
 						}
 					}
 					break;
+				case IDA_LSOLVE_FAIL:
+
+					if (_stoppedByCallback)
+					{
+						_lastIntTime = _timerIntegration.stop();
+						return;
+					}
+					// no break, fall through into default if not stopped by callback
+
 				default:
 					_lastIntTime = _timerIntegration.stop();
 

--- a/src/libcadet/SimulatorImpl.cpp
+++ b/src/libcadet/SimulatorImpl.cpp
@@ -1407,7 +1407,7 @@ namespace cadet
 						_lastIntTime = _timerIntegration.stop();
 						return;
 					}
-					// no break, fall through into default if not stopped by callback
+					[[fallthrough]]; // no break, fall through into default if not stopped by callback
 
 				default:
 					_lastIntTime = _timerIntegration.stop();

--- a/src/libcadet/SimulatorImpl.hpp
+++ b/src/libcadet/SimulatorImpl.hpp
@@ -135,6 +135,8 @@ public:
 	virtual double totalSimulationDuration() const CADET_NOEXCEPT { return _timerIntegration.totalElapsedTime(); }
 
 	virtual void setNotificationCallback(INotificationCallback* nc) CADET_NOEXCEPT;
+	virtual bool stoppedByNotificationCallback() CADET_NOEXCEPT { return _stoppedByCallback; }
+
 protected:
 
 	/**
@@ -307,6 +309,7 @@ protected:
 	double _lastIntTime; //!< Last simulation duration
 
 	INotificationCallback* _notification; //!< Callback handler for notifications
+	bool _stoppedByCallback; //!< Flag that is set to @c true if the simulation was stopped by the notification callback
 };
 
 } // namespace cadet

--- a/src/libcadet/api/CAPIv1.cpp
+++ b/src/libcadet/api/CAPIv1.cpp
@@ -411,6 +411,8 @@ namespace v1
 
 			realDrv->run();
 
+			if(realDrv->simulator()->stoppedByNotificationCallback())
+				return cdtStoppedByCallback;
 		}
 		catch(const std::exception& e)
 		{

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -82,6 +82,7 @@ add_executable(testRunner testRunner.cpp JsonTestModels.cpp ColumnTests.cpp Unit
 	BandMatrix.cpp DenseMatrix.cpp SparseMatrix.cpp StringHashing.cpp LogUtils.cpp AD.cpp Subset.cpp Graph.cpp
 	NonlinearSolvers.cpp
 	ReferenceSimulations.cpp
+	testCallbacks.cpp
 	"${CMAKE_CURRENT_BINARY_DIR}/Paths_$<CONFIG>.cpp" "${CMAKE_SOURCE_DIR}/src/io/JsonParameterProvider.cpp"
 	${TEST_ADDITIONAL_SOURCES}
 	$<TARGET_OBJECTS:libcadet_object>)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -82,7 +82,7 @@ add_executable(testRunner testRunner.cpp JsonTestModels.cpp ColumnTests.cpp Unit
 	BandMatrix.cpp DenseMatrix.cpp SparseMatrix.cpp StringHashing.cpp LogUtils.cpp AD.cpp Subset.cpp Graph.cpp
 	NonlinearSolvers.cpp
 	ReferenceSimulations.cpp
-	testCallbacks.cpp
+	Callbacks.cpp
 	"${CMAKE_CURRENT_BINARY_DIR}/Paths_$<CONFIG>.cpp" "${CMAKE_SOURCE_DIR}/src/io/JsonParameterProvider.cpp"
 	${TEST_ADDITIONAL_SOURCES}
 	$<TARGET_OBJECTS:libcadet_object>)

--- a/test/Callbacks.cpp
+++ b/test/Callbacks.cpp
@@ -24,7 +24,6 @@ using json = nlohmann::json;
 #include "common/JsonParameterProvider.hpp"
 #include "JsonTestModels.hpp"
 
-
 namespace cadet
 {
 namespace test

--- a/test/Callbacks.cpp
+++ b/test/Callbacks.cpp
@@ -75,28 +75,9 @@ TEST_CASE("Test Callback: timeout interrupts simulation but data is saved", "[Ca
 		cadet::JsonParameterProvider pp = createLWEConfigForTimeoutTest("COLUMN_MODEL_1D_GRM", timeout, polyDeg, nElem);
 
 		driver.configure(pp);
+		driver.run();
 
-		bool properErrorThrown = false;
-
-		try
-		{
-			driver.run();
-		}
-		catch (const IntegrationException& e)
-		{
-			properErrorThrown = true;
-
-			REQUIRE_THAT(
-				std::string(e.what()),
-				Catch::Matchers::Contains("Error in IDASolve")
-			);
-			REQUIRE_THAT(
-				std::string(e.what()),
-				Catch::Matchers::Contains("IDA_LSOLVE_FAIL")
-			);
-		}
-
-		REQUIRE(properErrorThrown);
+		REQUIRE(driver.simulator()->stoppedByNotificationCallback());
 		// factor applied since callback is invoked at the end of a time step, which might be a little later than the specified timeout
 		REQUIRE(driver.simulator()->lastSimulationDuration() <= 1.2 * timeout);
 

--- a/test/Callbacks.cpp
+++ b/test/Callbacks.cpp
@@ -20,6 +20,7 @@
 #include <json.hpp>
 using json = nlohmann::json;
 
+#include "Logging.hpp"
 #include "common/Driver.hpp"
 #include "common/JsonParameterProvider.hpp"
 #include "JsonTestModels.hpp"
@@ -101,7 +102,8 @@ TEST_CASE("Test Callback: timeout interrupts simulation but data is saved", "[Ca
 
 		// test that part of the solution is written
 		cadet::InternalStorageUnitOpRecorder const* const simData = driver.solution()->unitOperation(0);
-		REQUIRE(simData->numDataPoints() > 3 && simData->numDataPoints() < 1500);
+		REQUIRE(simData->numDataPoints() > 3);
+		REQUIRE(simData->numDataPoints() < 1500);
 }
 
 TEST_CASE("Test Callback: timeout is ignored when set to zero", "[Callback],[Timeout],[CI]")

--- a/test/testCallbacks.cpp
+++ b/test/testCallbacks.cpp
@@ -1,0 +1,144 @@
+// =============================================================================
+//  CADET
+//  
+//  Copyright © 2008-present: The CADET-Core Authors
+//            Please see the AUTHORS.md file.
+//  
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the GNU Public License v3.0 (or, at
+//  your option, any later version) which accompanies this distribution, and
+//  is available at http://www.gnu.org/licenses/gpl.html
+// =============================================================================
+
+/**
+ * @file 
+ * Tests for Driver timeout functionality
+ */
+
+#include <catch.hpp>
+#include <chrono>
+#include <json.hpp>
+using json = nlohmann::json;
+
+#include "common/Driver.hpp"
+#include "common/JsonParameterProvider.hpp"
+#include "JsonTestModels.hpp"
+
+
+namespace cadet
+{
+namespace test
+{
+
+namespace
+{
+	/**
+	 * @brief Creates a LWE configuration with DG discretization for timeout testing
+	 * @details Uses increased discretization to make simulation take longer, allowing
+	 *          timeout to be tested reliably
+	 * @param [in] uoType Unit operation type
+	 * @param [in] timeout timeout
+	 * @return Configuration with timeout and DG discretization
+	 */
+	cadet::JsonParameterProvider createLWEConfigForTimeoutTest(const std::string& uoType, const double timeout, const int polyDeg, const int nElem)
+	{
+		// Start with standard LWE configuration
+		cadet::JsonParameterProvider paramProvider = createLWE(uoType, "DG");
+
+		// Set timeout
+		paramProvider.pushScope("solver");
+		paramProvider.set("TIMEOUT", timeout);
+		paramProvider.popScope();
+
+		// Increase discretization and thus required compute time
+		paramProvider.pushScope("model");
+		paramProvider.pushScope("unit_000");
+		paramProvider.pushScope("discretization");
+		paramProvider.set("POLYDEG", polyDeg);
+		paramProvider.set("NELEM", nElem);
+		paramProvider.popScope();
+		paramProvider.popScope();
+		paramProvider.popScope();
+
+		return paramProvider;
+	}
+
+} // namespace
+
+TEST_CASE("Test Callback: timeout interrupts simulation but data is saved", "[Callback],[Timeout],[CI]")
+{
+		const double timeout = 2.5;
+		const int polyDeg = 3;
+		const int nElem = 16;
+
+		Driver driver;
+		cadet::JsonParameterProvider pp = createLWEConfigForTimeoutTest("COLUMN_MODEL_1D_GRM", timeout, polyDeg, nElem);
+
+		driver.configure(pp);
+
+		bool properErrorThrown = false;
+
+		try
+		{
+			driver.run();
+		}
+		catch (const IntegrationException& e)
+		{
+			properErrorThrown = true;
+
+			REQUIRE_THAT(
+				std::string(e.what()),
+				Catch::Matchers::Contains("Error in IDASolve")
+			);
+			REQUIRE_THAT(
+				std::string(e.what()),
+				Catch::Matchers::Contains("IDA_LSOLVE_FAIL")
+			);
+		}
+
+		REQUIRE(properErrorThrown);
+		// factor applied since callback is invoked at the end of a time step, which might be a little later than the specified timeout
+		REQUIRE(driver.simulator()->lastSimulationDuration() <= 1.2 * timeout);
+
+		// test that part of the solution is written
+		cadet::InternalStorageUnitOpRecorder const* const simData = driver.solution()->unitOperation(0);
+		REQUIRE(simData->numDataPoints() > 3 && simData->numDataPoints() < 1500);
+}
+
+TEST_CASE("Test Callback: timeout is ignored when set to zero", "[Callback],[Timeout],[CI]")
+{
+	const double timeout = 0.0;
+	const int polyDeg = 2;
+	const int nElem = 4;
+
+	Driver driver;
+	cadet::JsonParameterProvider pp = createLWEConfigForTimeoutTest("COLUMN_MODEL_1D_GRM", timeout, polyDeg, nElem);
+
+	driver.configure(pp);
+	driver.run();
+
+	// test that whole solution is written
+	cadet::InternalStorageUnitOpRecorder const* const simData = driver.solution()->unitOperation(0);
+
+	REQUIRE(simData->numDataPoints() == 1501);
+}
+
+TEST_CASE("Test Callback: timeout is ignored when set to < 0", "[Callback],[Timeout],[CI]")
+{
+	const double timeout = -5.0;
+	const int polyDeg = 2;
+	const int nElem = 4;
+
+	Driver driver;
+	cadet::JsonParameterProvider pp = createLWEConfigForTimeoutTest("COLUMN_MODEL_1D_GRM", timeout, polyDeg, nElem);
+
+	driver.configure(pp);
+	driver.run();
+
+	// test that whole solution is written
+	cadet::InternalStorageUnitOpRecorder const* const simData = driver.solution()->unitOperation(0);
+	REQUIRE(simData->numDataPoints() == 1501);
+}
+
+} // namespace test
+} // namespace cadet


### PR DESCRIPTION
This PR adds tests for the timeout added in #366, checking if the timeout is successfully applied to a large simulation and the solution is written up until timeout.


CI fails with some logging issues, see https://github.com/cadet/CADET-Core/issues/667