### PR TITLE
fixup! Update coverage workflow (#677)

### DIFF
--- a/.github/workflows/ci_coverage.yml
+++ b/.github/workflows/ci_coverage.yml
@@ -62,7 +62,7 @@ jobs:
       run:
         shell: bash -l {0}
     env:
-      SRC_DIR: ${{ github.workspace }}/src
+      SRC_DIR: ${{ github.workspace }}
       BUILD_DIR: ${{ github.workspace }}/build
       INSTALL_PREFIX: ${{ github.workspace }}/install
       BUILD_TYPE: RelWithDebInfo 
@@ -70,7 +70,6 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: true
-          path: src
           ref: ${{ github.event.inputs.ref || github.ref }}
 
       - name: Install GCC-14
@@ -177,7 +176,7 @@ jobs:
       - name: Generate Coverage Report
         run: |
           gcovr \
-            --root "${{ github.workspace }}/src" \
+            --root "${{ github.workspace }}" \
             --filter "${{ github.workspace }}/(src|include|build/src)" \
             --exclude-directories '.*ThirdParty.*' \
             --cobertura -o coverage.xml \


### PR DESCRIPTION
#677 leads to a significant drop in codecoverage (around 16%). This should be a small fix for the drop. I guess it is only a small error due to wrong pathing of the root directory within gcovr.