### PR TITLE
Fix FV convDispOp inlet Jacobian for generalized unit

### DIFF
--- a/src/libcadet/model/ColumnModelBuilder.cpp
+++ b/src/libcadet/model/ColumnModelBuilder.cpp
@@ -95,7 +95,7 @@ namespace model
 				if(arrowHeadOpt)
 					model = createAxialFVLRM(uoId);
 				else
-				model = createAxialCol1DFV(uoId);
+					model = createAxialCol1DFV(uoId);
 			}
 			else
 			{

--- a/src/libcadet/model/parts/ConvectionDispersionOperatorFV.cpp
+++ b/src/libcadet/model/parts/ConvectionDispersionOperatorFV.cpp
@@ -431,16 +431,11 @@ int AxialConvectionDispersionOperatorBaseFV::calcTransportJacobian(const IModel&
 	const double v = inletJacobianFactor();
 	jacInlet(0, 0) = forwardFlow() ? -v : v;
 
-	linalg::BandedEigenSparseRowIterator jac = linalg::BandedEigenSparseRowIterator(jacobian, 0);
-
-	for (int comp = 0; comp < static_cast<int>(_nComp); ++comp, ++jac)
-	{
-		const int row = forwardFlow() ? 0 : (static_cast<int>(_nCol) - 1) * static_cast<int>(_nComp);
-		jac[bulkOffset + row] = forwardFlow() ? -v : v;
-	}
-
-	if (!jacobian.isCompressed())
-		jacobian.makeCompressed();
+	// Inlet coupling: entries of the inlet-adjacent cell w.r.t. the inlet DOFs.
+	// These entries are reserved in convDispJacPattern(), so writing them keeps the matrix compressed.
+	const int inletCellRow = forwardFlow() ? 0 : (static_cast<int>(_nCol) - 1) * static_cast<int>(_nComp);
+	for (int comp = 0; comp < static_cast<int>(_nComp); ++comp)
+		jacobian.coeffRef(bulkOffset + inletCellRow + comp, comp) = jacInlet(0, 0);
 
 	return jacobian.isCompressed();
 }
@@ -1197,6 +1192,12 @@ int RadialConvectionDispersionOperatorBaseFV::calcTransportJacobian(const IModel
 
 	const double v = inletJacobianFactor();
 	jacInlet(0, 0) = forwardFlow() ? -v : v;
+
+	// Inlet coupling: entries of the inlet-adjacent cell w.r.t. the inlet DOFs.
+	// These entries are reserved in convDispJacPattern(), so writing them keeps the matrix compressed.
+	const int inletCellRow = forwardFlow() ? 0 : (static_cast<int>(_nCol) - 1) * static_cast<int>(_nComp);
+	for (int comp = 0; comp < static_cast<int>(_nComp); ++comp)
+		jacobian.coeffRef(bulkOffset + inletCellRow + comp, comp) = jacInlet(0, 0);
 
 	return jacobian.isCompressed();
 }
@@ -1990,6 +1991,12 @@ int FrustumConvectionDispersionOperatorBaseFV::calcTransportJacobian(const IMode
 
 	const double v = inletJacobianFactor();
 	jacInlet(0, 0) = forwardFlow() ? -v : v;
+
+	// Inlet coupling: entries of the inlet-adjacent cell w.r.t. the inlet DOFs.
+	// These entries are reserved in convDispJacPattern(), so writing them keeps the matrix compressed.
+	const int inletCellRow = forwardFlow() ? 0 : (static_cast<int>(_nCol) - 1) * static_cast<int>(_nComp);
+	for (int comp = 0; comp < static_cast<int>(_nComp); ++comp)
+		jacobian.coeffRef(bulkOffset + inletCellRow + comp, comp) = jacInlet(0, 0);
 
 	return jacobian.isCompressed();
 }

--- a/src/libcadet/model/parts/ConvectionDispersionOperatorFV.cpp
+++ b/src/libcadet/model/parts/ConvectionDispersionOperatorFV.cpp
@@ -431,6 +431,17 @@ int AxialConvectionDispersionOperatorBaseFV::calcTransportJacobian(const IModel&
 	const double v = inletJacobianFactor();
 	jacInlet(0, 0) = forwardFlow() ? -v : v;
 
+	linalg::BandedEigenSparseRowIterator jac = linalg::BandedEigenSparseRowIterator(jacobian, 0);
+
+	for (int comp = 0; comp < static_cast<int>(_nComp); ++comp, ++jac)
+	{
+		const int row = forwardFlow() ? 0 : (static_cast<int>(_nCol) - 1) * static_cast<int>(_nComp);
+		jac[bulkOffset + row] = forwardFlow() ? -v : v;
+	}
+
+	if (!jacobian.isCompressed())
+		jacobian.makeCompressed();
+
 	return jacobian.isCompressed();
 }
 

--- a/src/libcadet/model/parts/ConvectionDispersionOperatorFV.hpp
+++ b/src/libcadet/model/parts/ConvectionDispersionOperatorFV.hpp
@@ -89,9 +89,11 @@ public:
 	bool notifyDiscontinuousSectionTransition(double t, unsigned int secIdx);
 	bool notifyDiscontinuousSectionTransition(double t, unsigned int secIdx, Eigen::MatrixXd& jacInlet)
 	{
+		// Update velocity and flow direction before evaluating inletJacobianFactor()
+		const bool hasChanged = notifyDiscontinuousSectionTransition(t, secIdx);
 		jacInlet.resize(1, 1);
 		jacInlet(0, 0) = forwardFlow() ? -inletJacobianFactor() : inletJacobianFactor();
-		return notifyDiscontinuousSectionTransition(t, secIdx);
+		return hasChanged;
 	}
 
 	int residual(const IModel& model, double t, unsigned int secIdx, double const* y, double const* yDot, double* res, linalg::BandMatrix& jac);
@@ -231,9 +233,11 @@ public:
 	bool notifyDiscontinuousSectionTransition(double t, unsigned int secIdx);
 	bool notifyDiscontinuousSectionTransition(double t, unsigned int secIdx, Eigen::MatrixXd& jacInlet)
 	{
+		// Update velocity and flow direction before evaluating inletJacobianFactor()
+		const bool hasChanged = notifyDiscontinuousSectionTransition(t, secIdx);
 		jacInlet.resize(1, 1);
 		jacInlet(0, 0) = forwardFlow() ? -inletJacobianFactor() : inletJacobianFactor();
-		return notifyDiscontinuousSectionTransition(t, secIdx);
+		return hasChanged;
 	}
 
 	int residual(const IModel& model, double t, unsigned int secIdx, double const* y, double const* yDot, double* res, linalg::BandMatrix& jac);
@@ -380,9 +384,11 @@ public:
 	bool notifyDiscontinuousSectionTransition(double t, unsigned int secIdx);
 	bool notifyDiscontinuousSectionTransition(double t, unsigned int secIdx, Eigen::MatrixXd& jacInlet)
 	{
+		// Update velocity and flow direction before evaluating inletJacobianFactor()
+		const bool hasChanged = notifyDiscontinuousSectionTransition(t, secIdx);
 		jacInlet.resize(1, 1);
 		jacInlet(0, 0) = forwardFlow() ? -inletJacobianFactor() : inletJacobianFactor();
-		return notifyDiscontinuousSectionTransition(t, secIdx);
+		return hasChanged;
 	}
 
 	int residual(const IModel& model, double t, unsigned int secIdx, double const* y, double const* yDot, double* res, linalg::BandMatrix& jac);

--- a/src/libcadet/model/parts/ConvectionDispersionOperatorFV.hpp
+++ b/src/libcadet/model/parts/ConvectionDispersionOperatorFV.hpp
@@ -90,6 +90,7 @@ public:
 	bool notifyDiscontinuousSectionTransition(double t, unsigned int secIdx, Eigen::MatrixXd& jacInlet)
 	{
 		jacInlet.resize(1, 1);
+		jacInlet(0, 0) = forwardFlow() ? -inletJacobianFactor() : inletJacobianFactor();
 		return notifyDiscontinuousSectionTransition(t, secIdx);
 	}
 
@@ -231,6 +232,7 @@ public:
 	bool notifyDiscontinuousSectionTransition(double t, unsigned int secIdx, Eigen::MatrixXd& jacInlet)
 	{
 		jacInlet.resize(1, 1);
+		jacInlet(0, 0) = forwardFlow() ? -inletJacobianFactor() : inletJacobianFactor();
 		return notifyDiscontinuousSectionTransition(t, secIdx);
 	}
 
@@ -379,6 +381,7 @@ public:
 	bool notifyDiscontinuousSectionTransition(double t, unsigned int secIdx, Eigen::MatrixXd& jacInlet)
 	{
 		jacInlet.resize(1, 1);
+		jacInlet(0, 0) = forwardFlow() ? -inletJacobianFactor() : inletJacobianFactor();
 		return notifyDiscontinuousSectionTransition(t, secIdx);
 	}
 

--- a/test/ColumnModel1D.cpp
+++ b/test/ColumnModel1D.cpp
@@ -61,6 +61,16 @@ TEST_CASE("Column_1D as LRMP with FV equivalence with arrow head implementation"
 	cadet::test::column::testEqualResults(jpp1, jpp2, 1e-10, 1e-8);
 }
 
+TEST_CASE("Column_1D as GRM with FV transport Jacobian", "[Column_1D],[FV],[UnitOp],[Jacobian],[CI]")
+{
+	cadet::JsonParameterProvider jpp = createColumnLinearBenchmark(false, true, "COLUMN_MODEL_1D_GRM", "FV");
+
+	jpp.pushScope("discretization");
+	jpp.set("FV_ARROW_HEAD_OPTIMIZATION", false);
+	jpp.popScope();
+
+	cadet::test::column::testJacobianAD(jpp, std::numeric_limits<float>::epsilon() * 100.0);
+}
 
 TEST_CASE("Column_1D as GRM LWE forward vs backward flow", "[Column_1D],[DG],[DG1D],[Simulation],[CI]")
 {

--- a/test/ColumnTests.cpp
+++ b/test/ColumnTests.cpp
@@ -896,12 +896,12 @@ namespace column
 		unitAD->residualWithJacobian(simTime, simState, jacDir.data(), adParams, tls);
 		std::fill(jacDir.begin(), jacDir.end(), 0.0);
 
-		// Compare Jacobians
-		if (absTolFDpattern < 1E+10)
-		{
-			cadet::test::checkJacobianPatternFD(unitAna, unitAD, y.data(), nullptr, jacDir.data(), jacCol1.data(), jacCol2.data(), tls, absTolFDpattern);
-			cadet::test::checkJacobianPatternFD(unitAna, unitAna, y.data(), nullptr, jacDir.data(), jacCol1.data(), jacCol2.data(), tls, absTolFDpattern);
-		}
+		//// Compare Jacobians
+		//if (absTolFDpattern < 1E+10)
+		//{
+		//	cadet::test::checkJacobianPatternFD(unitAna, unitAD, y.data(), nullptr, jacDir.data(), jacCol1.data(), jacCol2.data(), tls, absTolFDpattern);
+		//	cadet::test::checkJacobianPatternFD(unitAna, unitAna, y.data(), nullptr, jacDir.data(), jacCol1.data(), jacCol2.data(), tls, absTolFDpattern);
+		//}
 		cadet::test::compareJacobian(unitAna, unitAD, nullptr, nullptr, jacDir.data(), jacCol1.data(), jacCol2.data(), absTolAD);
 //				cadet::test::compareJacobianFD(unitAna, unitAD, y.data(), nullptr, jacDir.data(), jacCol1.data(), jacCol2.data());
 

--- a/test/ColumnTests.cpp
+++ b/test/ColumnTests.cpp
@@ -896,12 +896,12 @@ namespace column
 		unitAD->residualWithJacobian(simTime, simState, jacDir.data(), adParams, tls);
 		std::fill(jacDir.begin(), jacDir.end(), 0.0);
 
-		//// Compare Jacobians
-		//if (absTolFDpattern < 1E+10)
-		//{
-		//	cadet::test::checkJacobianPatternFD(unitAna, unitAD, y.data(), nullptr, jacDir.data(), jacCol1.data(), jacCol2.data(), tls, absTolFDpattern);
-		//	cadet::test::checkJacobianPatternFD(unitAna, unitAna, y.data(), nullptr, jacDir.data(), jacCol1.data(), jacCol2.data(), tls, absTolFDpattern);
-		//}
+		// Compare Jacobians
+		if (absTolFDpattern < 1E+10)
+		{
+			cadet::test::checkJacobianPatternFD(unitAna, unitAD, y.data(), nullptr, jacDir.data(), jacCol1.data(), jacCol2.data(), tls, absTolFDpattern);
+			cadet::test::checkJacobianPatternFD(unitAna, unitAna, y.data(), nullptr, jacDir.data(), jacCol1.data(), jacCol2.data(), tls, absTolFDpattern);
+		}
 		cadet::test::compareJacobian(unitAna, unitAD, nullptr, nullptr, jacDir.data(), jacCol1.data(), jacCol2.data(), absTolAD);
 //				cadet::test::compareJacobianFD(unitAna, unitAD, y.data(), nullptr, jacDir.data(), jacCol1.data(), jacCol2.data());
 


### PR DESCRIPTION
The bulk FV convection dipsersion operator as used in the generalized unit looses its compressed storage, rendering corresponding simulations inefficient