### PR TITLE
Docker workflow: print checked out cadet-core details

### DIFF
--- a/.github/workflows/cd_docker.yml
+++ b/.github/workflows/cd_docker.yml
@@ -36,7 +36,18 @@ jobs:
           ref: ${{ github.event.inputs.ref || github.sha }}
           # Ensure all commits are available (needed for arbitrary commit SHAs including non-default branches)
           fetch-depth: 0
-
+          
+      - name: Show checked out Core commit
+        run: |
+          echo "HEAD SHA:"
+          git rev-parse HEAD
+          echo
+          echo "Last commit:"
+          git log -1 --oneline
+          echo
+          echo "Branches:"
+          git branch -a
+          
       - name: Get versions for Python and Process
         shell: bash
         run: |


### PR DESCRIPTION
cadet-verification ci fails with unknown binding model GPR. Ive added a commit hash print and indeed the cadet-core version used in the ci is outdated (see https://github.com/cadet/CADET-Python/pull/75). however i did build a new image with the current master and that one was successfully pulled as logged in the verification ci. something must be going wrong in the docker creation.

this pr prints details of the built cadet-core version in the docker workflow