### PR TITLE
Change docker workflow to assign `latest` to any version tag image

### DIFF
--- a/.github/workflows/cd_docker.yml
+++ b/.github/workflows/cd_docker.yml
@@ -66,7 +66,7 @@ jobs:
             ghcr.io/cadet/CADET-Suite
           tags: |
             # Only set latest for stable tag builds
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') && !contains(github.ref_name, '-') }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v')}}
             type=ref,event=branch
             type=raw,value=Core-${{ env.CORE_TAG }}-Python-${{ env.PYTHON_VERSION }}-Process-${{ env.PROCESS_VERSION }}
 


### PR DESCRIPTION
We will assign the latest tag to any version release, including pre-releases. this way, we can use this label for the CI of cadet-verification.