### PR TITLE
ACT binding: make field `ACT_USE_ION_CONC` mandatory and improve docs

### DIFF
--- a/doc/interface/binding/affinity_complex_titration.rst
+++ b/doc/interface/binding/affinity_complex_titration.rst
@@ -1,11 +1,7 @@
 .. _affinity_complex_titration_config:
 
 Affinity Complex Titration
-==========================
-
-**Group /input/model/unit_XXX/particle_type_ZZZ/adsorption – ADSORPTION_MODEL = AFFINITY_COMPLEX_TITRATION**
-
-For information on model equations, refer to :ref:`affinity_complex_titration`. 
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 General remarks
 ---------------
@@ -15,6 +11,16 @@ General remarks
 * The ACT implementation currently supports **at most one bound state per component**.
 * The first component can be specified either as a negative logarithmic concentration
   (:math:`\mathrm{pH}`, :math:`\mathrm{pNa}`, ...) or as a raw ion concentration.
+* To convert an existing ACT setup from ``ACT_USE_ION_CONC = False`` to ``ACT_USE_ION_CONC = True`` while keeping exactly the same model response:
+    1. Replace the first component value :math:`\mathrm{pIon}` by :math:`c_{\mathrm{ion}} = 10^{-\mathrm{pIon}}`.
+    2. Replace ``ACT_PKAA`` by ``ACT_CMID_A = 10^{-\mathrm{ACT\_PKAA}}``.
+    3. Replace ``ACT_PKAG`` by ``ACT_CMID_G = 10^{-\mathrm{ACT\_PKAG}}``.
+    4. Keep ``ACT_KA``, ``ACT_KD``, ``ACT_QMAX``, ``ACT_ETAA``, and ``ACT_ETAG`` unchanged.
+
+
+**Group /input/model/unit_XXX/particle_type_ZZZ/adsorption – ADSORPTION_MODEL = AFFINITY_COMPLEX_TITRATION**
+
+For information on model equations, refer to :ref:`affinity_complex_titration`.
 
 ``IS_KINETIC``
    Selects kinetic or quasi-stationary adsorption mode: 1 = kinetic, 0 = quasi-stationary.
@@ -46,9 +52,6 @@ General remarks
 ===================  =========================  =========================================
 **Type:** bool       **Range:** {False, True}   **Length:** 1
 ===================  =========================  =========================================
-
-Core kinetic parameters
------------------------
 
 ``ACT_KA``
    Adsorption rate constants.
@@ -95,8 +98,7 @@ Core kinetic parameters
 **Type:** double     **Range:** :math:`\mathbb{R}`   **Length:** NCOMP
 ===================  =============================  =========================================
 
-Parameters for ``ACT_USE_ION_CONC = False``
-----------------------------------------------------
+**Group /input/model/unit_XXX/particle_type_ZZZ/adsorption – ACT_USE_ION_CONC = False**
 
 Use these parameters only when the first component is given as :math:`\mathrm{pIon}`
 (for example :math:`\mathrm{pH}`).
@@ -119,8 +121,7 @@ Use these parameters only when the first component is given as :math:`\mathrm{pI
 **Type:** double     **Range:** :math:`\mathbb{R}`   **Length:** NCOMP
 ===================  ==============================  =========================================
 
-Parameters for ``ACT_USE_ION_CONC = True``
----------------------------------------------------
+**Group /input/model/unit_XXX/particle_type_ZZZ/adsorption – ACT_USE_ION_CONC = True**
 
 Use these parameters only when the first component is given as a raw ion concentration.
 CADET internally converts them to the same negative logarithmic axis used by the ``ACT_PKAA`` / ``ACT_PKAG`` form.
@@ -144,14 +145,3 @@ CADET internally converts them to the same negative logarithmic axis used by the
 ===================  =========================  =========================================
 **Type:** double     **Range:** :math:`\ge 0`   **Length:** NCOMP
 ===================  =========================  =========================================
-
-Practical switching rule
-------------------------
-
-To convert an existing ACT setup from ``ACT_USE_ION_CONC = False`` to ``ACT_USE_ION_CONC = True`` while keeping
-exactly the same model response:
-
-1. Replace the first component value :math:`\mathrm{pIon}` by :math:`c_{\mathrm{ion}} = 10^{-\mathrm{pIon}}`.
-2. Replace ``ACT_PKAA`` by ``ACT_CMID_A = 10^{-\mathrm{ACT\_PKAA}}``.
-3. Replace ``ACT_PKAG`` by ``ACT_CMID_G = 10^{-\mathrm{ACT\_PKAG}}``.
-4. Keep ``ACT_KA``, ``ACT_KD``, ``ACT_QMAX``, ``ACT_ETAA``, and ``ACT_ETAG`` unchanged.

--- a/doc/interface/binding/index.rst
+++ b/doc/interface/binding/index.rst
@@ -48,7 +48,7 @@ Note that, in any case, ``/input/model/unit_XXX/particle_type_ZZZ/adsorption_000
 This group also takes precedence over a possibly existing ``/input/model/unit_XXX/particle_type_ZZZ/adsorption`` group.
 
 .. toctree::
-    :maxdepth: 2
+    :maxdepth: 1
 
     linear
     multi_component_langmuir

--- a/src/libcadet/model/binding/AffinityComplexTitrationBinding.cpp
+++ b/src/libcadet/model/binding/AffinityComplexTitrationBinding.cpp
@@ -85,15 +85,6 @@ namespace
 		return e / (static_cast<T>(1.0) + e);
 	}
 
-	inline bool getBoolWithFallback(cadet::IParameterProvider& paramProvider, const char* primaryName, const char* fallbackName, bool defaultValue)
-	{
-		if (paramProvider.exists(primaryName))
-			return paramProvider.getBool(primaryName);
-		if (paramProvider.exists(fallbackName))
-			return paramProvider.getBool(fallbackName);
-		return defaultValue;
-	}
-
 	inline std::vector<double> getDoubleArrayWithFallback(cadet::IParameterProvider& paramProvider, const char* primaryName, const char* fallbackName)
 	{
 		if (paramProvider.exists(primaryName))
@@ -186,7 +177,12 @@ namespace cadet
 				}
 
 				// Read parameters related to ion concentration handling
-				_useIonConc = getBoolWithFallback(paramProvider, "ACT_USE_ION_CONC", "EXT_ACT_USE_ION_CONC", false);
+				if (paramProvider.exists("ACT_USE_ION_CONC"))
+					_useIonConc = paramProvider.getBool("ACT_USE_ION_CONC");
+				else if (paramProvider.exists("EXT_ACT_USE_ION_CONC"))
+					_useIonConc = paramProvider.getBool("EXT_ACT_USE_ION_CONC");
+				else
+					throw InvalidParameterException("ACT_USE_ION_CONC does not exist in model specification");
 
 				// Read either pKa or cMid parameters depending on the value of _useIonConc
 				if (!_useIonConc)


### PR DESCRIPTION
Explicit > Implicit
Also, i found that the documentation had a different format which i fixed.
Also i reduced the toctree of binding models to 1 which I think is sufficient for that list