### PR TITLE
Fix incorrect CADET-Python introduction code snippets in developer guide

### DIFF
--- a/doc/developer_guide/cadet_python.rst
+++ b/doc/developer_guide/cadet_python.rst
@@ -89,7 +89,7 @@ In this group, we set the parameters related to transport and column geometry.
 For a more detailed description of the parameters and their units, see the :ref:`corresponding file format <axial_flow_column_1D_config>`.
 
 .. literalinclude:: examples/breakthrough.py
-    :lines: 20-34
+    :lines: 20-36
 
 Note that film, particle, and surface diffusion are all component-specific, that is, they are vectors of length ``n_components``.
 
@@ -106,7 +106,7 @@ They are described in the :ref:`corresponding file format specification <multi_c
 In case of the Langmuir model, we have to specify the parameters ``kA``, ``kD``, and ``qMAX``.
 
 .. literalinclude:: examples/breakthrough.py
-    :lines: 37-41
+    :lines: 39-44
 
 Initial Conditions
 ~~~~~~~~~~~~~~~~~~
@@ -116,7 +116,7 @@ These concentrations are entered as vectors, where each entry gives the concentr
 In this example, we start with an empty column.
 
 .. literalinclude:: examples/breakthrough.py
-    :lines: 44-45
+    :lines: 47-49
 
 Setting up the Discretization
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -133,7 +133,7 @@ Moreover, we have to specify the number of bound states for each component.
 Finally, we set some other options for the discretization, which usually do not need to be changed.
 
 .. literalinclude:: examples/breakthrough.py
-    :lines: 48-66
+    :lines: 51-61
 
 Outlet Model
 ^^^^^^^^^^^^
@@ -143,7 +143,7 @@ The ``OUTLET`` is another pseudo unit operation that serves as sink for the syst
 .. note:: In this case, the outlet unit is actually not required. We could use the outlet concentration signal of the column model instead.
 
 .. literalinclude:: examples/breakthrough.py
-    :lines: 69-70
+    :lines: 64-65
 
 
 2. Setting up Time Sections and Connections
@@ -166,7 +166,7 @@ If the transition is continuous, the time integrator can try to step over the tr
 If you are unsure about the continuity, just leave it at ``0``.
 
 .. literalinclude:: examples/breakthrough.py
-    :lines: 73-75
+    :lines: 68-70
 
 As mentioned earlier, we now define the ``INLET`` profile using a piecewise cubic polynomial.
 On each section :math:`[ t_i, t_{i+1} ]` a cubic polynomial :math:`p_i` is defined:
@@ -184,7 +184,7 @@ Since the column should be constantly fed with :math:`1.0 \cdot 10^{-3} mol / m^
 Note that for more components, a vector of coefficients needs to be specified.
 
 .. literalinclude:: examples/breakthrough.py
-    :lines: 78-81
+    :lines: 73-76
 
 System Connectivity
 ^^^^^^^^^^^^^^^^^^^
@@ -206,7 +206,7 @@ Usually, ``Component from`` and ``Component to`` can be set to ``-1``, which wil
 In this case, we connect all components of ``unit_000`` to ``unit_001``, and from ``unit_001`` to ``unit_002``.
 
 .. literalinclude:: examples/breakthrough.py
-    :lines: 84-88
+    :lines: 79-83
 
 .. note:: Since the flow in the column models is incompressible, the total entering flow rate must equal the total outgoing flow rate.
   This restriction does not apply to a :ref:`CSTR model <cstr_model>`, because it has a variable volume.
@@ -220,7 +220,7 @@ First, we set some options for the solver and the time integrator.
 Usually, these only need to be adapted in special cases.
 
 .. literalinclude:: examples/breakthrough.py
-    :lines: 91-104
+    :lines: 86-99
 
 Of these options, the most interesting ones are ``time_integrator.abstol`` and ``time_integrator.reltol``, which control the errors during time integration, and ``nthreads``, which sets the number of CPU cores CADET is allowed to use.
 
@@ -234,21 +234,21 @@ In this example, we want to write the concentration profile of the inlet and out
 In addition, we are interested in the concentration in the interstitial volume (bulk volume) of the column.
 
 .. literalinclude:: examples/breakthrough.py
-    :lines: 106-115
+    :lines: 102-110
 
 Finally, we have to set the time points at which we want to evaluate the solution.
 Note that the end time must not exceed the last section time specified in the model.
 If the time points are not set explicitly, the time integrator outputs the solution at arbitrary time points between ``0`` and ``section_times[-1]``.
 
 .. literalinclude:: examples/breakthrough.py
-    :lines: 117-118
+    :lines: 113
 
 The last remaining step is to actually run the simulation.
 For this, we have to specify a filename, save the configuration to ``H5``-format and call call the ``model``\ ’s ``run()`` function.
 We check if the simulation has completed successfully and load the results.
 
 .. literalinclude:: examples/breakthrough.py
-    :lines: 121-131
+    :lines: 116-126
 
 4. Plotting the Results
 -----------------------
@@ -258,7 +258,7 @@ The structure and format of the data is described in the :ref:`file format speci
 Finally, we plot the concentration signal at the outlet of the column.
 
 .. literalinclude:: examples/breakthrough.py
-    :lines: 134-141
+    :lines: 129-136
 
 .. image:: _images/breakthrough_chromatogram.png
 


### PR DESCRIPTION
## Description of the PR

This PR fixes incorrect and incomplete code snippets in the [CADET-Python Introduction](https://github.com/cadet/CADET-Core/blob/master/doc/developer_guide/cadet_python.rst) section of the developer guide.
The previous version contained inaccurate and missing code lines, which affected reproducibility of the example.

## Type of Change

🔹 **Documentation update**

## Checklist

Please ensure you've completed the following tasks. Mark them with an `x` inside the brackets:

- [x] I have checked the CADET [Developer Guide](https://cadet.github.io/master/developer_guide)  
- [x] My code follows the project's code style and [RSE guidelines](https://rse-guidelines.readthedocs.io/en/latest/intro.html).
- [x] I have run relevant tests and verified that my changes do not break existing functionality.
- [x] I have updated documentation as needed.
- [x] I have reviewed my code for security considerations and potential vulnerabilities.
- [x] I have added necessary comments or descriptions for maintainers and reviewers.

## Additional Notes

The `v5.1.X` branch also contains some missing code lines, which may need to be addressed separately.