### PR TITLE
Ci/pin runner

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -16,13 +16,23 @@ jobs:
   CLAAssistant:
     runs-on: ubuntu-latest
     steps:
+      - name: "Generate token for signature storage repo"
+        id: cla-signatures-token
+        if: (github.event.comment.body == 'recheck' || contains(github.event.comment.body, 'I have read the CLA Document and I hereby sign the CLA')) || github.event_name == 'pull_request_target'
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.CLA_APP_ID }}
+          private-key: ${{ secrets.CLA_APP_PRIVATE_KEY }}
+          owner: cadet
+          repositories: cla-signatures
+
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || contains(github.event.comment.body, 'I have read the CLA Document and I hereby sign the CLA')) || github.event_name == 'pull_request_target'
         uses: contributor-assistant/github-action@v2.4.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # The below token has repo scope for the project configured further below to store signatures.
-          PERSONAL_ACCESS_TOKEN: ${{ secrets.CADET_CLA_SIGNATURES }}
+          # App-issued token, scoped only to cadet/cla-signatures, used to store signatures.
+          PERSONAL_ACCESS_TOKEN: ${{ steps.cla-signatures-token.outputs.token }}
           PATH_TO_CLA: 'https://github.com/cadet/cadet-core/blob/master/CLA.md'
         with:
           path-to-signatures: 'signatures/version1/signatures.json'

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -52,7 +52,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-15, windows-2022]
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -89,7 +89,7 @@ jobs:
             cadet-${{ env.CACHE_VERSION }}-${{ runner.os }}-
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.0.0
+        uses: pypa/cibuildwheel@v4.1.0
         env:
           CIBW_BUILD: "cp312-* cp313-* cp314-*"
           CIBW_ENABLE: cpython-prerelease


### PR DESCRIPTION
This PR fixes bug within the `cla.yml` and `wheels.yml` workflows.

- aa11ccc8 "pin GitHub runners for Mac and Windows": matrix pinned to macos-15/windows-2022 instead of the floating -latest labels (root cause of the vcpkg/clang and delocate/deployment-target failures).
- 29789663 "bump cibuildwheel version": v3.0.0 → v4.1.0 (old version was unstable and caused the "HTTP" bugs sometimes)
- f629e005 "update cla to take organization token from GitHub App":  replaces the personal CADET_CLA_SIGNATURES PAT with a token minted via actions/create-github-app-token, scoped to cadet/cla-signatures only.

Notes:
- I removed old secret `CADET_CLA_SIGNATURES` 
- CLA still fails here, since its running the one from master but I tested it and it runs https://github.com/cadet/CADET-Core/actions/runs/29490095355
- wheels also sucessfully ran with the version pins https://github.com/cadet/CADET-Core/actions/runs/29487126884