### PR TITLE
Fix exception in 2D unit function `setFlowRates`

### DIFF
--- a/src/libcadet/model/ColumnModel2D.cpp
+++ b/src/libcadet/model/ColumnModel2D.cpp
@@ -791,7 +791,7 @@ void ColumnModel2D::notifyDiscontinuousSectionTransition(double t, unsigned int 
 	}
 }
 
-void ColumnModel2D::setFlowRates(active const* in, active const* out) CADET_NOEXCEPT
+void ColumnModel2D::setFlowRates(active const* in, active const* out)
 {
 	_convDispOp.setFlowRates(in, out);
 }

--- a/src/libcadet/model/ColumnModel2D.hpp
+++ b/src/libcadet/model/ColumnModel2D.hpp
@@ -79,7 +79,7 @@ public:
 
 	virtual UnitOpIdx unitOperationId() const CADET_NOEXCEPT { return _unitOpIdx; }
 	virtual unsigned int numComponents() const CADET_NOEXCEPT { return _disc.nComp; }
-	virtual void setFlowRates(active const* in, active const* out) CADET_NOEXCEPT;
+	virtual void setFlowRates(active const* in, active const* out);
 	virtual unsigned int numInletPorts() const CADET_NOEXCEPT { return _disc.radNPoints; }
 	virtual unsigned int numOutletPorts() const CADET_NOEXCEPT { return _disc.radNPoints; }
 	virtual bool canAccumulate() const CADET_NOEXCEPT { return false; }

--- a/src/libcadet/model/UnitOperation.hpp
+++ b/src/libcadet/model/UnitOperation.hpp
@@ -550,7 +550,7 @@ public:
 	 * @param [in] in Array with total volumetric inlet flow rate for each port
 	 * @param [in] out Array with total volumetric outlet flow rate for each port
 	 */
-	virtual void setFlowRates(active const* in, active const* out) CADET_NOEXCEPT = 0;
+	virtual void setFlowRates(active const* in, active const* out) = 0;
 
 	/**
 	* @brief Returns whether this unit operation supports non-matching volumetric inlet and outlet flow rates


### PR DESCRIPTION
This PR fixes the exception in the `setFlowRates` function of 2D DG models. Exceptions were disallowed in that function via the compile flag CADET_NOEXCEPT, leading to undefined behaviour without error or log.