### PR TITLE
Fix particle diffusion Operator FV

### DIFF
--- a/src/libcadet/model/particle/GeneralRateParticle.cpp
+++ b/src/libcadet/model/particle/GeneralRateParticle.cpp
@@ -313,7 +313,6 @@ namespace model
 			active const* const filmDiff = _parDiffOp->getFilmDiffusion(secIdx);
 			const ParamType invBetaC = 1.0 / static_cast<ParamType>(packing.colPorosity) - 1.0;
 			const ParamType jacCF_val = invBetaC * static_cast<ParamType>(surfaceToVolumeRatio());
-			const ParamType epsP = static_cast<ParamType>(_parDiffOp->getPorosity());
 
 			// Add flux to column void / bulk volume using discretized film diffusion
 			for (unsigned int comp = 0; comp < _nComp; ++comp)

--- a/src/libcadet/model/particle/GeneralRateParticle.cpp
+++ b/src/libcadet/model/particle/GeneralRateParticle.cpp
@@ -311,23 +311,17 @@ namespace model
 		{
 			// film diffusion bulk eq. term
 			active const* const filmDiff = _parDiffOp->getFilmDiffusion(secIdx);
-			active const* const parDiff = _parDiffOp->getParDiffusion(secIdx);
 			const ParamType invBetaC = 1.0 / static_cast<ParamType>(packing.colPorosity) - 1.0;
 			const ParamType jacCF_val = invBetaC * static_cast<ParamType>(surfaceToVolumeRatio());
 			const ParamType epsP = static_cast<ParamType>(_parDiffOp->getPorosity());
-			const ParamType halfWidth = static_cast<ParamType>(_parDiffOp->outerCellHalfWidth());
-			const int bndOrder = _parDiffOp->boundaryOrder();
 
 			// Add flux to column void / bulk volume using discretized film diffusion
 			for (unsigned int comp = 0; comp < _nComp; ++comp)
 			{
-				ParamType kf_FV;
-				if (bndOrder == 2 && nDiscPoints() > 1 && static_cast<double>(halfWidth) > 0.0)
-					kf_FV = 1.0 / (halfWidth / epsP / static_cast<ParamType>(_parDiffOp->getPoreAccessFactor()[comp]) / static_cast<ParamType>(parDiff[comp]) + 1.0 / static_cast<ParamType>(filmDiff[comp]));
-				else
-					kf_FV = static_cast<ParamType>(filmDiff[comp]);
+				ParamType discretizedFilmDiffusionFactor = static_cast<ParamType>(_parDiffOp->discretizedFilmDiffusionFactor(comp));
 
-				resBulk[comp] += kf_FV * jacCF_val * static_cast<ParamType>(packing.parTypeVolFrac) * (yBulk[comp] - yPar[(nDiscPoints() - 1) * stridePoint() + comp]);
+				// + 1/Beta^c * (surfaceToVolumeRatio^p_j) * d_j * (k_f * [c^b - c^p])
+				resBulk[comp] += discretizedFilmDiffusionFactor * static_cast<ParamType>(filmDiff[comp]) * jacCF_val * static_cast<ParamType>(packing.parTypeVolFrac) * (yBulk[comp] - yPar[(nDiscPoints() - 1) * stridePoint() + comp]);
 			}
 		}
 

--- a/src/libcadet/model/particle/GeneralRateParticle.cpp
+++ b/src/libcadet/model/particle/GeneralRateParticle.cpp
@@ -311,15 +311,23 @@ namespace model
 		{
 			// film diffusion bulk eq. term
 			active const* const filmDiff = _parDiffOp->getFilmDiffusion(secIdx);
+			active const* const parDiff = _parDiffOp->getParDiffusion(secIdx);
 			const ParamType invBetaC = 1.0 / static_cast<ParamType>(packing.colPorosity) - 1.0;
 			const ParamType jacCF_val = invBetaC * static_cast<ParamType>(surfaceToVolumeRatio());
-//			const ParamType jacPF_val = -1.0 / static_cast<ParamType>(getPorosity());
+			const ParamType epsP = static_cast<ParamType>(_parDiffOp->getPorosity());
+			const ParamType halfWidth = static_cast<ParamType>(_parDiffOp->outerCellHalfWidth());
+			const int bndOrder = _parDiffOp->boundaryOrder();
 
-			// Add flux to column void / bulk volume
+			// Add flux to column void / bulk volume using discretized film diffusion
 			for (unsigned int comp = 0; comp < _nComp; ++comp)
 			{
-				// + 1/Beta^c * (surfaceToVolumeRatio^p_j) * d_j * (k_f * [c^b - c^p])
-				resBulk[comp] += static_cast<ParamType>(filmDiff[comp]) * jacCF_val * static_cast<ParamType>(packing.parTypeVolFrac) * (yBulk[comp] - yPar[(nDiscPoints() - 1) * stridePoint() + comp]);
+				ParamType kf_FV;
+				if (bndOrder == 2 && nDiscPoints() > 1 && static_cast<double>(halfWidth) > 0.0)
+					kf_FV = 1.0 / (halfWidth / epsP / static_cast<ParamType>(_parDiffOp->getPoreAccessFactor()[comp]) / static_cast<ParamType>(parDiff[comp]) + 1.0 / static_cast<ParamType>(filmDiff[comp]));
+				else
+					kf_FV = static_cast<ParamType>(filmDiff[comp]);
+
+				resBulk[comp] += kf_FV * jacCF_val * static_cast<ParamType>(packing.parTypeVolFrac) * (yBulk[comp] - yPar[(nDiscPoints() - 1) * stridePoint() + comp]);
 			}
 		}
 

--- a/src/libcadet/model/parts/ParticleDiffusionOperatorBase.hpp
+++ b/src/libcadet/model/parts/ParticleDiffusionOperatorBase.hpp
@@ -180,10 +180,14 @@ namespace parts
 		inline const active& getPorosity() const CADET_NOEXCEPT { return _parPorosity; }
 		inline const active* getPoreAccessFactor() const CADET_NOEXCEPT { return &_poreAccessFactor[0]; }
 		inline const active* getFilmDiffusion(const unsigned int secIdx) const CADET_NOEXCEPT { return getSectionDependentSlice(_filmDiffusion, _nComp, secIdx); }
+		inline const active* getParDiffusion(const unsigned int secIdx) const CADET_NOEXCEPT { return getSectionDependentSlice(_parDiffusion, _nComp, secIdx); }
 		inline IParameterStateDependence* getParDepSurfDiffusion() const CADET_NOEXCEPT { return _parDepSurfDiffusion; }
 		inline bool paramDepSurfDiffParTypeIndep() const CADET_NOEXCEPT { return !_paramDepSurfDiffTypeDep; }
 		inline MultiplexMode parDiffMode() const CADET_NOEXCEPT { return _parDiffusionMode; }
 		inline MultiplexMode parSurfDiffMode() const CADET_NOEXCEPT { return _parSurfDiffusionMode; }
+
+		virtual active outerCellHalfWidth() const CADET_NOEXCEPT { return active(0.0); }
+		virtual int boundaryOrder() const CADET_NOEXCEPT { return 2; }
 
 	protected:
 

--- a/src/libcadet/model/parts/ParticleDiffusionOperatorBase.hpp
+++ b/src/libcadet/model/parts/ParticleDiffusionOperatorBase.hpp
@@ -180,14 +180,12 @@ namespace parts
 		inline const active& getPorosity() const CADET_NOEXCEPT { return _parPorosity; }
 		inline const active* getPoreAccessFactor() const CADET_NOEXCEPT { return &_poreAccessFactor[0]; }
 		inline const active* getFilmDiffusion(const unsigned int secIdx) const CADET_NOEXCEPT { return getSectionDependentSlice(_filmDiffusion, _nComp, secIdx); }
-		inline const active* getParDiffusion(const unsigned int secIdx) const CADET_NOEXCEPT { return getSectionDependentSlice(_parDiffusion, _nComp, secIdx); }
 		inline IParameterStateDependence* getParDepSurfDiffusion() const CADET_NOEXCEPT { return _parDepSurfDiffusion; }
 		inline bool paramDepSurfDiffParTypeIndep() const CADET_NOEXCEPT { return !_paramDepSurfDiffTypeDep; }
 		inline MultiplexMode parDiffMode() const CADET_NOEXCEPT { return _parDiffusionMode; }
 		inline MultiplexMode parSurfDiffMode() const CADET_NOEXCEPT { return _parSurfDiffusionMode; }
-
-		virtual active outerCellHalfWidth() const CADET_NOEXCEPT { return active(0.0); }
-		virtual int boundaryOrder() const CADET_NOEXCEPT { return 2; }
+		
+		virtual active discretizedFilmDiffusionFactor(const int comp) const CADET_NOEXCEPT { return active(1.0); }
 
 	protected:
 

--- a/src/libcadet/model/parts/ParticleDiffusionOperatorFV.cpp
+++ b/src/libcadet/model/parts/ParticleDiffusionOperatorFV.cpp
@@ -513,30 +513,21 @@ namespace parts
 		/* Film diffusion */
 		// note that bulk equation part is treated outside this operator; here we only handle the particle equation film diffusion
 
-		// Discretized film diffusion kf for finite volumes
-		ParamType kf_FV = 0.0;
 		const ParamType epsP = static_cast<ParamType>(_parPorosity);
-		//const ParamType surfaceToVolumeRatio = _parGeomSurfToVol / static_cast<ParamType>(_parRadius);
 		const ParamType outerAreaPerVolume = static_cast<ParamType>(_parOuterSurfAreaPerVolume[_nParPoints - 1]);
-
 		const ParamType jacPF_val = -outerAreaPerVolume / epsP;
-
-		// Discretized film diffusion kf for finite volumes
-		if (cadet_likely(_boundaryOrderFV == 2))
-		{
-			const ParamType absOuterShellHalfRadius = 0.5 * static_cast<ParamType>(_deltaR[_nParPoints - 1]);
-			for (int comp = 0; comp < _nComp; ++comp)
-				kf_FV = 1.0 / (absOuterShellHalfRadius / epsP / static_cast<ParamType>(_poreAccessFactor[comp]) / static_cast<ParamType>(parDiff[comp]) + 1.0 / static_cast<ParamType>(filmDiff[comp]));
-		}
-		else
-		{
-			for (int comp = 0; comp < _nComp; ++comp)
-				kf_FV = static_cast<ParamType>(filmDiff[comp]);
-		}
+		const ParamType absOuterShellHalfRadius = 0.5 * static_cast<ParamType>(_deltaR[_nParPoints - 1]);
 
 		// bead boundary condition in outer bead shell equation
 		for (int comp = 0; comp < _nComp; ++comp)
 		{
+			// Discretized film diffusion kf for finite volumes (per component)
+			ParamType kf_FV;
+			if (cadet_likely(_boundaryOrderFV == 2))
+				kf_FV = 1.0 / (absOuterShellHalfRadius / epsP / static_cast<ParamType>(_poreAccessFactor[comp]) / static_cast<ParamType>(parDiff[comp]) + 1.0 / static_cast<ParamType>(filmDiff[comp]));
+			else
+				kf_FV = static_cast<ParamType>(filmDiff[comp]);
+
 			ResidualType flux = kf_FV * (yBulk[comp * strideBulkComp()] - yPar[(_nParPoints - 1) * strideParPoint() + comp]);
 			resPar[(_nParPoints - 1) * strideParPoint() + comp] += jacPF_val / static_cast<ParamType>(_poreAccessFactor[comp]) * flux;
 		}
@@ -546,16 +537,14 @@ namespace parts
 		{
 			active const* const parSurfDiff = getSectionDependentSlice(_parSurfDiffusion, _strideBound, secIdx);
 			active const* const parCenterRadius = _parCenterRadius.data();
-			const ParamType absOuterShellHalfRadius = 0.5 * static_cast<ParamType>(_deltaR[_nParPoints - 1]);
-
-			// Recalculate kf_FV for surface diffusion
-			for (int comp = 0; comp < _nComp; ++comp)
-				kf_FV = (1.0 - static_cast<ParamType>(_parPorosity)) / (1.0 + epsP * static_cast<ParamType>(_poreAccessFactor[comp]) * static_cast<ParamType>(parDiff[comp]) / (absOuterShellHalfRadius * static_cast<ParamType>(filmDiff[comp])));
 
 			const ParamType dr = static_cast<ParamType>(parCenterRadius[_nParPoints - 1]) - static_cast<ParamType>(parCenterRadius[_nParPoints - 2]);
 
 			for (int comp = 0; comp < _nComp; ++comp)
 			{
+				// Recalculate kf_FV for surface diffusion (per component)
+				const ParamType kf_FV = (1.0 - static_cast<ParamType>(_parPorosity)) / (1.0 + epsP * static_cast<ParamType>(_poreAccessFactor[comp]) * static_cast<ParamType>(parDiff[comp]) / (absOuterShellHalfRadius * static_cast<ParamType>(filmDiff[comp])));
+
 				const unsigned int nBound = _nBound[comp];
 				ResidualType surfFlux = 0.0;
 
@@ -869,34 +858,29 @@ namespace parts
 		for (int blk = 0; blk < nBulkPoints; blk++)
 		{
 			for (int comp = 0; comp < _nComp; comp++, ++jacCp, ++jacCl) {
-				// add Cb on Cb entries (added since these entries are also touched by bulk jacobian)
-				// row: already at bulk phase. already at current node and component.
-				// col: already at bulk phase. already at current node and component.
-				if (!outliersOnly)
-					jacCl[0] += static_cast<double>(filmDiff[comp]) * (1.0 - colPorosity) / colPorosity
-					* _parGeomSurfToVol / static_cast<double>(_parRadius)
-					* static_cast<double>(parTypeVolFrac[_parTypeIdx + blk * nParType]);
-				// add Cb on Cp entries
-				// row: already at bulk phase. already at current node and component.
-				// col: go to current particle phase entry.
-				jacCl[jacCp.row() - jacCl.row()] = -static_cast<double>(filmDiff[comp]) * (1.0 - colPorosity) / colPorosity
-					* _parGeomSurfToVol / static_cast<double>(_parRadius)
-					* static_cast<double>(parTypeVolFrac[_parTypeIdx + blk * nParType]);
-
-				// Cp on Cb entry
-				// Discretized film diffusion kf for finite volumes
+				// Discretized film diffusion kf for finite volumes (per component)
 				double kf_FV = 0.0;
 				if (cadet_likely(_boundaryOrderFV == 2))
 				{
 					const double absOuterShellHalfRadius = 0.5 * static_cast<double>(_deltaR[_nParPoints - 1]);
-					for (int comp = 0; comp < _nComp; ++comp)
-						kf_FV = 1.0 / (absOuterShellHalfRadius / epsP / static_cast<double>(_poreAccessFactor[comp]) / static_cast<double>(parDiff[comp]) + 1.0 / static_cast<double>(filmDiff[comp]));
+					kf_FV = 1.0 / (absOuterShellHalfRadius / epsP / static_cast<double>(_poreAccessFactor[comp]) / static_cast<double>(parDiff[comp]) + 1.0 / static_cast<double>(filmDiff[comp]));
 				}
 				else
 				{
-					for (int comp = 0; comp < _nComp; ++comp)
-						kf_FV = static_cast<double>(filmDiff[comp]);
+					kf_FV = static_cast<double>(filmDiff[comp]);
 				}
+
+				// Cb on Cb entries (added since these entries are also touched by bulk jacobian)
+				if (!outliersOnly)
+					jacCl[0] += kf_FV * (1.0 - colPorosity) / colPorosity
+					* _parGeomSurfToVol / static_cast<double>(_parRadius)
+					* static_cast<double>(parTypeVolFrac[_parTypeIdx + blk * nParType]);
+				// Cb on Cp entries
+				jacCl[jacCp.row() - jacCl.row()] = -kf_FV * (1.0 - colPorosity) / colPorosity
+					* _parGeomSurfToVol / static_cast<double>(_parRadius)
+					* static_cast<double>(parTypeVolFrac[_parTypeIdx + blk * nParType]);
+
+				// Cp on Cb entry
 				jacCp[jacCl.row() - jacCp.row()] = kf_FV * jacPF_val / static_cast<double>(_poreAccessFactor[comp]);
 
 				// Cp on Cp entry

--- a/src/libcadet/model/parts/ParticleDiffusionOperatorFV.cpp
+++ b/src/libcadet/model/parts/ParticleDiffusionOperatorFV.cpp
@@ -522,13 +522,11 @@ namespace parts
 		for (int comp = 0; comp < _nComp; ++comp)
 		{
 			// Discretized film diffusion kf for finite volumes (per component)
-			ParamType kf_FV;
+			ParamType kf_FV = 1.0;
 			if (cadet_likely(_boundaryOrderFV == 2))
-				kf_FV = 1.0 / (absOuterShellHalfRadius / epsP / static_cast<ParamType>(_poreAccessFactor[comp]) / static_cast<ParamType>(parDiff[comp]) + 1.0 / static_cast<ParamType>(filmDiff[comp]));
-			else
-				kf_FV = static_cast<ParamType>(filmDiff[comp]);
+				kf_FV = 1.0 / (absOuterShellHalfRadius * static_cast<ParamType>(filmDiff[comp]) / epsP / static_cast<ParamType>(_poreAccessFactor[comp]) / static_cast<ParamType>(parDiff[comp]) + 1.0);
 
-			ResidualType flux = kf_FV * (yBulk[comp * strideBulkComp()] - yPar[(_nParPoints - 1) * strideParPoint() + comp]);
+			ResidualType flux = kf_FV * static_cast<ParamType>(filmDiff[comp]) * (yBulk[comp * strideBulkComp()] - yPar[(_nParPoints - 1) * strideParPoint() + comp]);
 			resPar[(_nParPoints - 1) * strideParPoint() + comp] += jacPF_val / static_cast<ParamType>(_poreAccessFactor[comp]) * flux;
 		}
 

--- a/src/libcadet/model/parts/ParticleDiffusionOperatorFV.hpp
+++ b/src/libcadet/model/parts/ParticleDiffusionOperatorFV.hpp
@@ -142,6 +142,9 @@ namespace parts
 
 		bool setSensitiveParameter(std::unordered_set<active*>& sensParams, const ParameterId& pId, unsigned int adDirection, double adValue);
 
+		active outerCellHalfWidth() const CADET_NOEXCEPT override { return 0.5 * _deltaR[_nParPoints - 1]; }
+		int boundaryOrder() const CADET_NOEXCEPT override { return _boundaryOrderFV; }
+
 	protected:
 
 		void parBindingPattern(std::vector<Eigen::Triplet<double>>& tripletList, const int offset, const unsigned int colNode);

--- a/src/libcadet/model/parts/ParticleDiffusionOperatorFV.hpp
+++ b/src/libcadet/model/parts/ParticleDiffusionOperatorFV.hpp
@@ -142,8 +142,13 @@ namespace parts
 
 		bool setSensitiveParameter(std::unordered_set<active*>& sensParams, const ParameterId& pId, unsigned int adDirection, double adValue);
 
-		active outerCellHalfWidth() const CADET_NOEXCEPT override { return 0.5 * _deltaR[_nParPoints - 1]; }
-		int boundaryOrder() const CADET_NOEXCEPT override { return _boundaryOrderFV; }
+		active discretizedFilmDiffusionFactor(const int comp) const CADET_NOEXCEPT
+		{
+			if (_boundaryOrderFV == 2 && nDiscPoints() > 1)
+				return 1.0 / (0.5 * _deltaR[_nParPoints - 1] * _filmDiffusion[comp] / _parPorosity / _poreAccessFactor[comp] / _parDiffusion[comp] + 1.0);
+			else
+				return active(1.0);
+		}
 
 	protected:
 

--- a/test/ColumnModel1D.cpp
+++ b/test/ColumnModel1D.cpp
@@ -25,6 +25,42 @@
 #include "common/Driver.hpp"
 
 
+TEST_CASE("Column_1D as GRM with FV equivalence with arrow head implementation", "[Column_1D],[FV],[Simulation],[CI]")
+{
+	cadet::JsonParameterProvider jpp1 = createLWE("COLUMN_MODEL_1D_GRM", "FV");
+	cadet::JsonParameterProvider jpp2 = createLWE("COLUMN_MODEL_1D_GRM", "FV");
+	cadet::test::column::FVParams disc(32);
+
+	disc.setDisc(jpp1);
+	disc.setDisc(jpp2);
+
+	// disable arrow head optimization for second setting
+	jpp2.pushScope("model");
+	jpp2.pushScope("unit_000");
+	jpp2.pushScope("discretization");
+	jpp2.set("FV_ARROW_HEAD_OPTIMIZATION", false);
+	jpp2.popScope();
+	jpp2.popScope();
+	jpp2.popScope();
+
+	// low time integration tolerances to minimize impact of different linear solvers
+	jpp2.pushScope("solver");
+	jpp2.pushScope("time_integrator");
+	jpp2.set("ABSTOL", 1e-12);
+	jpp2.set("RELTOL", 1e-10);
+	jpp2.popScope();
+	jpp2.popScope();
+
+	jpp1.pushScope("solver");
+	jpp1.pushScope("time_integrator");
+	jpp1.set("ABSTOL", 1e-12);
+	jpp1.set("RELTOL", 1e-10);
+	jpp1.popScope();
+	jpp1.popScope();
+
+	cadet::test::column::testEqualResults(jpp1, jpp2, 1e-10, 1e-8);
+}
+
 TEST_CASE("Column_1D as LRMP with FV equivalence with arrow head implementation", "[Column_1D],[FV],[Simulation],[CI]")
 {
 	cadet::JsonParameterProvider jpp1 = createLWE("COLUMN_MODEL_1D_LRMP", "FV");


### PR DESCRIPTION
## Expected Behavior
FV GRM simulations with and without arrow head optimization should yield the same result

## Actual Behavior
FV GRM simulations with and without arrow head optimization yield different results
<img width="2500" height="696" alt="image" src="https://github.com/user-attachments/assets/72ad35a3-ad5c-4313-b421-f4820fbef767" />

## Steps to Reproduce the Problem
Execute the attached LWE simulations which only differ in the field `FV_ARROW_HEAD_OPTIMIZATION`
[LWE_debug_files.zip](https://github.com/user-attachments/files/30040757/LWE_debug_files.zip)

## Further explanation
#465 introduced a FV particle diffusion operator (based on the implementation in `GeneralRateModel.cpp`) to be used in the ColumnModel1D unit operation. However, running our standard LWE example with a GRM, I get different results.
The newly added test shows the different results.
There must be some deviation from the particle diffusion as implemented in `GeneralRateModel.cpp`.