### PR TITLE
CD: fix PATH environment variable order in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,7 @@ RUN /cadet/CADET-Core/install/bin/cadet-cli /cadet/CADET-Core/install/bin/LWE.h5
 FROM condaforge/miniforge3:${MINIFORGE_VERSION} AS deploy
 COPY --from=build /cadet/CADET-Core/install /cadet/CADET-Core/install
 COPY --from=build /usr/lib/x86_64-linux-gnu/libsz.so.2 /cadet/CADET-Core/install/lib
-ENV PATH="$PATH:/cadet/CADET-Core/install/bin"
+ENV PATH="/cadet/CADET-Core/install/bin:$PATH"
 
 RUN apt-get update && \
     apt-get -y install libhdf5-dev libsuperlu-dev git git-lfs && \


### PR DESCRIPTION
Ensure the CADET-Core version built by the docker image prioritized by searches instead of any conda/system cadet-cli (which might be installed later in the docker image) by prepending the install directory to PATH in the Docker deploy stage.