### PR TITLE
Fix tbb inclusion and 2D unit parallelization loop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -205,6 +205,38 @@ if (ENABLE_THREADING)
 	if(NOT TBB_FOUND)
 		find_package(TBB COMPONENTS tbb OPTIONAL_COMPONENTS tbb_preview)
 	endif()
+	
+	# Detect TBB_INTERFACE_VERSION for modern TBB CONFIG mode
+	if (TBB_FOUND AND NOT DEFINED TBB_INTERFACE_VERSION)
+		# Get include directory from target
+		if(TARGET TBB::tbb)
+			get_target_property(TBB_INCLUDE_DIRS TBB::tbb INTERFACE_INCLUDE_DIRECTORIES)
+		elseif(TARGET TBB::tbb_preview)
+			get_target_property(TBB_INCLUDE_DIRS TBB::tbb_preview INTERFACE_INCLUDE_DIRECTORIES)
+		endif()
+		
+		if (TBB_INCLUDE_DIRS)
+			list(GET TBB_INCLUDE_DIRS 0 TBB_INCLUDE_DIR)
+			
+			if (EXISTS "${TBB_INCLUDE_DIR}/oneapi/tbb/version.h")
+				file(READ "${TBB_INCLUDE_DIR}/oneapi/tbb/version.h" _tbb_version_file)
+			elseif (EXISTS "${TBB_INCLUDE_DIR}/tbb/tbb_stddef.h")
+				file(READ "${TBB_INCLUDE_DIR}/tbb/tbb_stddef.h" _tbb_version_file)
+			endif()
+			
+			if (_tbb_version_file)
+				string(REGEX REPLACE ".*#define TBB_VERSION_MAJOR ([0-9]+).*" "\\1"
+					TBB_VERSION_MAJOR "${_tbb_version_file}")
+				string(REGEX REPLACE ".*#define TBB_VERSION_MINOR ([0-9]+).*" "\\1"
+					TBB_VERSION_MINOR "${_tbb_version_file}")
+				string(REGEX REPLACE ".*#define TBB_INTERFACE_VERSION ([0-9]+).*" "\\1"
+					TBB_INTERFACE_VERSION "${_tbb_version_file}")
+				
+				message(STATUS "Detected TBB interface version: ${TBB_INTERFACE_VERSION}")
+			endif()
+		endif()
+	endif()
+	
 	set_package_properties(TBB PROPERTIES
 		TYPE RECOMMENDED
 		PURPOSE "Accelerates computation via multi-threading"
@@ -231,30 +263,16 @@ if (ENABLE_THREADING)
 			set(CADET_PARALLEL_FLAG "CADET_PARALLELIZE")
 		endif()
 
-		get_target_property(TBB_IFACE_COMP_DEF ${TBB_TARGET} INTERFACE_COMPILE_DEFINITIONS)
-		if (TBB_IFACE_COMP_DEF)
-			list(APPEND TBB_IFACE_COMP_DEF ${CADET_PARALLEL_FLAG})
-		else()
-			set(TBB_IFACE_COMP_DEF ${CADET_PARALLEL_FLAG})
+		# Set compile definitions using modern CMake approach
+		if (CADET_PARALLEL_FLAG)
+			target_compile_definitions(${TBB_TARGET} INTERFACE ${CADET_PARALLEL_FLAG})
 		endif()
-		if (TBB_IFACE_COMP_DEF)
-			set_target_properties(${TBB_TARGET} PROPERTIES INTERFACE_COMPILE_DEFINITIONS "${TBB_IFACE_COMP_DEF}")
-		endif()
-		unset(TBB_IFACE_COMP_DEF)
 
 		if (TBB_INTERFACE_VERSION GREATER_EQUAL 11004)
-			# Use global_control instead of task_scheduler_init
-			get_target_property(TBB_IFACE_COMP_DEF ${TBB_TARGET} INTERFACE_COMPILE_DEFINITIONS)
-			set_target_properties(${TBB_TARGET} PROPERTIES INTERFACE_COMPILE_DEFINITIONS "${TBB_IFACE_COMP_DEF}")
-			if (TBB_IFACE_COMP_DEF)
-				list(APPEND TBB_IFACE_COMP_DEF "CADET_TBB_GLOBALCTRL")
-			else()
-				set(TBB_IFACE_COMP_DEF "CADET_TBB_GLOBALCTRL")
-			endif()
-			if (TBB_IFACE_COMP_DEF)
-				set_target_properties(${TBB_TARGET} PROPERTIES INTERFACE_COMPILE_DEFINITIONS "${TBB_IFACE_COMP_DEF}")
-			endif()
-			unset(TBB_IFACE_COMP_DEF)
+			message(STATUS "Using TBB global_control (TBB_INTERFACE_VERSION=${TBB_INTERFACE_VERSION} >= 11004)")
+			target_compile_definitions(${TBB_TARGET} INTERFACE CADET_TBB_GLOBALCTRL)
+		else()
+			message(STATUS "Using TBB task_scheduler_init (TBB_INTERFACE_VERSION=${TBB_INTERFACE_VERSION} < 11004)")
 		endif()
 	endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,7 +199,12 @@ set(TBB_TARGET "")
 if (ENABLE_THREADING)
 	set(TBB_PREFER_STATIC_LIBS ${ENABLE_STATIC_LINK_DEPS})
 	set(TBB_USE_DEBUG_BUILD OFF)
-	find_package(TBB COMPONENTS tbb OPTIONAL_COMPONENTS tbb_preview)
+	# Prefer modern config package (conda-forge, oneAPI, vcpkg, system installs)
+	find_package(TBB CONFIG QUIET COMPONENTS tbb OPTIONAL_COMPONENTS tbb_preview)
+	# Fallback to legacy FindTBB.cmake
+	if(NOT TBB_FOUND)
+		find_package(TBB COMPONENTS tbb OPTIONAL_COMPONENTS tbb_preview)
+	endif()
 	set_package_properties(TBB PROPERTIES
 		TYPE RECOMMENDED
 		PURPOSE "Accelerates computation via multi-threading"
@@ -208,8 +213,12 @@ if (ENABLE_THREADING)
 	set(CADET_PARALLEL_FLAG "")
 	if (TBB_FOUND)
 		# Use tbb_preview instead of tbb if it has been found
-		if (TBB_tbb_preview_FOUND)
+		if(TARGET TBB::tbb_preview)
+			set(TBB_TARGET "TBB::tbb_preview")
+		elseif(TARGET TBB::TBBpreview)
 			set(TBB_TARGET "TBB::TBBpreview")
+		elseif(TARGET TBB::tbb)
+			set(TBB_TARGET "TBB::tbb")
 		else()
 			set(TBB_TARGET "TBB::TBB")
 		endif()

--- a/src/libcadet/model/ColumnModel1D.cpp
+++ b/src/libcadet/model/ColumnModel1D.cpp
@@ -964,41 +964,42 @@ int ColumnModel1D::residualImpl(double t, unsigned int secIdx, StateType const* 
 			}
 
 			residualBulk<StateType, ResidualType, ParamType, wantJac, wantRes>(t, secIdx, y, yDot, res, threadLocalMem);
-
-			continue;
 		}
-
-		const unsigned int parType = (pblk - 1) / _disc.nPoints;
-		const unsigned int colNode = (pblk - 1) % _disc.nPoints;
-
-		linalg::BandedEigenSparseRowIterator jacIt;
-
-		if (wantJac)
+		else
 		{
-			jacIt = linalg::BandedEigenSparseRowIterator(
-				_globalJac,
-				idxr.offsetCp(ParticleTypeIndex{ parType }, ParticleIndex{ colNode })
+			const unsigned int parType = (pblk - 1) / _disc.nPoints;
+			const unsigned int colNode = (pblk - 1) % _disc.nPoints;
+
+			linalg::BandedEigenSparseRowIterator jacIt;
+
+			if (wantJac)
+			{
+				jacIt = linalg::BandedEigenSparseRowIterator(
+					_globalJac,
+					idxr.offsetCp(ParticleTypeIndex{ parType }, ParticleIndex{ colNode })
+				);
+			}
+
+			model::columnPackingParameters packing
+			{
+				_parTypeVolFrac[parType + _disc.nParType * colNode],
+				_colPorosity,
+				ColumnPosition{ _convDispOp.relativeCoordinate(colNode), 0.0, 0.0 }
+			};
+
+
+			_particles[parType]->residual(t, secIdx,
+				y + idxr.offsetCp(ParticleTypeIndex{ parType }, ParticleIndex{ colNode }),
+				y + idxr.offsetC() + colNode * idxr.strideColNode(),
+				yDot ? yDot + idxr.offsetCp(ParticleTypeIndex{ parType }, ParticleIndex{ colNode }) : nullptr,
+				res ? res + idxr.offsetCp(ParticleTypeIndex{ parType }, ParticleIndex{ colNode }) : nullptr,
+				res ? res + idxr.offsetC() + colNode * idxr.strideColNode() : nullptr,
+				packing, jacIt, tlmAlloc,
+				typename cadet::ParamSens<ParamType>::enabled()
 			);
 		}
 
-		model::columnPackingParameters packing
-		{
-			_parTypeVolFrac[parType + _disc.nParType * colNode],
-			_colPorosity,
-			ColumnPosition{ _convDispOp.relativeCoordinate(colNode), 0.0, 0.0 }
-		};
-
-
-		_particles[parType]->residual(t, secIdx,
-			y + idxr.offsetCp(ParticleTypeIndex{ parType }, ParticleIndex{ colNode }),
-			y + idxr.offsetC() + colNode * idxr.strideColNode(),
-			yDot ? yDot + idxr.offsetCp(ParticleTypeIndex{ parType }, ParticleIndex{ colNode }) : nullptr,
-			res ? res + idxr.offsetCp(ParticleTypeIndex{ parType }, ParticleIndex{ colNode }) : nullptr,
-			res ? res + idxr.offsetC() + colNode * idxr.strideColNode() : nullptr,
-			packing, jacIt, tlmAlloc,
-			typename cadet::ParamSens<ParamType>::enabled()
-		);
-	}
+	} CADET_PARFOR_END;
 
 	if (!wantRes)
 		return 0;


### PR DESCRIPTION
The CMake configuration was failing to detect TBB.
Subsequently, CMake failed to detect TBB_INTERFACE_VERSION when
using modern TBB CONFIG packages (oneTBB, conda-forge, vcpkg), causing
CADET_TBB_GLOBALCTRL to never be defined. This resulted in compilation
errors due to the use of deprecated task_scheduler_init API.
Lastly, the 2D column unit did not implement the tbb parallelization loop properly.

Changes:
- Add TBB_INTERFACE_VERSION detection for CONFIG mode by reading version
  from oneapi/tbb/version.h or tbb/tbb_stddef.h
- Replace manual INTERFACE_COMPILE_DEFINITIONS management with modern
  target_compile_definitions() CMake commands
- Add diagnostic messages to report detected TBB version and selected API
- Ensure CADET_TBB_GLOBALCTRL is properly set for TBB versions >= 11004
- fix 2D unit residual parallelization loop

This fixes compatibility with oneTBB 2022.1+ where task_scheduler_init
has been removed in favor of tbb::global_control.