### PR TITLE
 Add calculation of conserved moieties

### DIFF
--- a/src/libcadet/model/ReactionModel.hpp
+++ b/src/libcadet/model/ReactionModel.hpp
@@ -312,6 +312,13 @@ public:
 	virtual unsigned int numReactionsCombined() const CADET_NOEXCEPT = 0;
 
 	virtual unsigned int numReactions() const CADET_NOEXCEPT { return 0; };
+
+	virtual bool supportsConservedMoieties() const CADET_NOEXCEPT { return false; }
+
+	virtual bool isInEquilibrium(unsigned int reaction) const CADET_NOEXCEPT { return false;}
+	
+	virtual double getStoichiometry(unsigned int component, unsigned int reaction) const CADET_NOEXCEPT { return 0.0; }
+
 protected:
 };
 

--- a/src/libcadet/model/reaction/ConservedMoieties.hpp
+++ b/src/libcadet/model/reaction/ConservedMoieties.hpp
@@ -1,0 +1,134 @@
+#include "model/ReactionModel.hpp"
+#include "cadet/Exceptions.hpp"
+#include "ConfigurationHelper.hpp"
+#include "SensParamUtil.hpp"
+
+#include "LoggingUtils.hpp"
+#include "Logging.hpp"
+
+#include <Eigen/Core>
+#include <Eigen/SVD>
+
+#include <utility>
+#include <vector>
+
+
+namespace cadet
+{
+
+namespace model
+{
+
+
+
+class ConservedMoieties
+    {
+        
+        private:
+        bool enabled = false;
+
+        unsigned int nStates = 0;
+        unsigned int nReactionTotal = 0; // 1. only one reaction model later: for all reaction models
+        unsigned int nReactionEquilibirum = 0;
+        
+        std::vector<unsigned int> _reactionColumnOffset;
+        std::vector<bool> _eqReactionMask;
+
+        Eigen::MatrixXd _S; // N dim: nStates x nReaction
+        Eigen::MatrixXd _eqS; // N_eq dim: nStates x nEqreaction
+        
+        Eigen::MatrixXd _L; // L dim: nMoities x nStates
+        unsigned int _rank;
+
+        double TOL = 1e-15; 
+
+        public:
+        const Eigen::MatrixXd& getConservedMoitiesMatrix() const { return _L; }
+        void setConservedMoitiesMatrix(Eigen::MatrixXd L){ _L = L; }
+
+        const Eigen::MatrixXd& getStoichiomerie() const { return _S; }
+        void setStoichiomerie(Eigen::MatrixXd& S){ _S = S; }
+
+        bool configure(unsigned int states, std::vector<unsigned int>&& reactionColumnOffset,
+            std::vector<bool>&& eqReactionFlags, Eigen::MatrixXd&& stoichiometry, double rankTol)
+        {
+            enabled = false;
+            nStates = states;
+            nReactionTotal = static_cast<unsigned int>(eqReactionFlags.size());
+            _reactionColumnOffset = std::move(reactionColumnOffset);
+            _eqReactionMask = std::move(eqReactionFlags);
+            _S = std::move(stoichiometry);
+            TOL = rankTol;
+
+            extractEquilibriumStoichiometry();
+            computeLeftNullspace();
+
+            enabled = true;
+            return true;
+        }
+
+        void extractEquilibriumStoichiometry()
+        {
+            unsigned int nEq = 0;
+            for (bool isEq : _eqReactionMask)
+            {
+                if (isEq) ++nEq;
+            }
+
+            nReactionEquilibirum = nEq;
+            _eqS.resize(_S.rows(), nEq);
+            unsigned int col = 0;
+
+            for (unsigned int r = 0; r < _eqReactionMask.size(); ++r)
+            {
+                if (!_eqReactionMask[r])
+                    continue;
+                _eqS.col(col) = _S.col(r);
+                col++;
+            }
+
+        }
+
+        void computeLeftNullspace()
+        {
+            if (_eqS.cols() == 0)
+            { 
+                _rank = 0;
+                _L = Eigen::MatrixXd::Identity(_eqS.rows(), _eqS.rows());
+                return;
+            }
+
+            Eigen::MatrixXd A = _eqS.transpose();
+            Eigen::JacobiSVD<Eigen::MatrixXd> svd(A, Eigen::ComputeFullV);
+            
+            const auto& singularValues = svd.singularValues();
+
+            _rank = 0;
+            for (int i = 0; i < singularValues.size(); ++i)
+            {
+                if (singularValues(i) > TOL)
+                    ++_rank;
+            }
+
+            const unsigned int nullity = static_cast<unsigned int>(A.cols()) - _rank;
+            
+            if (nullity == 0)
+            {
+                _L = Eigen::MatrixXd::Zero(0, _eqS.rows());
+                return;
+            }
+            
+            const Eigen::MatrixXd V = svd.matrixV();
+            
+            // Columns rank ... end span null(A)
+            const Eigen::MatrixXd nullspace = V.rightCols(nullity);
+            // L such that L * N = 0
+            _L = nullspace.transpose();
+        }
+
+    };
+
+
+} //model
+
+} //cadet

--- a/src/libcadet/model/reaction/MassActionLawReaction.cpp
+++ b/src/libcadet/model/reaction/MassActionLawReaction.cpp
@@ -268,6 +268,11 @@ public:
 	virtual unsigned int numReactions() const CADET_NOEXCEPT { return _stoichiometry.columns(); }
 	virtual unsigned int numReactionsLiquid() const CADET_NOEXCEPT { return 0; }
 	virtual unsigned int numReactionsCombined() const CADET_NOEXCEPT { return 0; }
+	
+	virtual bool supportsConservedMoieties() const CADET_NOEXCEPT { return true; }
+
+	virtual bool isInEquilibrium(unsigned int reaction) const CADET_NOEXCEPT { return _eqMaskVector[reaction];}
+	virtual double getStoichiometry(unsigned int component, unsigned int reaction) const CADET_NOEXCEPT { return static_cast<double>(_stoichiometry.native(component, reaction));}
 
 	CADET_DYNAMICREACTIONMODEL_BOILERPLATE
 
@@ -277,6 +282,9 @@ protected:
 	linalg::ActiveDenseMatrix _stoichiometry;
 	linalg::ActiveDenseMatrix _expFwd;
 	linalg::ActiveDenseMatrix _expBwd;
+
+	std::vector<bool> _eqMaskVector;
+
 	
 	
 	inline int maxNumReactions() const CADET_NOEXCEPT
@@ -332,7 +340,17 @@ protected:
 			std::transform(_stoichiometry.data(), _stoichiometry.data() + _stoichiometry.elements(), _expBwd.data(), [](const active& v) { return std::max(0.0, static_cast<double>(v)); });
 		}
 		registerCompRowMatrix(_parameters, unitOpIdx, parTypeIdx, "MAL_EXPONENTS_BWD", _expBwd);
-		
+
+		_eqMaskVector.assign(maxNumReactions(), false);
+		if (paramProvider.exists("MAL_IS_KINETIC"))
+		{
+			const std::vector<int> isKinetic = paramProvider.getIntArray("MAL_IS_KINETIC");
+			if (static_cast<int>(isKinetic.size()) != _stoichiometry.columns())
+				throw InvalidParameterException("Expected MAL_IS_KINETIC and MAL_STOICHIOMETRY columns has to be of the same size (" + std::to_string(_stoichiometry.columns()) + ")");
+
+			for (int r = 0; r < _stoichiometry.columns(); ++r)
+				_eqMaskVector[r] = (isKinetic[r] == 0);
+		}
 
 		return true;
 	}

--- a/src/libcadet/model/reaction/ReactionSystem.hpp
+++ b/src/libcadet/model/reaction/ReactionSystem.hpp
@@ -13,6 +13,7 @@
 #pragma once
 
 #include "model/reaction/ReactionModelBase.hpp"
+#include "model/reaction/ConservedMoieties.hpp"
 #include "model/ReactionModel.hpp"
 #include "cadet/Exceptions.hpp"
 #include "ConfigurationHelper.hpp"
@@ -31,6 +32,7 @@
 #include <limits>
 #include <cmath>
 #include <unordered_set>
+#include <utility>
 
 namespace cadet
 {
@@ -54,6 +56,7 @@ struct ReactionSystem
         struct PhaseData
         {
             std::vector<IDynamicReactionModel*> dynReactions; //!< Dynamic reactions in the phase
+            ConservedMoieties consMoities;
 
             /**
              * @brief Default constructor initializing phase data with safe defaults
@@ -268,6 +271,55 @@ struct ReactionSystem
             }
         
             return dynReactionConfSuccess;
+        }
+        
+        bool configureConservedMoities(const std::string& phaseType, unsigned int nStates, double rankTol)
+        {
+            if (phaseType == "cross_phase")
+                throw InvalidParameterException("Conserved moieties are not supported for cross_phase reactions");
+
+            auto& phase = getPhaseData(phaseType);
+            auto& cm = phase.consMoities;
+            
+            unsigned int totalCols = 0;
+            std::vector<unsigned int> reactionColumnOffset;
+            reactionColumnOffset.reserve(phase.dynReactions.size());
+            
+            for (const auto* reaction : phase.dynReactions)
+            {
+                reactionColumnOffset.push_back(totalCols);
+
+                if (!reaction)
+                    continue;
+                if (!reaction->supportsConservedMoieties())
+                    throw InvalidParameterException("Reaction model does not support conserved moieties");
+                
+                totalCols += reaction->numReactions();
+            }
+            Eigen::MatrixXd S(nStates, totalCols);
+            std::vector<bool> eqReactionFlags(totalCols);
+
+            unsigned int colOffset = 0;
+            for (const auto* reaction : phase.dynReactions)
+            {
+                if (!reaction)
+                    continue;
+                const unsigned int nReac = reaction->numReactions();
+                
+                for (unsigned int r = 0; r < nReac; ++r)
+                {
+                    eqReactionFlags[colOffset + r]  = reaction->isInEquilibrium(r);
+
+                    for (unsigned int s = 0; s < nStates; ++s)
+                    {
+                        S(s, colOffset + r) = reaction->getStoichiometry(s, r);
+                    }
+                }
+
+                colOffset += nReac;
+            }
+
+            return cm.configure(nStates, std::move(reactionColumnOffset), std::move(eqReactionFlags), std::move(S), rankTol);
         }
 
         /**

--- a/test/ReactionModelTests.cpp
+++ b/test/ReactionModelTests.cpp
@@ -499,6 +499,47 @@ namespace reaction
 		testTimeDerivativeJacobianDynamicReactionsFD(jpp, bulk, particle, particleModifiers, h, absTol, relTol);
 	}
 
+	Eigen::MatrixXd conservedMoietiesFromMassActionLaw(unsigned int nComp, const char* config)
+	{
+		std::vector<unsigned int> nBound(nComp, 0);
+		std::vector<unsigned int> boundOffset(nComp, 0);
+
+		cadet::JsonParameterProvider jpp(config);
+		cadet::ReactionModelFactory rmf;
+		std::unique_ptr<cadet::model::IDynamicReactionModel> model(rmf.createDynamic("MASS_ACTION_LAW"));
+		REQUIRE(model);
+		REQUIRE(model->configureModelDiscretization(jpp, nComp, nBound.data(), boundOffset.data()));
+		REQUIRE(model->configure(jpp, 0, 0));
+
+		const unsigned int nReactions = model->numReactions();
+		Eigen::MatrixXd stoichiometry(nComp, nReactions);
+		std::vector<bool> eqReactionFlags(nReactions);
+
+		for (unsigned int r = 0; r < nReactions; ++r)
+		{
+			eqReactionFlags[r] = model->isInEquilibrium(r);
+			for (unsigned int c = 0; c < nComp; ++c)
+				stoichiometry(c, r) = model->getStoichiometry(c, r);
+		}
+
+		cadet::model::ConservedMoieties cm;
+		REQUIRE(cm.configure(nComp, std::vector<unsigned int>{0u}, std::move(eqReactionFlags), std::move(stoichiometry), 1e-14));
+
+		return cm.getConservedMoitiesMatrix();
+	}
+
+	void checkNullSpace(const Eigen::MatrixXd& left, const Eigen::MatrixXd& right)
+	{
+		const double nullspaceTol = 1e-12;
+		const Eigen::MatrixXd product = left * right;
+
+		for (Eigen::Index r = 0; r < product.rows(); ++r)
+		{
+			for (Eigen::Index c = 0; c < product.cols(); ++c)
+				CHECK(std::abs(product(r, c)) <= nullspaceTol);
+		}
+	}
+
 } // namespace reaction
 } // namespace test
 } // namespace cadet

--- a/test/ReactionModelTests.hpp
+++ b/test/ReactionModelTests.hpp
@@ -193,6 +193,10 @@ namespace reaction
 	 */
 	void testTimeDerivativeJacobianDynamicReactionsFD(const std::string& uoType, const std::string& spatialMethod, bool bulk, bool particle, bool particleModifiers, double h, double absTol, double relTol);
 
+	void checkNullSpace(const Eigen::MatrixXd& left, const Eigen::MatrixXd& right);
+	Eigen::MatrixXd conservedMoietiesFromMassActionLaw(unsigned int nComp, const char* config);
+
+
 } // namespace reaction
 } // namespace test
 } // namespace cadet

--- a/test/ReactionModels.cpp
+++ b/test/ReactionModels.cpp
@@ -14,6 +14,104 @@
 
 #include "ReactionModelTests.hpp"
 #include "ColumnTests.hpp"
+#include "ReactionModelFactory.hpp"
+#include "common/JsonParameterProvider.hpp"
+
+#include <cmath>
+#include <memory>
+#include <utility>
+#include <vector>
+
+
+TEST_CASE("MassActionLaw conserved moieties nullspace", "[MassActionLaw],[ReactionModel],[ConservedMoieties],[CI]")
+{
+	SECTION("A <-> B")
+	{
+		const Eigen::MatrixXd L = cadet::test::reaction::conservedMoietiesFromMassActionLaw(2,
+			R"json({
+				"MAL_KFWD": [1.0],
+				"MAL_KBWD": [2.0],
+				"MAL_STOICHIOMETRY": [-1.0,
+				                       1.0],
+				"MAL_IS_KINETIC": [0]
+			})json");
+
+		Eigen::MatrixXd S(2, 1);
+		S << -1.0, 1.0;
+
+		REQUIRE(L.rows() == 1);
+		REQUIRE(L.cols() == 2);
+		cadet::test::reaction::checkNullSpace(L, S);
+	}
+
+	SECTION("A + B <-> C")
+	{
+		const Eigen::MatrixXd L = cadet::test::reaction::conservedMoietiesFromMassActionLaw(3,
+			R"json({
+				"MAL_KFWD": [1.0],
+				"MAL_KBWD": [2.0],
+				"MAL_STOICHIOMETRY": [-1.0,
+				                      -1.0,
+				                       1.0],
+				"MAL_IS_KINETIC": [0]
+			})json");
+
+		Eigen::MatrixXd S(3, 1);
+		S << -1.0, -1.0, 1.0;
+
+		REQUIRE(L.rows() == 2);
+		REQUIRE(L.cols() == 3);
+		cadet::test::reaction::checkNullSpace(L, S);
+		
+	}
+	SECTION("A + B <-> C (eq) and A <-> B (kin)")
+	{
+		const Eigen::MatrixXd L = cadet::test::reaction::conservedMoietiesFromMassActionLaw(3,
+			R"json({
+				"MAL_KFWD": [1.0,1.0],
+				"MAL_KBWD": [2.0,2.0],
+				"MAL_STOICHIOMETRY": [-1.0,-1.0,
+				                      -1.0, 1.0,
+				                       1.0, 0.0],
+				"MAL_IS_KINETIC": [0,1]
+			})json");
+
+		Eigen::MatrixXd S(3, 1);
+		S << -1.0, -1.0, 1.0;
+
+		REQUIRE(L.rows() == 2);
+		REQUIRE(L.cols() == 3);
+		cadet::test::reaction::checkNullSpace(L, S);
+
+	}
+
+	SECTION("No equilibrium MAL reaction")
+	{
+		const Eigen::MatrixXd L = cadet::test::reaction::conservedMoietiesFromMassActionLaw(3,
+			R"json({
+				"MAL_KFWD": [1.0],
+				"MAL_KBWD": [2.0],
+				"MAL_STOICHIOMETRY": [-1.0,
+				                      -1.0,
+				                       1.0],
+				"MAL_IS_KINETIC": [1]
+			})json");
+
+ 		Eigen::MatrixXd expected;
+		expected = Eigen::MatrixXd::Identity(3, 3);
+		
+		const double tol = 1e-12;
+
+		REQUIRE(L.rows() == expected.rows());
+		REQUIRE(L.cols() == expected.cols());
+
+		for (Eigen::Index r = 0; r < L.rows(); ++r)
+		{
+			for (Eigen::Index c = 0; c < L.cols(); ++c)
+				CHECK(std::abs(L(r, c) - expected(r, c)) <= tol);
+		}
+	}
+}
 
 TEST_CASE("MassActionLaw kinetic analytic Jacobian vs AD", "[MassActionLaw],[ReactionModel],[Jacobian],[AD]")
 {


### PR DESCRIPTION
First step towards fixing #20.
This PR will add the calculation of conserved moieties for single-phase reactions.

ToDo:
- [x] Add new conserved moieties class
- [x] Add configure to ReactionSystem.hpp
- [x] Add related function to reaction interface class
- [x] Add tests.

More information about the algorithm is available under the [forum post about reactions in rapid equilibrium](https://forum.cadet-web.de/t/reaction-in-rapid-equilibrium/1098)

Follow-ups:
- Use conserved moiety matrix to enable reaction in rapid equilibrium for unit operations 