### PR TITLE
Fix columnModelBuilder for DPFR LRM_FV unit

### DIFF
--- a/src/libcadet/model/ColumnModelBuilder.cpp
+++ b/src/libcadet/model/ColumnModelBuilder.cpp
@@ -92,6 +92,9 @@ namespace model
 			}
 			else if (discName == "FV")
 			{
+				if(arrowHeadOpt)
+					model = createAxialFVLRM(uoId);
+				else
 				model = createAxialCol1DFV(uoId);
 			}
 			else


### PR DESCRIPTION
We introduced the arrow head optimization flag in #719 , but for a DPFR (NPARTYPE=0) the columnModelBuilder always fell back to the columnModel1D. This PR changes the code to also ask for the optimization flag for a DPFR