### PR TITLE
Add infrastructure for smoothness indicator

### DIFF
--- a/include/cadet/SolutionExporter.hpp
+++ b/include/cadet/SolutionExporter.hpp
@@ -66,6 +66,13 @@ public:
 	virtual bool isParticleLumped(unsigned int parType) const CADET_NOEXCEPT = 0;
 
 	/**
+	 * @brief Returns whether the discretization of the model has a smoothness indicator
+	 * @details spatial discretization may contain a smoothness indicator reporting on the solution
+	 * @return @c true if indicator is present, otherwise @c false
+	 */
+	virtual bool discHasSmoothnessIndicator() const CADET_NOEXCEPT = 0;
+
+	/**
 	 * @brief Returns whether the primary coordinate is always a single element
 	 * @details If the primary coordinate is always a single element, the singleton dimension can be removed.
 	 * @return @c true if the state in the primary coordinate direction is always represented by a single element, otherwise @c false
@@ -323,6 +330,12 @@ public:
 	 */
 	virtual int writeOutlet(double* buffer) const = 0;
 
+	/**
+	 * @brief Writes the smoothness indicator if present
+	 * @param [out] buffer Pointer to buffer that receives the data
+	 * @return Number of written items
+	 */
+	virtual int writeSmoothnessIndicator(double* buffer) const = 0;
 
 	/**
 	 * @brief Returns primary coordinates (e.g., axial for axial flow columns)

--- a/include/common/Driver.hpp
+++ b/include/common/Driver.hpp
@@ -97,6 +97,11 @@ void readDataOutputConfig(ParamProvider_t& pp, StorageConfig_t& cfg, const std::
 		cfg.storeVolume = pp.getBool("WRITE_" + dataType + "_VOLUME");
 	else
 		cfg.storeVolume = false;
+
+	if (pp.exists("WRITE_" + dataType + "_SMOOTHNESS_INDICATOR"))
+		cfg.storeSmoothnessIndicator = pp.getBool("WRITE_" + dataType + "_SMOOTHNESS_INDICATOR");
+	else
+		cfg.storeSmoothnessIndicator = false;
 }
 
 template <class ParamProvider_t>

--- a/include/common/SolutionRecorderImpl.hpp
+++ b/include/common/SolutionRecorderImpl.hpp
@@ -51,14 +51,15 @@ public:
 		bool storeOutlet;
 		bool storeInlet;
 		bool storeVolume;
+		bool storeSmoothnessIndicator;
 	};
 
 	InternalStorageUnitOpRecorder() : InternalStorageUnitOpRecorder(UnitOpIndep) { }
 
-	InternalStorageUnitOpRecorder(UnitOpIdx idx) : _cfgSolution({false, false, false, true, false, false, false}),
-		_cfgSolutionDot({false, false, false, false, false, false, false}), _cfgSensitivity({false, false, false, true, false, false, false}),
-		_cfgSensitivityDot({false, false, false, true, false, false, false}), _storeTime(false), _storeCoordinates(false), _splitComponents(true), _splitPorts(true),
-		_singleAsMultiPortUnitOps(false), _keepBulkSingletonDim(true), _curCfg(nullptr), _nComp(0), _nVolumeDof(0), _nAxialCells(0), _nRadialCells(0),
+	InternalStorageUnitOpRecorder(UnitOpIdx idx) : _cfgSolution({ false, false, false, true, false, false, false, false }),
+		_cfgSolutionDot({ false, false, false, false, false, false, false, false }), _cfgSensitivity({ false, false, false, true, false, false, false, false }),
+		_cfgSensitivityDot({ false, false, false, true, false, false, false, false }), _storeTime(false), _storeCoordinates(false),
+		_splitComponents(true), _splitPorts(true), _singleAsMultiPortUnitOps(false), _keepBulkSingletonDim(true), _curCfg(nullptr), _nComp(0), _nVolumeDof(0), _nAxialPoints(0), _nRadialPoints(0),
 		_nInletPorts(0), _nOutletPorts(0), _numTimesteps(0), _numSens(0), _unitOp(idx), _needsReAlloc(false), _axialCoords(0), _radialCoords(0), _particleCoords(0)
 	{
 	}
@@ -126,8 +127,8 @@ public:
 
 		_keepBulkSingletonDim = exporter.hasPrimaryExtent();
 
-		_nAxialCells = exporter.numPrimaryCoordinates();
-		_nRadialCells = exporter.numSecondaryCoordinates();
+		_nAxialPoints = exporter.numPrimaryCoordinates();
+		_nRadialPoints = exporter.numSecondaryCoordinates();
 
 		// Query particle type specific structure
 		const unsigned int numParTypes = exporter.numParticleTypes();
@@ -171,7 +172,7 @@ public:
 				offset += _nParShells[i];
 			}
 		}
-
+		 
 		// Validate config
 		validateConfig(exporter, _cfgSolution);
 		validateConfig(exporter, _cfgSolutionDot);
@@ -257,6 +258,15 @@ public:
 
 			v.resize(v.size() + sliceSize);
 			exporter.writeMobilePhase(v.data() + v.size() - sliceSize);
+		}
+
+		if (_curCfg->storeSmoothnessIndicator)
+		{
+			const int sliceSize = exporter.numMobilePhaseDofs();
+			std::vector<double>& v = _curStorage->smoothnessIndicator;
+
+			v.resize(v.size() + sliceSize);
+			exporter.writeSmoothnessIndicator(v.data() + v.size() - sliceSize);
 		}
 
 		if (_curCfg->storeParticle)
@@ -352,7 +362,7 @@ public:
 		if (!_storeCoordinates)
 			return;
 
-		if (!_axialCoords.empty() && ((_keepBulkSingletonDim && (_nAxialCells == 1)) || (_nAxialCells > 1)))
+		if (!_axialCoords.empty() && ((_keepBulkSingletonDim && (_nAxialPoints == 1)) || (_nAxialPoints > 1)))
 			writer.template vector<double>("AXIAL_COORDINATES", _axialCoords);
 		if (!_radialCoords.empty())
 			writer.template vector<double>("RADIAL_COORDINATES", _radialCoords);
@@ -474,8 +484,8 @@ public:
 	inline unsigned int numComponents() const CADET_NOEXCEPT { return _nComp; }
 	inline unsigned int numInletPorts() const CADET_NOEXCEPT { return _nInletPorts; }
 	inline unsigned int numOutletPorts() const CADET_NOEXCEPT { return _nOutletPorts; }
-	inline unsigned int numAxialCells() const CADET_NOEXCEPT { return _nAxialCells; }
-	inline unsigned int numRadialCells() const CADET_NOEXCEPT { return _nRadialCells; }
+	inline unsigned int numAxialPoints() const CADET_NOEXCEPT { return _nAxialPoints; }
+	inline unsigned int numRadialPoints() const CADET_NOEXCEPT { return _nRadialPoints; }
 	inline unsigned int numParticleTypes() const CADET_NOEXCEPT { return _nParShells.size(); }
 	inline unsigned int numParticleShells(unsigned int parType = 0) const CADET_NOEXCEPT { return _nParShells[parType]; }
 	inline unsigned int numBoundStates(unsigned int parType = 0) const CADET_NOEXCEPT { return _nBoundStates[parType]; }
@@ -488,6 +498,7 @@ public:
 	inline double const* solid(unsigned int parType = 0) const CADET_NOEXCEPT { return _data.solid[parType].data(); }
 	inline double const* flux() const CADET_NOEXCEPT { return _data.flux.data(); }
 	inline double const* volume() const CADET_NOEXCEPT { return _data.volume.data(); }
+	inline double const* smoothnessIndicator() const CADET_NOEXCEPT { return _data.smoothnessIndicator.data(); }
 	inline double const* inletDot() const CADET_NOEXCEPT { return _dataDot.inlet.data(); }
 	inline double const* outletDot() const CADET_NOEXCEPT { return _dataDot.outlet.data(); }
 	inline double const* bulkDot() const CADET_NOEXCEPT { return _dataDot.bulk.data(); }
@@ -523,6 +534,7 @@ protected:
 		std::vector<std::vector<double>> solid;
 		std::vector<double> flux;
 		std::vector<double> volume;
+		std::vector<double> smoothnessIndicator;
 	};
 
 	inline void beginSensitivity(unsigned int sensIdx)
@@ -547,6 +559,7 @@ protected:
 		cfg.storeSolid = exporter.hasSolidPhase() && cfg.storeSolid;
 		cfg.storeFlux = exporter.hasParticleFlux() && cfg.storeFlux;
 		cfg.storeVolume = exporter.hasVolume() && cfg.storeVolume;
+		cfg.storeSmoothnessIndicator = exporter.discHasSmoothnessIndicator() && cfg.storeSmoothnessIndicator;
 	}
 
 	inline void allocateMemory(const ISolutionExporter& exporter)
@@ -581,6 +594,9 @@ protected:
 
 		if (_curCfg->storeVolume)
 			_curStorage->volume.reserve(nAllocTimesteps * exporter.numVolumeDofs());
+
+		if (_curCfg->storeSmoothnessIndicator)
+			_curStorage->smoothnessIndicator.reserve(nAllocTimesteps * exporter.numMobilePhaseDofs());
 	}
 
 	template <typename Writer_t>
@@ -606,8 +622,8 @@ protected:
 							}
 							else
 							{
-								oss << prefix << "_OUTLET_PORT_" << std::setfill('0') << std::setw(3) << std::setprecision(0) << port 
-									<<  "_COMP_" << std::setfill('0') << std::setw(3) << std::setprecision(0) << comp;
+								oss << prefix << "_OUTLET_PORT_" << std::setfill('0') << std::setw(3) << std::setprecision(0) << port
+									<< "_COMP_" << std::setfill('0') << std::setw(3) << std::setprecision(0) << comp;
 							}
 
 							writer.template vector<double>(oss.str(), _numTimesteps, _curStorage->outlet.data() + comp + port * _nComp, _nComp * _nOutletPorts);
@@ -648,13 +664,13 @@ protected:
 					oss << prefix << "_OUTLET";
 					if ((_nOutletPorts == 1) && !_singleAsMultiPortUnitOps)
 					{
-						const std::vector<std::size_t> layout = {_numTimesteps, _nComp};
+						const std::vector<std::size_t> layout = { _numTimesteps, _nComp };
 						debugCheckTensorLayout(layout, _curStorage->outlet.size());
 						writer.template tensor<double>(oss.str(), layout.size(), layout.data(), _curStorage->outlet.data());
 					}
 					else
 					{
-						const std::vector<std::size_t> layout = {_numTimesteps, _nOutletPorts, _nComp};
+						const std::vector<std::size_t> layout = { _numTimesteps, _nOutletPorts, _nComp };
 						debugCheckTensorLayout(layout, _curStorage->outlet.size());
 						writer.template tensor<double>(oss.str(), layout.size(), layout.data(), _curStorage->outlet.data());
 					}
@@ -679,8 +695,8 @@ protected:
 							}
 							else
 							{
-								oss << prefix << "_INLET_PORT_" << std::setfill('0') << std::setw(3) << std::setprecision(0) << port 
-									<<  "_COMP_" << std::setfill('0') << std::setw(3) << std::setprecision(0) << comp;
+								oss << prefix << "_INLET_PORT_" << std::setfill('0') << std::setw(3) << std::setprecision(0) << port
+									<< "_COMP_" << std::setfill('0') << std::setw(3) << std::setprecision(0) << comp;
 							}
 
 							writer.template vector<double>(oss.str(), _numTimesteps, _curStorage->inlet.data() + comp + port * _nComp, _nComp * _nInletPorts);
@@ -721,13 +737,13 @@ protected:
 					oss << prefix << "_INLET";
 					if ((_nInletPorts == 1) && !_singleAsMultiPortUnitOps)
 					{
-						const std::vector<std::size_t> layout = {_numTimesteps, _nComp};
+						const std::vector<std::size_t> layout = { _numTimesteps, _nComp };
 						debugCheckTensorLayout(layout, _curStorage->inlet.size());
 						writer.template tensor<double>(oss.str(), layout.size(), layout.data(), _curStorage->inlet.data());
 					}
 					else
 					{
-						const std::vector<std::size_t> layout = {_numTimesteps, _nInletPorts, _nComp};
+						const std::vector<std::size_t> layout = { _numTimesteps, _nInletPorts, _nComp };
 						debugCheckTensorLayout(layout, _curStorage->inlet.size());
 						writer.template tensor<double>(oss.str(), layout.size(), layout.data(), _curStorage->inlet.data());
 					}
@@ -741,10 +757,10 @@ protected:
 			layout.reserve(3);
 			layout.push_back(_numTimesteps);
 
-			if ((_keepBulkSingletonDim && (_nAxialCells == 1)) || (_nAxialCells > 1))
-				layout.push_back(_nAxialCells);
-			if (_nRadialCells > 0)
-				layout.push_back(_nRadialCells);
+			if ((_keepBulkSingletonDim && (_nAxialPoints == 1)) || (_nAxialPoints > 1))
+				layout.push_back(_nAxialPoints);
+			if (_nRadialPoints > 0)
+				layout.push_back(_nRadialPoints);
 
 			for (unsigned int comp = 0; comp < _nComp; ++comp)
 			{
@@ -763,10 +779,10 @@ protected:
 			layout.reserve(4);
 			layout.push_back(_numTimesteps);
 
-			if ((_keepBulkSingletonDim && (_nAxialCells == 1)) || (_nAxialCells > 1))
-				layout.push_back(_nAxialCells);
-			if (_nRadialCells > 0)
-				layout.push_back(_nRadialCells);
+			if ((_keepBulkSingletonDim && (_nAxialPoints == 1)) || (_nAxialPoints > 1))
+				layout.push_back(_nAxialPoints);
+			if (_nRadialPoints > 0)
+				layout.push_back(_nRadialPoints);
 			layout.push_back(_nComp);
 
 			debugCheckTensorLayout(layout, _curStorage->bulk.size());
@@ -782,10 +798,10 @@ protected:
 				layout.reserve(4);
 				layout.push_back(_numTimesteps);
 
-				if ((_keepBulkSingletonDim && (_nAxialCells == 1)) || (_nAxialCells > 1))
-					layout.push_back(_nAxialCells);
-				if (_nRadialCells > 0)
-					layout.push_back(_nRadialCells);
+				if ((_keepBulkSingletonDim && (_nAxialPoints == 1)) || (_nAxialPoints > 1))
+					layout.push_back(_nAxialPoints);
+				if (_nRadialPoints > 0)
+					layout.push_back(_nRadialPoints);
 
 				if (_nParShells[0] >= 1)
 				{
@@ -810,10 +826,10 @@ protected:
 					layout.reserve(4);
 					layout.push_back(_numTimesteps);
 
-					if ((_keepBulkSingletonDim && (_nAxialCells == 1)) || (_nAxialCells > 1))
-						layout.push_back(_nAxialCells);
-					if (_nRadialCells > 0)
-						layout.push_back(_nRadialCells);
+					if ((_keepBulkSingletonDim && (_nAxialPoints == 1)) || (_nAxialPoints > 1))
+						layout.push_back(_nAxialPoints);
+					if (_nRadialPoints > 0)
+						layout.push_back(_nRadialPoints);
 
 					if (_nParShells[parType] >= 1)
 					{
@@ -841,10 +857,10 @@ protected:
 			layout.reserve(5);
 			layout.push_back(_numTimesteps);
 
-			if ((_keepBulkSingletonDim && (_nAxialCells == 1)) || (_nAxialCells > 1))
-				layout.push_back(_nAxialCells);
-			if (_nRadialCells > 0)
-				layout.push_back(_nRadialCells);
+			if ((_keepBulkSingletonDim && (_nAxialPoints == 1)) || (_nAxialPoints > 1))
+				layout.push_back(_nAxialPoints);
+			if (_nRadialPoints > 0)
+				layout.push_back(_nRadialPoints);
 
 			if (_nParShells.size() <= 1)
 			{
@@ -903,10 +919,10 @@ protected:
 				layout.reserve(4);
 				layout.push_back(_numTimesteps);
 
-				if ((_keepBulkSingletonDim && (_nAxialCells == 1)) || (_nAxialCells > 1))
-					layout.push_back(_nAxialCells);
-				if (_nRadialCells > 0)
-					layout.push_back(_nRadialCells);
+				if ((_keepBulkSingletonDim && (_nAxialPoints == 1)) || (_nAxialPoints > 1))
+					layout.push_back(_nAxialPoints);
+				if (_nRadialPoints > 0)
+					layout.push_back(_nRadialPoints);
 
 				if (_nParShells[0] >= 1)
 				{
@@ -935,10 +951,10 @@ protected:
 					layout.reserve(4);
 					layout.push_back(_numTimesteps);
 
-					if ((_keepBulkSingletonDim && (_nAxialCells == 1)) || (_nAxialCells > 1))
-						layout.push_back(_nAxialCells);
-					if (_nRadialCells > 0)
-						layout.push_back(_nRadialCells);
+					if ((_keepBulkSingletonDim && (_nAxialPoints == 1)) || (_nAxialPoints > 1))
+						layout.push_back(_nAxialPoints);
+					if (_nRadialPoints > 0)
+						layout.push_back(_nRadialPoints);
 
 					if (_nParShells[parType] >= 1)
 					{
@@ -970,10 +986,10 @@ protected:
 			layout.reserve(5);
 			layout.push_back(_numTimesteps);
 
-			if ((_keepBulkSingletonDim && (_nAxialCells == 1)) || (_nAxialCells > 1))
-				layout.push_back(_nAxialCells);
-			if (_nRadialCells > 0)
-				layout.push_back(_nRadialCells);
+			if ((_keepBulkSingletonDim && (_nAxialPoints == 1)) || (_nAxialPoints > 1))
+				layout.push_back(_nAxialPoints);
+			if (_nRadialPoints > 0)
+				layout.push_back(_nRadialPoints);
 
 			if (_nParShells.size() <= 1)
 			{
@@ -1030,10 +1046,10 @@ protected:
 
 			layout.push_back(_numTimesteps);
 			layout.push_back(_nParShells.size());
-			if ((_keepBulkSingletonDim && (_nAxialCells == 1)) || (_nAxialCells > 1))
-				layout.push_back(_nAxialCells);
-			if (_nRadialCells > 0)
-				layout.push_back(_nRadialCells);
+			if ((_keepBulkSingletonDim && (_nAxialPoints == 1)) || (_nAxialPoints > 1))
+				layout.push_back(_nAxialPoints);
+			if (_nRadialPoints > 0)
+				layout.push_back(_nRadialPoints);
 
 			for (unsigned int comp = 0; comp < _nComp; ++comp)
 			{
@@ -1050,10 +1066,10 @@ protected:
 
 			layout.push_back(_numTimesteps);
 			layout.push_back(_nParShells.size());
-			if ((_keepBulkSingletonDim && (_nAxialCells == 1)) || (_nAxialCells > 1))
-				layout.push_back(_nAxialCells);
-			if (_nRadialCells > 0)
-				layout.push_back(_nRadialCells);
+			if ((_keepBulkSingletonDim && (_nAxialPoints == 1)) || (_nAxialPoints > 1))
+				layout.push_back(_nAxialPoints);
+			if (_nRadialPoints > 0)
+				layout.push_back(_nRadialPoints);
 			layout.push_back(_nComp);
 
 			debugCheckTensorLayout(layout, _curStorage->flux.size());
@@ -1071,6 +1087,24 @@ protected:
 			// Once other unit operations are implemented with more than one volume, we should add the option here to write this as a matrix (singletonDimension filed etc, see other output).
 			writer.template vector<double>(oss.str(), _numTimesteps * _nVolumeDof, _curStorage->volume.data(), 1);
 		}
+
+		if (_curCfg->storeSmoothnessIndicator)
+		{
+			oss.str("");
+			oss << prefix << "_SMOOTHNESS_INDICATOR";
+
+			std::vector<std::size_t> layout(0);
+			layout.reserve(4);
+			layout.push_back(_numTimesteps);
+
+			if (_nAxialPoints > 0)
+				layout.push_back(_nAxialPoints);
+			layout.push_back(_nComp);
+
+			debugCheckTensorLayout(layout, _curStorage->smoothnessIndicator.size());
+
+			writer.template tensor<double>(oss.str(), layout.size(), layout.data(), _curStorage->smoothnessIndicator.data());
+		}
 	}
 
 	inline void clear(Storage& s)
@@ -1087,6 +1121,7 @@ protected:
 
 		s.flux.clear();
 		s.volume.clear();
+		s.smoothnessIndicator.clear();
 	}
 
 	template <typename T>
@@ -1132,8 +1167,8 @@ protected:
 
 	unsigned int _nComp;
 	unsigned int _nVolumeDof;
-	unsigned int _nAxialCells;
-	unsigned int _nRadialCells;
+	unsigned int _nAxialPoints;
+	unsigned int _nRadialPoints;
 	unsigned int _nInletPorts;
 	unsigned int _nOutletPorts;
 	std::vector<unsigned int> _nParShells;
@@ -1308,7 +1343,7 @@ public:
 			}
 		}
 	}
-	
+
 	template <typename Writer_t>
 	void writeSolution(Writer_t& writer)
 	{

--- a/src/libcadet/api/CAPIv1.cpp
+++ b/src/libcadet/api/CAPIv1.cpp
@@ -571,11 +571,11 @@ namespace v1
 			} \
 		\
 			if (nAxialCells) \
-				*nAxialCells = unitRec->numAxialCells(); \
+				*nAxialCells = unitRec->numAxialPoints(); \
 			if (keepAxialSingletonDimension) \
 				*keepAxialSingletonDimension = unitRec->keepBulkSingletonDim(); \
 			if (nRadialCells) \
-				*nRadialCells = unitRec->numRadialCells(); \
+				*nRadialCells = unitRec->numRadialPoints(); \
 			if (nComp) \
 				*nComp = unitRec->numComponents(); \
 			if (data) \
@@ -605,11 +605,11 @@ namespace v1
 			} \
 		\
 			if (nAxialCells) \
-				*nAxialCells = unitRec->numAxialCells(); \
+				*nAxialCells = unitRec->numAxialPoints(); \
 			if (keepAxialSingletonDimension) \
 				*keepAxialSingletonDimension = unitRec->keepBulkSingletonDim(); \
 			if (nRadialCells) \
-				*nRadialCells = unitRec->numRadialCells(); \
+				*nRadialCells = unitRec->numRadialPoints(); \
 			if (nParShells) \
 				*nParShells = unitRec->numParticleShells(parType); \
 			if (keepParticleSingletonDimension) \
@@ -643,11 +643,11 @@ namespace v1
 			} \
 		\
 			if (nAxialCells) \
-				*nAxialCells = unitRec->numAxialCells(); \
+				*nAxialCells = unitRec->numAxialPoints(); \
 			if (keepAxialSingletonDimension) \
 				*keepAxialSingletonDimension = unitRec->keepBulkSingletonDim(); \
 			if (nRadialCells) \
-				*nRadialCells = unitRec->numRadialCells(); \
+				*nRadialCells = unitRec->numRadialPoints(); \
 			if (nParShells) \
 				*nParShells = unitRec->numParticleShells(parType); \
 			if (keepParticleSingletonDim) \
@@ -682,11 +682,11 @@ namespace v1
 			} \
 		\
 			if (nAxialCells) \
-				*nAxialCells = unitRec->numAxialCells(); \
+				*nAxialCells = unitRec->numAxialPoints(); \
 			if (keepAxialSingletonDimension) \
 				*keepAxialSingletonDimension = unitRec->keepBulkSingletonDim(); \
 			if (nRadialCells) \
-				*nRadialCells = unitRec->numRadialCells(); \
+				*nRadialCells = unitRec->numRadialPoints(); \
 			if (nParType) \
 				*nParType = unitRec->numParticleTypes(); \
 			if (nComp) \
@@ -947,7 +947,7 @@ namespace v1
 		bool keepAxialSingletonDimension = unitRec->keepBulkSingletonDim();
 
 		if (nCoords)
-			*nCoords = unitRec->numAxialCells();
+			*nCoords = unitRec->numAxialPoints();
 
 		if (nCoords && *nCoords == 1 && !keepAxialSingletonDimension)
 		{
@@ -974,7 +974,7 @@ namespace v1
 		}
 
 		if (nCoords)
-			*nCoords = unitRec->numRadialCells();
+			*nCoords = unitRec->numRadialPoints();
 		if (data)
 			*data = unitRec->secondaryCoordinates();
 

--- a/src/libcadet/model/ColumnModel1D.hpp
+++ b/src/libcadet/model/ColumnModel1D.hpp
@@ -389,6 +389,7 @@ protected:
 		virtual bool hasVolume() const CADET_NOEXCEPT { return false; }
 		virtual bool isParticleLumped(unsigned int parType) const CADET_NOEXCEPT { return _model._particles[parType]->isParticleLumped(); }
 		virtual bool hasPrimaryExtent() const CADET_NOEXCEPT { return true; }
+		virtual bool discHasSmoothnessIndicator() const CADET_NOEXCEPT { return _model._convDispOp.hasSmoothnessIndicator(); }
 
 		virtual unsigned int numComponents() const CADET_NOEXCEPT { return _disc.nComp; }
 		virtual unsigned int numPrimaryCoordinates() const CADET_NOEXCEPT { return _disc.nPoints; }
@@ -431,6 +432,7 @@ protected:
 		virtual int writeInlet(double* buffer) const;
 		virtual int writeOutlet(unsigned int port, double* buffer) const;
 		virtual int writeOutlet(double* buffer) const;
+		virtual int writeSmoothnessIndicator(double* buffer) const { return _model._convDispOp.writeSmoothnessIndicator(buffer); }
 		/**
 		* @brief calculates, writes the physical axial/column coordinates of the DG discretization with double! interface nodes
 		*/

--- a/src/libcadet/model/ColumnModel2D.hpp
+++ b/src/libcadet/model/ColumnModel2D.hpp
@@ -398,7 +398,7 @@ protected:
 		virtual bool hasVolume() const CADET_NOEXCEPT { return false; }
 		virtual bool isParticleLumped(unsigned int parType) const CADET_NOEXCEPT { return _model._particles[parType]->isParticleLumped(); }
 		virtual bool hasPrimaryExtent() const CADET_NOEXCEPT { return true; }
-		virtual bool hasSmoothnessIndicator() const CADET_NOEXCEPT { return false; }
+		virtual bool discHasSmoothnessIndicator() const CADET_NOEXCEPT { return false; }
 
 		virtual unsigned int numComponents() const CADET_NOEXCEPT { return _disc.nComp; }
 		virtual unsigned int numPrimaryCoordinates() const CADET_NOEXCEPT { return _disc.axNPoints; }
@@ -434,8 +434,7 @@ protected:
 		virtual int writeInlet(double* buffer) const;
 		virtual int writeOutlet(unsigned int port, double* buffer) const;
 		virtual int writeOutlet(double* buffer) const;
-
-		virtual int writeSmoothnessIndicator(double* indicator) const { return 0; }
+		virtual int writeSmoothnessIndicator(double* buffer) const { return _model._convDispOp.writeSmoothnessIndicator(buffer); }
 
 		virtual int writePrimaryCoordinates(double* coords) const
 		{

--- a/src/libcadet/model/GeneralRateModel.hpp
+++ b/src/libcadet/model/GeneralRateModel.hpp
@@ -473,6 +473,7 @@ protected:
 		virtual bool hasVolume() const CADET_NOEXCEPT { return false; }
 		virtual bool isParticleLumped(unsigned int parType) const CADET_NOEXCEPT { return false; }
 		virtual bool hasPrimaryExtent() const CADET_NOEXCEPT { return true; }
+		virtual bool discHasSmoothnessIndicator() const CADET_NOEXCEPT { return false; }
 
 		virtual unsigned int numComponents() const CADET_NOEXCEPT { return _disc.nComp; }
 		virtual unsigned int numPrimaryCoordinates() const CADET_NOEXCEPT { return _disc.nCol; }
@@ -515,6 +516,7 @@ protected:
 		virtual int writeInlet(double* buffer) const;
 		virtual int writeOutlet(unsigned int port, double* buffer) const;
 		virtual int writeOutlet(double* buffer) const;
+		virtual int writeSmoothnessIndicator(double* buffer) const { return _model._convDispOp.writeSmoothnessIndicator(buffer); }
 
 		virtual int writePrimaryCoordinates(double* coords) const
 		{

--- a/src/libcadet/model/GeneralRateModel2D.hpp
+++ b/src/libcadet/model/GeneralRateModel2D.hpp
@@ -416,6 +416,7 @@ protected:
 		virtual bool hasVolume() const CADET_NOEXCEPT { return false; }
 		virtual bool isParticleLumped(unsigned int parType) const CADET_NOEXCEPT { return false; }
 		virtual bool hasPrimaryExtent() const CADET_NOEXCEPT { return true; }
+		virtual bool discHasSmoothnessIndicator() const CADET_NOEXCEPT { return false; }
 
 		virtual unsigned int numComponents() const CADET_NOEXCEPT { return _disc.nComp; }
 		virtual unsigned int numPrimaryCoordinates() const CADET_NOEXCEPT { return _disc.nCol; }
@@ -458,6 +459,7 @@ protected:
 		virtual int writeInlet(double* buffer) const;
 		virtual int writeOutlet(unsigned int port, double* buffer) const;
 		virtual int writeOutlet(double* buffer) const;
+		virtual int writeSmoothnessIndicator(double* buffer) const { return _model._convDispOp.writeSmoothnessIndicator(buffer); }
 
 		virtual int writePrimaryCoordinates(double* coords) const
 		{

--- a/src/libcadet/model/InletModel.hpp
+++ b/src/libcadet/model/InletModel.hpp
@@ -178,6 +178,7 @@ protected:
 		virtual bool hasVolume() const CADET_NOEXCEPT { return false; }
 		virtual bool isParticleLumped(unsigned int parType) const CADET_NOEXCEPT { return false; }
 		virtual bool hasPrimaryExtent() const CADET_NOEXCEPT { return false; }
+		virtual bool discHasSmoothnessIndicator() const CADET_NOEXCEPT { return false; }
 
 		virtual unsigned int numComponents() const CADET_NOEXCEPT { return _nComp; }
 		virtual unsigned int numPrimaryCoordinates() const CADET_NOEXCEPT { return 0; }
@@ -208,6 +209,7 @@ protected:
 		virtual int writeInlet(double* buffer) const;
 		virtual int writeOutlet(unsigned int port, double* buffer) const;
 		virtual int writeOutlet(double* buffer) const;
+		virtual int writeSmoothnessIndicator(double* buffer) const { return 0; }
 
 		virtual int writePrimaryCoordinates(double* coords) const { return 0; }
 		virtual int writeSecondaryCoordinates(double* coords) const { return 0; }

--- a/src/libcadet/model/LumpedRateModelWithPores.hpp
+++ b/src/libcadet/model/LumpedRateModelWithPores.hpp
@@ -403,6 +403,7 @@ protected:
 		virtual bool hasVolume() const CADET_NOEXCEPT { return false; }
 		virtual bool isParticleLumped(unsigned int parType) const CADET_NOEXCEPT { return true; }
 		virtual bool hasPrimaryExtent() const CADET_NOEXCEPT { return true; }
+		virtual bool discHasSmoothnessIndicator() const CADET_NOEXCEPT { return false; }
 
 		virtual unsigned int numComponents() const CADET_NOEXCEPT { return _disc.nComp; }
 		virtual unsigned int numPrimaryCoordinates() const CADET_NOEXCEPT { return _disc.nCol; }
@@ -439,6 +440,7 @@ protected:
 		virtual int writeInlet(double* buffer) const;
 		virtual int writeOutlet(unsigned int port, double* buffer) const;
 		virtual int writeOutlet(double* buffer) const;
+		virtual int writeSmoothnessIndicator(double* buffer) const { return _model._convDispOp.writeSmoothnessIndicator(buffer); }
 
 		virtual int writePrimaryCoordinates(double* coords) const
 		{

--- a/src/libcadet/model/LumpedRateModelWithoutPores.hpp
+++ b/src/libcadet/model/LumpedRateModelWithoutPores.hpp
@@ -312,6 +312,7 @@ protected:
 		virtual bool hasVolume() const CADET_NOEXCEPT { return false; }
 		virtual bool isParticleLumped(unsigned int parType) const CADET_NOEXCEPT { return true; }
 		virtual bool hasPrimaryExtent() const CADET_NOEXCEPT { return true; }
+		virtual bool discHasSmoothnessIndicator() const CADET_NOEXCEPT { return false; }
 
 		virtual unsigned int numComponents() const CADET_NOEXCEPT { return _disc.nComp; }
 		virtual unsigned int numPrimaryCoordinates() const CADET_NOEXCEPT { return _disc.nCol; }
@@ -342,7 +343,7 @@ protected:
 		virtual int writeInlet(double* buffer) const;
 		virtual int writeOutlet(unsigned int port, double* buffer) const;
 		virtual int writeOutlet(double* buffer) const;
-
+		virtual int writeSmoothnessIndicator(double* buffer) const { return _model._convDispOp.writeSmoothnessIndicator(buffer); }
 
 		virtual int writePrimaryCoordinates(double* coords) const
 		{

--- a/src/libcadet/model/LumpedRateModelWithoutPoresDG.hpp
+++ b/src/libcadet/model/LumpedRateModelWithoutPoresDG.hpp
@@ -309,6 +309,7 @@ namespace cadet
 				virtual bool hasVolume() const CADET_NOEXCEPT { return false; }
 				virtual bool isParticleLumped(unsigned int parType) const CADET_NOEXCEPT { return true; }
 				virtual bool hasPrimaryExtent() const CADET_NOEXCEPT { return true; }
+				virtual bool discHasSmoothnessIndicator() const CADET_NOEXCEPT { return _model._convDispOp.hasSmoothnessIndicator(); }
 
 				virtual unsigned int numComponents() const CADET_NOEXCEPT { return _disc.nComp; }
 				virtual unsigned int numPrimaryCoordinates() const CADET_NOEXCEPT { return _disc.nPoints; }
@@ -339,6 +340,7 @@ namespace cadet
 				virtual int writeInlet(double* buffer) const;
 				virtual int writeOutlet(unsigned int port, double* buffer) const;
 				virtual int writeOutlet(double* buffer) const;
+				virtual int writeSmoothnessIndicator(double* buffer) const { return _model._convDispOp.writeSmoothnessIndicator(buffer); }
 				/**
 				 * @brief calculates the physical node coordinates of the DG discretization with double! interface nodes
 				 */

--- a/src/libcadet/model/MultiChannelTransportModel.hpp
+++ b/src/libcadet/model/MultiChannelTransportModel.hpp
@@ -266,6 +266,7 @@ protected:
 		virtual bool hasVolume() const CADET_NOEXCEPT { return false; }
 		virtual bool isParticleLumped(unsigned int parType) const CADET_NOEXCEPT { return false; }
 		virtual bool hasPrimaryExtent() const CADET_NOEXCEPT { return true; }
+		virtual bool discHasSmoothnessIndicator() const CADET_NOEXCEPT { return false; }
 
 		virtual unsigned int numComponents() const CADET_NOEXCEPT { return _disc.nComp; }
 		virtual unsigned int numPrimaryCoordinates() const CADET_NOEXCEPT { return _disc.nCol; }
@@ -296,6 +297,7 @@ protected:
 		virtual int writeInlet(double* buffer) const;
 		virtual int writeOutlet(unsigned int port, double* buffer) const;
 		virtual int writeOutlet(double* buffer) const;
+		virtual int writeSmoothnessIndicator(double* buffer) const { return 0; }
 
 		virtual int writePrimaryCoordinates(double* coords) const
 		{

--- a/src/libcadet/model/OutletModel.hpp
+++ b/src/libcadet/model/OutletModel.hpp
@@ -161,6 +161,7 @@ protected:
 		virtual bool hasVolume() const CADET_NOEXCEPT { return false; }
 		virtual bool isParticleLumped(unsigned int parType) const CADET_NOEXCEPT { return false; }
 		virtual bool hasPrimaryExtent() const CADET_NOEXCEPT { return false; }
+		virtual bool discHasSmoothnessIndicator() const CADET_NOEXCEPT { return false; }
 
 		virtual unsigned int numComponents() const CADET_NOEXCEPT { return _nComp; }
 		virtual unsigned int numPrimaryCoordinates() const CADET_NOEXCEPT { return 0; }
@@ -192,6 +193,7 @@ protected:
 		virtual int writeOutlet(unsigned int port, double* buffer) const;
 		virtual int writeOutlet(double* buffer) const;
 
+		virtual int writeSmoothnessIndicator(double* indicator) const { return 0; }
 		virtual int writePrimaryCoordinates(double* coords) const { return 0; }
 		virtual int writeSecondaryCoordinates(double* coords) const { return 0; }
 		virtual int writeParticleCoordinates(unsigned int parType, double* coords) const { return 0; }

--- a/src/libcadet/model/StirredTankModel.hpp
+++ b/src/libcadet/model/StirredTankModel.hpp
@@ -191,6 +191,7 @@ protected:
 		virtual bool hasVolume() const CADET_NOEXCEPT { return true; }
 		virtual bool isParticleLumped(unsigned int parType) const CADET_NOEXCEPT { return true; }
 		virtual bool hasPrimaryExtent() const CADET_NOEXCEPT { return false; }
+		virtual bool discHasSmoothnessIndicator() const CADET_NOEXCEPT { return false; }
 
 		virtual unsigned int numComponents() const CADET_NOEXCEPT { return _nComp; }
 		virtual unsigned int numPrimaryCoordinates() const CADET_NOEXCEPT { return 1; }
@@ -221,6 +222,7 @@ protected:
 		virtual int writeInlet(double* buffer) const;
 		virtual int writeOutlet(unsigned int port, double* buffer) const;
 		virtual int writeOutlet(double* buffer) const;
+		virtual int writeSmoothnessIndicator(double* buffer) const { return 0; }
 
 		virtual double const* solidPhase(unsigned int parType) const { return _data + 2 * _nComp; }
 

--- a/src/libcadet/model/parts/ConvectionDispersionOperator.hpp
+++ b/src/libcadet/model/parts/ConvectionDispersionOperator.hpp
@@ -111,6 +111,8 @@ public:
 	inline unsigned int nCol() const CADET_NOEXCEPT { return _nCol; }
 	inline Weno const* weno() const CADET_NOEXCEPT { return _weno; }
 	inline HighResolutionKoren const* koren() const CADET_NOEXCEPT { return _koren; }
+	inline bool hasSmoothnessIndicator() const CADET_NOEXCEPT { return false; }
+	inline int writeSmoothnessIndicator(double* buffer) const CADET_NOEXCEPT { return 0; }
 
 	unsigned int jacobianLowerBandwidth() const CADET_NOEXCEPT;
 	unsigned int jacobianUpperBandwidth() const CADET_NOEXCEPT;
@@ -221,6 +223,8 @@ public:
 	inline unsigned int nCol() const CADET_NOEXCEPT { return _nCol; }
 	inline Weno const* weno() const CADET_NOEXCEPT { return _weno; }
 	inline HighResolutionKoren const* koren() const CADET_NOEXCEPT { return _koren; }
+	inline bool hasSmoothnessIndicator() const CADET_NOEXCEPT { return false; }
+	inline int writeSmoothnessIndicator(double* buffer) const CADET_NOEXCEPT { return 0; }
 
 	unsigned int jacobianLowerBandwidth() const CADET_NOEXCEPT;
 	unsigned int jacobianUpperBandwidth() const CADET_NOEXCEPT;
@@ -340,6 +344,8 @@ public:
 	inline unsigned int nCol() const CADET_NOEXCEPT { return _nCol; }
 	inline Weno const* weno() const CADET_NOEXCEPT { return _weno; }
 	inline HighResolutionKoren const* koren() const CADET_NOEXCEPT { return _koren; }
+	inline bool hasSmoothnessIndicator() const CADET_NOEXCEPT { return false; }
+	inline int writeSmoothnessIndicator(double* buffer) const CADET_NOEXCEPT { return 0; }
 
 	unsigned int jacobianLowerBandwidth() const CADET_NOEXCEPT;
 	unsigned int jacobianUpperBandwidth() const CADET_NOEXCEPT;
@@ -432,6 +438,9 @@ public:
 
 	int jacobian(const IModel& model, double t, unsigned int secIdx, double const* y, double const* yDot, double* res);
 	int jacobian(const IModel& model, double t, unsigned int secIdx, active const* y, double const* yDot, active* res);
+
+	inline bool hasSmoothnessIndicator() const CADET_NOEXCEPT { return _baseOp.hasSmoothnessIndicator(); }
+	inline int writeSmoothnessIndicator(double* buffer) const CADET_NOEXCEPT { return _baseOp.writeSmoothnessIndicator(buffer); }
 
 	void prepareADvectors(const AdJacobianParams& adJac) const;
 	void extractJacobianFromAD(active const* const adRes, unsigned int adDirOffset);

--- a/src/libcadet/model/parts/ConvectionDispersionOperatorDG.hpp
+++ b/src/libcadet/model/parts/ConvectionDispersionOperatorDG.hpp
@@ -118,6 +118,8 @@ namespace cadet
 				inline unsigned int nelements() const CADET_NOEXCEPT { return _nElem; }
 				inline unsigned int nNodes() const CADET_NOEXCEPT { return _nNodes; }
 				inline unsigned int nPoints() const CADET_NOEXCEPT { return _nPoints; }
+				inline bool hasSmoothnessIndicator() const CADET_NOEXCEPT { return false; }
+				inline int writeSmoothnessIndicator(double* buffer) const CADET_NOEXCEPT { return 0; }
 
 				// Indexer functionality:
 				// Strides

--- a/src/libcadet/model/parts/MultiChannelConvectionDispersionOperator.hpp
+++ b/src/libcadet/model/parts/MultiChannelConvectionDispersionOperator.hpp
@@ -127,6 +127,9 @@ protected:
 	void setUserdefinedRadialDisc();
 	void updateRadialDisc();
 
+	inline bool hasSmoothnessIndicator() const CADET_NOEXCEPT { return false; }
+	inline int writeSmoothnessIndicator(double* buffer) const CADET_NOEXCEPT { return 0; }
+
 	enum class RadialDiscretizationMode : int
 	{
 		/**

--- a/src/libcadet/model/parts/TwoDimensionalConvectionDispersionOperator.hpp
+++ b/src/libcadet/model/parts/TwoDimensionalConvectionDispersionOperator.hpp
@@ -111,6 +111,9 @@ public:
 	inline linalg::CompressedSparseMatrix& jacobian() CADET_NOEXCEPT { return _jacC; }
 	inline const linalg::CompressedSparseMatrix& jacobian() const CADET_NOEXCEPT { return _jacC; }
 
+	inline bool hasSmoothnessIndicator() const CADET_NOEXCEPT { return false; }
+	inline int writeSmoothnessIndicator(double* buffer) const CADET_NOEXCEPT { return 0; }
+
 protected:
 
 	class LinearSolver;

--- a/src/libcadet/model/parts/TwoDimensionalConvectionDispersionOperatorDG.hpp
+++ b/src/libcadet/model/parts/TwoDimensionalConvectionDispersionOperatorDG.hpp
@@ -144,6 +144,9 @@ public:
 	double getRadialAvgNodalValue(const double* const val, int nodeIdx) const CADET_NOEXCEPT;
 	void getRadialAvgNodalValuesElem(const double* const val, double* buffer) const CADET_NOEXCEPT;
 
+	inline bool hasSmoothnessIndicator() const CADET_NOEXCEPT { return false; }
+	inline int writeSmoothnessIndicator(double* buffer) const CADET_NOEXCEPT { return 0; }
+
 protected:
 
 	/*


### PR DESCRIPTION
This PR adds the infrastructure to add smoothness indicators to our `convDispOp` classes that can be written to the simulation output. In preparation of #131 