### PR TITLE
ANN binding: extend to arbitrary number of network layers

### DIFF
--- a/src/libcadet/model/binding/NeuralNetwork.h
+++ b/src/libcadet/model/binding/NeuralNetwork.h
@@ -13,6 +13,7 @@
 
 #include <Eigen/Dense>
 
+#include <algorithm>
 #include <cmath>
 #include <stdexcept>
 #include <string>
@@ -21,9 +22,8 @@
 // =============================================================================
 // ClassANN — Feedforward neural network with ELU activations.
 //
-// Architecture (single-component, scalar output):
-//   1-hidden-layer:  y = W2 * ELU(W1 * x + b1) + b2
-//   2-hidden-layer:  y = W3 * ELU(W2 * ELU(W1 * x + b1) + b2) + b3
+// Architecture (N hidden layers, scalar output):
+//   y = W_{N} * ELU(... ELU(W_0 * x + b_0) ...) + b_{N}
 //
 // Weight storage convention (matches original training export):
 //   All weight matrices are stored COLUMN-MAJOR (Fortran order).
@@ -31,7 +31,7 @@
 //   W(row=i, col=j) = kernel[i + j * n_out].
 //   This means Eigen::Map<MatrixXd>(kernel.data(), n_out, n_in) gives W directly.
 //
-// MKL has been removed. All linear algebra uses Eigen.
+// All hidden layers share the same width (num_nodes).
 // All workspace buffers are pre-allocated at construction — no heap allocation
 // inside forward/backward methods.
 // =============================================================================
@@ -41,9 +41,9 @@ class ClassANN
 public:
 	// -------------------------------------------------------------------------
 	// Constructor — pre-allocates all workspace buffers.
-	// num_layer: number of hidden layers (1 or 2)
-	// num_nodes: nodes per hidden layer (same for all hidden layers)
-	// num_inputs: input dimensionality
+	// num_layer:   number of hidden layers (>= 1); all share width num_nodes
+	// num_nodes:   nodes per hidden layer
+	// num_inputs:  input dimensionality
 	// num_outputs: output dimensionality (1 for single-component isotherm)
 	// -------------------------------------------------------------------------
 	ClassANN(unsigned int num_layer, unsigned int num_nodes,
@@ -52,176 +52,112 @@ public:
 		, number_of_nodes(num_nodes)
 		, number_of_input(num_inputs)
 		, number_of_output(num_outputs)
-		, ws_z1(num_nodes)
-		, ws_z1_pre(num_nodes)
-		, ws_z2(num_nodes)
-		, ws_delta(num_nodes)
-		, ws_delta2(num_nodes)
+		, ws_z(num_layer, Eigen::VectorXd(num_nodes))
+		, ws_h(num_layer, Eigen::VectorXd(num_nodes))
+		, ws_delta_cur(num_nodes)
+		, ws_delta_nxt(num_nodes)
 	{
-		if (num_layer != 1 && num_layer != 2)
+		if (num_layer < 1)
 			throw std::invalid_argument(
-				"ClassANN: only 1 or 2 hidden layers are supported.");
+				"ClassANN: at least 1 hidden layer is required.");
 	}
 
 	// -------------------------------------------------------------------------
-	// Forward pass — 1-hidden-layer network.
+	// General forward pass for N hidden layers.
 	//
-	// y = W2 * ELU(W1 * x + b1) + b2
-	//
-	// kernel0: W1 col-major (num_nodes x num_input)
-	// bias0:   b1 (num_nodes,)
-	// kernel1: W2 col-major (num_output x num_nodes)
-	// bias1:   b2 (num_output,)
-	// input:   x  (num_input,)
-	// output:  y  (num_output,)   -- must be pre-allocated by caller
+	// kernels[0..N-1]: hidden layer weight matrices, col-major (num_nodes x prev)
+	// kernels[N]:      output layer weight matrix,   col-major (num_output x num_nodes)
+	// biases[0..N-1]:  hidden layer biases  (num_nodes,)
+	// biases[N]:       output layer bias    (num_output,)
+	// input:           x  (num_input,)
+	// output:          y  (num_output,)  — must be pre-allocated by caller
 	// -------------------------------------------------------------------------
-	void forward_single_layer(
+	void forward(
+		const std::vector<const double*>& kernels,
+		const std::vector<const double*>& biases,
 		const double* input,
-		const double* kernel0, const double* bias0,
-		const double* kernel1, const double* bias1,
 		double* output) const
 	{
 		using Map    = Eigen::Map<const Eigen::MatrixXd>;
 		using MapVec = Eigen::Map<const Eigen::VectorXd>;
 
-		// z1 = W1 * x + b1
-		ws_z1 = Map(kernel0, number_of_nodes, number_of_input)
-		        * MapVec(input, number_of_input)
-		        + MapVec(bias0, number_of_nodes);
+		const unsigned int N = number_of_layers;
 
-		elu_inplace(ws_z1);   // h1 = ELU(z1), stored in ws_z1
+		// First hidden layer: h[0] = ELU(W[0] * x + b[0])
+		ws_h[0] = Map(kernels[0], number_of_nodes, number_of_input)
+		          * MapVec(input, number_of_input)
+		          + MapVec(biases[0], number_of_nodes);
+		elu_inplace(ws_h[0]);
 
-		// y = W2 * h1 + b2
+		// Remaining hidden layers: h[l] = ELU(W[l] * h[l-1] + b[l])
+		for (unsigned int l = 1; l < N; ++l)
+		{
+			ws_h[l] = Map(kernels[l], number_of_nodes, number_of_nodes)
+			          * ws_h[l - 1]
+			          + MapVec(biases[l], number_of_nodes);
+			elu_inplace(ws_h[l]);
+		}
+
+		// Output layer (no activation): y = W[N] * h[N-1] + b[N]
 		Eigen::Map<Eigen::VectorXd>(output, number_of_output) =
-		    Map(kernel1, number_of_output, number_of_nodes) * ws_z1
-		    + MapVec(bias1, number_of_output);
+		    Map(kernels[N], number_of_output, number_of_nodes) * ws_h[N - 1]
+		    + MapVec(biases[N], number_of_output);
 	}
 
 	// -------------------------------------------------------------------------
-	// Forward pass — 2-hidden-layer network.
+	// General Jacobian (gradient dy/dx) for N hidden layers.
 	//
-	// y = W3 * ELU(W2 * ELU(W1 * x + b1) + b2) + b3
+	// kernels / biases: same layout as forward().
+	//   biases[N] (output layer) is accepted but not used — keeps the
+	//   interface symmetric with forward() so callers can reuse the same arrays.
 	//
-	// kernel0: W1 col-major (num_nodes x num_input)
-	// bias0:   b1 (num_nodes,)
-	// kernel1: W2 col-major (num_nodes x num_nodes)
-	// bias1:   b2 (num_nodes,)
-	// kernel2: W3 col-major (num_output x num_nodes)
-	// bias2:   b3 (num_output,)
-	// input:   x  (num_input,)
-	// output:  y  (num_output,)   -- must be pre-allocated by caller
-	// -------------------------------------------------------------------------
-	void forward_two_layers(
-		const double* input,
-		const double* kernel0, const double* bias0,
-		const double* kernel1, const double* bias1,
-		const double* kernel2, const double* bias2,
-		double* output) const
-	{
-		using Map    = Eigen::Map<const Eigen::MatrixXd>;
-		using MapVec = Eigen::Map<const Eigen::VectorXd>;
-
-		// z1 = W1 * x + b1,  h1 = ELU(z1)
-		ws_z1 = Map(kernel0, number_of_nodes, number_of_input)
-		        * MapVec(input, number_of_input)
-		        + MapVec(bias0, number_of_nodes);
-		elu_inplace(ws_z1);
-
-		// z2 = W2 * h1 + b2,  h2 = ELU(z2)
-		ws_z2 = Map(kernel1, number_of_nodes, number_of_nodes) * ws_z1
-		        + MapVec(bias1, number_of_nodes);
-		elu_inplace(ws_z2);
-
-		// y = W3 * h2 + b3  (no activation on output layer)
-		Eigen::Map<Eigen::VectorXd>(output, number_of_output) =
-		    Map(kernel2, number_of_output, number_of_nodes) * ws_z2
-		    + MapVec(bias2, number_of_output);
-	}
-
-	// -------------------------------------------------------------------------
-	// Jacobian — 1-hidden-layer network.
-	//
-	// dy/dx = W1^T * diag(ELU'(z1)) * W2^T
 	// For scalar output (num_output=1) this gives a (num_input,) gradient vector.
-	//
-	// The pre-activation z1 is computed internally and stored in ws_z1_pre.
 	// -------------------------------------------------------------------------
-	void jacobian_single_layer(
+	void jacobian(
+		const std::vector<const double*>& kernels,
+		const std::vector<const double*>& biases,
 		const double* input,
-		const double* kernel0, const double* bias0,
-		const double* kernel1,
 		double* grad_out) const
 	{
 		using Map    = Eigen::Map<const Eigen::MatrixXd>;
 		using MapVec = Eigen::Map<const Eigen::VectorXd>;
 
-		// Forward: z1 = W1 * x + b1  (keep pre-activation for ELU')
-		ws_z1_pre = Map(kernel0, number_of_nodes, number_of_input)
-		            * MapVec(input, number_of_input)
-		            + MapVec(bias0, number_of_nodes);
+		const unsigned int N = number_of_layers;
 
-		// delta = W2^T * 1  (output layer weight transposed, scalar output)
-		// For num_output=1: W2 has shape (1 x num_nodes), W2^T is (num_nodes x 1)
-		ws_delta = Map(kernel1, number_of_output, number_of_nodes).transpose()
-		           * Eigen::VectorXd::Ones(number_of_output);
+		// Forward pass: collect pre-activations (ws_z) and post-activations (ws_h)
+		ws_z[0] = Map(kernels[0], number_of_nodes, number_of_input)
+		          * MapVec(input, number_of_input)
+		          + MapVec(biases[0], number_of_nodes);
+		ws_h[0] = ws_z[0];
+		elu_inplace(ws_h[0]);
 
-		// Multiply element-wise by ELU'(z1)
-		elu_backward_inplace(ws_delta, ws_z1_pre);
-
-		// grad = W1^T * delta
-		Eigen::Map<Eigen::VectorXd>(grad_out, number_of_input) =
-		    Map(kernel0, number_of_nodes, number_of_input).transpose() * ws_delta;
-	}
-
-	// -------------------------------------------------------------------------
-	// Jacobian — 2-hidden-layer network.
-	//
-	// dy/dx = W1^T * diag(ELU'(z1)) * W2^T * diag(ELU'(z2)) * W3^T
-	//
-	// Backprop steps:
-	//   delta  = W3^T * 1              [elementwise * ELU'(z2)]
-	//   delta2 = W2^T * delta          [elementwise * ELU'(z1)]
-	//   grad   = W1^T * delta2
-	// -------------------------------------------------------------------------
-	void jacobian_two_layers(
-		const double* input,
-		const double* kernel0, const double* bias0,
-		const double* kernel1, const double* bias1,
-		const double* kernel2,
-		double* grad_out) const
-	{
-		using Map    = Eigen::Map<const Eigen::MatrixXd>;
-		using MapVec = Eigen::Map<const Eigen::VectorXd>;
-
-		// Forward pass to get pre-activations z1 and z2
-		// z1 = W1 * x + b1
-		ws_z1_pre = Map(kernel0, number_of_nodes, number_of_input)
-		            * MapVec(input, number_of_input)
-		            + MapVec(bias0, number_of_nodes);
-
-		// h1 = ELU(z1)
-		ws_z1 = ws_z1_pre;
-		elu_inplace(ws_z1);
-
-		// z2 = W2 * h1 + b2  (keep pre-activation for ELU')
-		ws_z2 = Map(kernel1, number_of_nodes, number_of_nodes) * ws_z1
-		        + MapVec(bias1, number_of_nodes);
+		for (unsigned int l = 1; l < N; ++l)
+		{
+			ws_z[l] = Map(kernels[l], number_of_nodes, number_of_nodes)
+			          * ws_h[l - 1]
+			          + MapVec(biases[l], number_of_nodes);
+			ws_h[l] = ws_z[l];
+			elu_inplace(ws_h[l]);
+		}
 
 		// Backward pass
-		// delta = W3^T (scalar output => W3 shape (1 x n_h), W3^T shape (n_h,))
-		ws_delta = Map(kernel2, number_of_output, number_of_nodes).transpose()
-		           * Eigen::VectorXd::Ones(number_of_output);
+		// Initial delta: W_out^T * 1  elementwise  ELU'(z[N-1])
+		ws_delta_cur = Map(kernels[N], number_of_output, number_of_nodes).transpose()
+		               * Eigen::VectorXd::Ones(number_of_output);
+		elu_backward_inplace(ws_delta_cur, ws_z[N - 1]);
 
-		// delta .*= ELU'(z2)
-		elu_backward_inplace(ws_delta, ws_z2);
+		// Propagate delta back through hidden layers N-2 down to 0
+		for (int l = static_cast<int>(N) - 2; l >= 0; --l)
+		{
+			ws_delta_nxt = Map(kernels[l + 1], number_of_nodes, number_of_nodes).transpose()
+			               * ws_delta_cur;
+			elu_backward_inplace(ws_delta_nxt, ws_z[l]);
+			ws_delta_cur.swap(ws_delta_nxt);
+		}
 
-		// delta2 = W2^T * delta  .*  ELU'(z1)
-		ws_delta2 = Map(kernel1, number_of_nodes, number_of_nodes).transpose() * ws_delta;
-		elu_backward_inplace(ws_delta2, ws_z1_pre);
-
-		// grad = W1^T * delta2
+		// Input-space gradient: grad = W_0^T * delta
 		Eigen::Map<Eigen::VectorXd>(grad_out, number_of_input) =
-		    Map(kernel0, number_of_nodes, number_of_input).transpose() * ws_delta2;
+		    Map(kernels[0], number_of_nodes, number_of_input).transpose() * ws_delta_cur;
 	}
 
 private:
@@ -231,11 +167,10 @@ private:
 	unsigned int number_of_output;
 
 	// Pre-allocated workspace (mutable so forward/backward can be called on const objects)
-	mutable Eigen::VectorXd ws_z1;       // pre- or post-activation layer 1
-	mutable Eigen::VectorXd ws_z1_pre;   // pre-activation layer 1 (kept for backprop)
-	mutable Eigen::VectorXd ws_z2;       // pre-activation layer 2 (kept for backprop)
-	mutable Eigen::VectorXd ws_delta;    // backprop gradient buffer layer 2
-	mutable Eigen::VectorXd ws_delta2;   // backprop gradient buffer layer 1
+	mutable std::vector<Eigen::VectorXd> ws_z;        // pre-activations,  ws_z[l] for hidden layer l
+	mutable std::vector<Eigen::VectorXd> ws_h;        // post-activations, ws_h[l] for hidden layer l
+	mutable Eigen::VectorXd             ws_delta_cur; // current backprop delta
+	mutable Eigen::VectorXd             ws_delta_nxt; // scratch buffer for backprop swap
 
 	// -------------------------------------------------------------------------
 	// ELU activation applied in-place.
@@ -251,8 +186,8 @@ private:
 
 	// -------------------------------------------------------------------------
 	// Multiply gradient vector element-wise by ELU'(z_pre).
-	// ELU'(z) = 1          if z >= 0
-	//         = exp(z)      if z <  0
+	// ELU'(z) = 1       if z >= 0
+	//         = exp(z)   if z <  0
 	//
 	// grad:   current backprop gradient (modified in-place)
 	// z_pre:  pre-activation values at the same layer

--- a/src/libcadet/model/binding/NeuralNetworkBinding.cpp
+++ b/src/libcadet/model/binding/NeuralNetworkBinding.cpp
@@ -78,9 +78,10 @@ namespace cadet
         public:
 
             NeuralNetworkBindingBase()
-                : _bias0(), _kernel0()
-                , _bias1(), _kernel1()
-                , _bias2(), _kernel2()
+                : _layerKernels()
+                , _layerBiases()
+                , _kernelPtrs()
+                , _biasPtrs()
                 , _normFactor()
                 , _porosFactors()
                 , _offsets()
@@ -116,21 +117,24 @@ namespace cadet
             using ParamHandlerBindingModelBase<ParamHandler_t>::_nComp;
             using ParamHandlerBindingModelBase<ParamHandler_t>::_nBoundStates;
 
-            // Network weights and biases — one set of vectors per bound state.
+            // Network weights and biases — indexed [bndIdx][layerIdx].
+            // layerIdx runs 0.._nLayers (inclusive): indices 0.._nLayers-1 are hidden
+            // layers, index _nLayers is the output layer.
             // Inner vector follows col-major storage (matches training export).
-            std::vector<std::vector<double>> _bias0;    // b1: (nNodes,)            per bound state
-            std::vector<std::vector<double>> _kernel0;  // W1: (nNodes x nInput)    per bound state
-            std::vector<std::vector<double>> _bias1;    // b2: (nNodes,) or (1,)    per bound state
-            std::vector<std::vector<double>> _kernel1;  // W2: (nNodes x nNodes) or (1 x nNodes) per bound state
-            std::vector<std::vector<double>> _bias2;    // b3: (1,)      — 2-layer only, per bound state
-            std::vector<std::vector<double>> _kernel2;  // W3: (1 x nNodes) — 2-layer only, per bound state
+            std::vector<std::vector<std::vector<double>>> _layerKernels; // [bndIdx][layerIdx]
+            std::vector<std::vector<std::vector<double>>> _layerBiases;  // [bndIdx][layerIdx]
 
-            std::vector<double> _normFactor;   // shared normalisation factor per input dimension (length _nInput)
+            // Pre-allocated raw-pointer caches used in the hot path — avoids heap
+            // allocation inside fluxImpl / jacobianImpl.
+            std::vector<std::vector<const double*>> _kernelPtrs; // [bndIdx][layerIdx]
+            std::vector<std::vector<const double*>> _biasPtrs;   // [bndIdx][layerIdx]
+
+            std::vector<double> _normFactor;   // normalisation factor per input dimension (length _nInput)
             std::vector<double> _porosFactors; // porosity scaling — one per bound state
             std::vector<double> _offsets;      // ANN(x=0) — one per bound state, subtracted for zero intercept
 
-            unsigned int _nLayers;   // number of hidden layers (1 or 2), shared across all bound states
-            unsigned int _nNodes;    // nodes per hidden layer,            shared across all bound states
+            unsigned int _nLayers;   // number of hidden layers (>= 1), shared across all bound states
+            unsigned int _nNodes;    // nodes per hidden layer,         shared across all bound states
             unsigned int _nInput;    // input dimensionality (== nComp)
             unsigned int _nOutput;   // output dimensionality (always 1 — scalar isotherm per bound state)
 
@@ -150,11 +154,11 @@ namespace cadet
 
                 // --- Read shared scalar configuration ---
                 _nLayers = static_cast<unsigned int>(paramProvider.getInt("NLAYERS"));
-                _nNodes = static_cast<unsigned int>(paramProvider.getInt("NNODES"));
+                _nNodes  = static_cast<unsigned int>(paramProvider.getInt("NNODES"));
 
-                if (_nLayers != 1u && _nLayers != 2u)
+                if (_nLayers < 1u)
                     throw InvalidParameterException(
-                        "NEURAL_NETWORK binding: NLAYERS must be 1 or 2. Got: "
+                        "NEURAL_NETWORK binding: NLAYERS must be >= 1. Got: "
                         + std::to_string(_nLayers));
 
                 if (_nNodes == 0u)
@@ -162,7 +166,7 @@ namespace cadet
 
                 // Input/output dimensionality: each bound state's ANN takes the full
                 // c_p vector and predicts a scalar solid concentration.
-                _nInput = _nComp;
+                _nInput  = _nComp;
                 _nOutput = 1u;
 
                 // --- Validate bound state count and compute total ---
@@ -177,103 +181,88 @@ namespace cadet
                     ++totalNumBoundStates;
                 }
 
-                // --- Clear and reserve containers ---
-                _bias0.clear();    _bias0.reserve(totalNumBoundStates);
-                _kernel0.clear();  _kernel0.reserve(totalNumBoundStates);
-                _bias1.clear();    _bias1.reserve(totalNumBoundStates);
-                _kernel1.clear();  _kernel1.reserve(totalNumBoundStates);
-                _bias2.clear();    _bias2.reserve(totalNumBoundStates);
-                _kernel2.clear();  _kernel2.reserve(totalNumBoundStates);
-                _porosFactors.clear(); _porosFactors.reserve(totalNumBoundStates);
-                _offsets.clear();  _offsets.reserve(totalNumBoundStates);
-                _annModels.clear(); _annModels.reserve(totalNumBoundStates);
-                _normFactor.clear(); _normFactor.reserve(totalNumBoundStates);
+                const unsigned int nTotalLayers = _nLayers + 1u; // hidden layers + output layer
 
-				// --- Read parameters for each NN / bound state ---
+                // --- Clear and reserve containers ---
+                _layerKernels.clear(); _layerKernels.reserve(totalNumBoundStates);
+                _layerBiases.clear();  _layerBiases.reserve(totalNumBoundStates);
+                _kernelPtrs.clear();   _kernelPtrs.reserve(totalNumBoundStates);
+                _biasPtrs.clear();     _biasPtrs.reserve(totalNumBoundStates);
+                _porosFactors.clear(); _porosFactors.reserve(totalNumBoundStates);
+                _offsets.clear();      _offsets.reserve(totalNumBoundStates);
+                _annModels.clear();    _annModels.reserve(totalNumBoundStates);
+                _normFactor.clear();   _normFactor.reserve(totalNumBoundStates);
+
+                // --- Read parameters for each NN / bound state ---
                 for (unsigned int bndIdx = 0u; bndIdx < totalNumBoundStates; ++bndIdx)
                 {
-					const std::string scopeName = std::format("bound_state_{:03}", bndIdx);
+                    const std::string scopeName = std::format("bound_state_{:03}", bndIdx);
                     paramProvider.pushScope(scopeName);
 
                     _porosFactors.push_back(paramProvider.getDouble("POROSITY_FACTOR"));
                     _normFactor.push_back(paramProvider.getDouble("NORM_FACTOR"));
 
-                    paramProvider.pushScope("layer_0");
-                    _kernel0.push_back(paramProvider.getDoubleArray("KERNEL"));
-                    _bias0.push_back(paramProvider.getDoubleArray("BIAS"));
-                    paramProvider.popScope();
+                    _layerKernels.emplace_back();
+                    _layerBiases.emplace_back();
+                    _layerKernels.back().reserve(nTotalLayers);
+                    _layerBiases.back().reserve(nTotalLayers);
 
-                    paramProvider.pushScope("layer_1");
-                    _kernel1.push_back(paramProvider.getDoubleArray("KERNEL"));
-                    _bias1.push_back(paramProvider.getDoubleArray("BIAS"));
-                    paramProvider.popScope();
-
-                    if (_nLayers == 2u)
+                    for (unsigned int l = 0u; l < nTotalLayers; ++l)
                     {
-                        paramProvider.pushScope("layer_2");
-                        _kernel2.push_back(paramProvider.getDoubleArray("KERNEL"));
-                        _bias2.push_back(paramProvider.getDoubleArray("BIAS"));
+                        paramProvider.pushScope(std::format("layer_{}", l));
+                        _layerKernels.back().push_back(paramProvider.getDoubleArray("KERNEL"));
+                        _layerBiases.back().push_back(paramProvider.getDoubleArray("BIAS"));
                         paramProvider.popScope();
                     }
 
                     paramProvider.popScope();  // bound_state_N
 
                     // --- Validate weight sizes for this bound state ---
-                    // W1: (nNodes x nInput) -> nNodes * nInput elements
-                    if (_kernel0.back().size() != _nNodes * _nInput)
-                        throw InvalidParameterException(
-                            "NEURAL_NETWORK binding: " + scopeName
-                            + "/layer_0 KERNEL size must be NNODES * NCOMP = "
-                            + std::to_string(_nNodes * _nInput));
-                    if (_bias0.back().size() != _nNodes)
-                        throw InvalidParameterException(
-                            "NEURAL_NETWORK binding: " + scopeName
-                            + "/layer_0 BIAS size must be NNODES = "
-                            + std::to_string(_nNodes));
-
-                    if (_nLayers == 2u)
+                    // Hidden layers 0.._nLayers-1
+                    for (unsigned int l = 0u; l < _nLayers; ++l)
                     {
-                        // W2: (nNodes x nNodes)
-                        if (_kernel1.back().size() != _nNodes * _nNodes)
+                        const unsigned int prevSize = (l == 0u) ? _nInput : _nNodes;
+                        if (_layerKernels.back()[l].size() != _nNodes * prevSize)
                             throw InvalidParameterException(
                                 "NEURAL_NETWORK binding: " + scopeName
-                                + "/layer_1 KERNEL size must be NNODES * NNODES = "
-                                + std::to_string(_nNodes * _nNodes));
-                        if (_bias1.back().size() != _nNodes)
+                                + "/layer_" + std::to_string(l) + " KERNEL size must be "
+                                + std::to_string(_nNodes) + " * " + std::to_string(prevSize)
+                                + " = " + std::to_string(_nNodes * prevSize));
+                        if (_layerBiases.back()[l].size() != _nNodes)
                             throw InvalidParameterException(
                                 "NEURAL_NETWORK binding: " + scopeName
-                                + "/layer_1 BIAS size must be NNODES = "
+                                + "/layer_" + std::to_string(l) + " BIAS size must be NNODES = "
                                 + std::to_string(_nNodes));
-                        // W3: (nOutput x nNodes) == (1 x nNodes)
-                        if (_kernel2.back().size() != _nOutput * _nNodes)
-                            throw InvalidParameterException(
-                                "NEURAL_NETWORK binding: " + scopeName
-                                + "/layer_2 KERNEL size must be NOUTPUT * NNODES = "
-                                + std::to_string(_nOutput * _nNodes));
-                        if (_bias2.back().size() != _nOutput)
-                            throw InvalidParameterException(
-                                "NEURAL_NETWORK binding: " + scopeName
-                                + "/layer_2 BIAS size must be NOUTPUT = "
-                                + std::to_string(_nOutput));
                     }
-                    else  // 1-layer: layer_1 is the output layer
-                    {
-                        // W2: (nOutput x nNodes)
-                        if (_kernel1.back().size() != _nOutput * _nNodes)
-                            throw InvalidParameterException(
-                                "NEURAL_NETWORK binding: " + scopeName
-                                + "/layer_1 KERNEL size must be NOUTPUT * NNODES = "
-                                + std::to_string(_nOutput * _nNodes));
-                        if (_bias1.back().size() != _nOutput)
-                            throw InvalidParameterException(
-                                "NEURAL_NETWORK binding: " + scopeName
-                                + "/layer_1 BIAS size must be NOUTPUT = "
-                                + std::to_string(_nOutput));
-                    }
+                    // Output layer _nLayers
+                    if (_layerKernels.back()[_nLayers].size() != _nOutput * _nNodes)
+                        throw InvalidParameterException(
+                            "NEURAL_NETWORK binding: " + scopeName
+                            + "/layer_" + std::to_string(_nLayers) + " KERNEL size must be "
+                            + std::to_string(_nOutput) + " * " + std::to_string(_nNodes)
+                            + " = " + std::to_string(_nOutput * _nNodes));
+                    if (_layerBiases.back()[_nLayers].size() != _nOutput)
+                        throw InvalidParameterException(
+                            "NEURAL_NETWORK binding: " + scopeName
+                            + "/layer_" + std::to_string(_nLayers) + " BIAS size must be NOUTPUT = "
+                            + std::to_string(_nOutput));
 
-                    // Build ANN model for this bound state
                     _annModels.push_back(
                         std::make_unique<ClassANN>(_nLayers, _nNodes, _nInput, _nOutput));
+                }
+
+                // --- Build pre-allocated pointer caches (avoids allocation in hot path) ---
+                _kernelPtrs.resize(totalNumBoundStates);
+                _biasPtrs.resize(totalNumBoundStates);
+                for (unsigned int bndIdx = 0u; bndIdx < totalNumBoundStates; ++bndIdx)
+                {
+                    _kernelPtrs[bndIdx].resize(nTotalLayers);
+                    _biasPtrs[bndIdx].resize(nTotalLayers);
+                    for (unsigned int l = 0u; l < nTotalLayers; ++l)
+                    {
+                        _kernelPtrs[bndIdx][l] = _layerKernels[bndIdx][l].data();
+                        _biasPtrs[bndIdx][l]   = _layerBiases[bndIdx][l].data();
+                    }
                 }
 
                 // --- Pre-allocate shared runtime buffers ---
@@ -383,45 +372,23 @@ namespace cadet
         private:
 
             // -------------------------------------------------------------------------
-            // Forward pass dispatcher for bound state bndIdx.
+            // Forward pass for bound state bndIdx.
+            // Uses pre-allocated pointer caches — no heap allocation.
             // Input x must already be normalised.
             // -------------------------------------------------------------------------
             void _annForward(unsigned int bndIdx, const double* x, double* pred) const
             {
-                if (_nLayers == 1u)
-                    _annModels[bndIdx]->forward_single_layer(
-                        x,
-                        _kernel0[bndIdx].data(), _bias0[bndIdx].data(),
-                        _kernel1[bndIdx].data(), _bias1[bndIdx].data(),
-                        pred);
-                else
-                    _annModels[bndIdx]->forward_two_layers(
-                        x,
-                        _kernel0[bndIdx].data(), _bias0[bndIdx].data(),
-                        _kernel1[bndIdx].data(), _bias1[bndIdx].data(),
-                        _kernel2[bndIdx].data(), _bias2[bndIdx].data(),
-                        pred);
+                _annModels[bndIdx]->forward(_kernelPtrs[bndIdx], _biasPtrs[bndIdx], x, pred);
             }
 
             // -------------------------------------------------------------------------
-            // Jacobian dispatcher for bound state bndIdx.
+            // Jacobian for bound state bndIdx.
+            // Uses pre-allocated pointer caches — no heap allocation.
             // Input x must already be normalised.
             // -------------------------------------------------------------------------
             void _annJacobian(unsigned int bndIdx, const double* x, double* grad) const
             {
-                if (_nLayers == 1u)
-                    _annModels[bndIdx]->jacobian_single_layer(
-                        x,
-                        _kernel0[bndIdx].data(), _bias0[bndIdx].data(),
-                        _kernel1[bndIdx].data(),
-                        grad);
-                else
-                    _annModels[bndIdx]->jacobian_two_layers(
-                        x,
-                        _kernel0[bndIdx].data(), _bias0[bndIdx].data(),
-                        _kernel1[bndIdx].data(), _bias1[bndIdx].data(),
-                        _kernel2[bndIdx].data(),
-                        grad);
+                _annModels[bndIdx]->jacobian(_kernelPtrs[bndIdx], _biasPtrs[bndIdx], x, grad);
             }
         };
 


### PR DESCRIPTION
This PR extends the ANN binding to support networks with an arbitrary number of layers, previously we only supported nLayers = 1, 2.