### PR TITLE
Fix par disc type handling

### DIFF
--- a/src/libcadet/model/parts/ParticleDiffusionOperatorDG.cpp
+++ b/src/libcadet/model/parts/ParticleDiffusionOperatorDG.cpp
@@ -89,15 +89,13 @@ namespace parts
 
 		// Read particle discretization mode and default to "EQUIDISTANT"
 		_parDiscMode = ParticleDiscretizationMode::Equidistant;
-		std::string pdt = paramProvider.getString("PAR_DISC_TYPE");
+		std::string pdt = paramProvider.exists("PAR_DISC_TYPE") ? paramProvider.getString("PAR_DISC_TYPE") : "EQUIDISTANT";
 
 		if (pdt == "EQUIVOLUME")
 			_parDiscMode = ParticleDiscretizationMode::Equivolume;
 		else if (pdt == "USER_DEFINED")
-			_parDiscMode = ParticleDiscretizationMode::UserDefined;
-
-		if (paramProvider.exists("PAR_DISC_VECTOR"))
 		{
+			_parDiscMode = ParticleDiscretizationMode::UserDefined;
 			_parDiscVector = paramProvider.getDoubleArray("PAR_DISC_VECTOR");
 			if (_parDiscVector.size() < _nParPoints)
 				throw InvalidParameterException("Field PAR_DISC_VECTOR contains too few elements (" + std::to_string(_nParPoints) + " required)");

--- a/src/libcadet/model/parts/ParticleDiffusionOperatorFV.cpp
+++ b/src/libcadet/model/parts/ParticleDiffusionOperatorFV.cpp
@@ -70,9 +70,9 @@ namespace parts
 		_parDiscMode = ParticleDiscretizationMode::Equidistant;
 		std::string pdt = paramProvider.getString("PAR_DISC_TYPE");
 
-		if (pdt == "EQUIVOLUME_PAR")
+		if (pdt == "EQUIVOLUME")
 			_parDiscMode = ParticleDiscretizationMode::Equivolume;
-		else if (pdt == "USER_DEFINED_PAR")
+		else if (pdt == "USER_DEFINED")
 			_parDiscMode = ParticleDiscretizationMode::UserDefined;
 
 		if (paramProvider.exists("PAR_DISC_VECTOR"))

--- a/src/libcadet/model/parts/ParticleDiffusionOperatorFV.cpp
+++ b/src/libcadet/model/parts/ParticleDiffusionOperatorFV.cpp
@@ -68,15 +68,13 @@ namespace parts
 
 		// Read particle discretization mode and default to "EQUIDISTANT_PAR"
 		_parDiscMode = ParticleDiscretizationMode::Equidistant;
-		std::string pdt = paramProvider.getString("PAR_DISC_TYPE");
+		std::string pdt = paramProvider.exists("PAR_DISC_TYPE") ? paramProvider.getString("PAR_DISC_TYPE") : "EQUIDISTANT";
 
 		if (pdt == "EQUIVOLUME")
 			_parDiscMode = ParticleDiscretizationMode::Equivolume;
 		else if (pdt == "USER_DEFINED")
-			_parDiscMode = ParticleDiscretizationMode::UserDefined;
-
-		if (paramProvider.exists("PAR_DISC_VECTOR"))
 		{
+			_parDiscMode = ParticleDiscretizationMode::UserDefined;
 			_parDiscVector = paramProvider.getDoubleArray("PAR_DISC_VECTOR");
 			if (_parDiscVector.size() < _nParPoints)
 				throw InvalidParameterException("Field PAR_DISC_VECTOR contains too few elements (" + std::to_string(_nParPoints) + " required)");


### PR DESCRIPTION
Handling was not consistent, ie optional for fv and mandatory for dg, made optional for both.
Also, the names to be specified were outdated for the FV particle diffusion operator.