### PR TITLE
Add rapid equilibrium liquid bulk reaction  to CSTR 

### DIFF
--- a/src/libcadet/model/ReactionModel.hpp
+++ b/src/libcadet/model/ReactionModel.hpp
@@ -319,6 +319,30 @@ public:
 	
 	virtual double getStoichiometry(unsigned int component, unsigned int reaction) const CADET_NOEXCEPT { return 0.0; }
 
+
+	virtual int residualEquilibriumFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, const unsigned int nStates, active const* y,
+		active* res, unsigned int& eqIdx, LinearBufferAllocator workSpace) const = 0;
+
+	virtual int residualEquilibriumFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, const unsigned int nStates, double const* y,
+		active* res, unsigned int& eqIdx, LinearBufferAllocator workSpace) const = 0;
+
+	virtual int residualEquilibriumFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, const unsigned int nStates, double const* y,
+		double* res, unsigned int& eqIdx, LinearBufferAllocator workSpace) const = 0;
+
+
+	virtual void analyticEquilibriumJacobian(double t, unsigned int secIdx, const ColumnPosition& colPos, const unsigned int nStates, double const* y,
+		unsigned int& eqIdx, unsigned int eqRowOffset, linalg::BandMatrix::RowIterator jac, LinearBufferAllocator workSpace) const = 0;
+
+	virtual void analyticEquilibriumJacobian(double t, unsigned int secIdx, const ColumnPosition& colPos, const unsigned int nStates, double const* y,
+		unsigned int& eqIdx, unsigned int eqRowOffset, linalg::DenseBandedRowIterator jac, LinearBufferAllocator workSpace) const = 0;
+
+	virtual void analyticEquilibriumJacobian(double t, unsigned int secIdx, const ColumnPosition& colPos, const unsigned int nStates, double const* y,
+		unsigned int& eqIdx,unsigned int eqRowOffset, linalg::BandedSparseRowIterator jac, LinearBufferAllocator workSpace) const = 0;
+
+	virtual void analyticEquilibriumJacobian(double t, unsigned int secIdx, const ColumnPosition& colPos, const unsigned int nStates, double const* y,
+		unsigned int& eqIdx,unsigned int eqRowOffset, linalg::BandedEigenSparseRowIterator jac, LinearBufferAllocator workSpace) const = 0;
+
+
 protected:
 };
 

--- a/src/libcadet/model/StirredTankModel.cpp
+++ b/src/libcadet/model/StirredTankModel.cpp
@@ -395,7 +395,10 @@ bool CSTRModel::configure(IParameterProvider& paramProvider)
 
 	// Reconfigure reaction model
 	if (paramProvider.exists("NREAC_LIQUID"))
+	{
 		dynReactionConfSuccess = _reactionSystemBulk.configure("liquid", 0, _unitOpIdx, paramProvider) && dynReactionConfSuccess;
+		dynReactionConfSuccess = _reactionSystemBulk.configureConservedMoities("liquid", _nComp, 1e-14) && dynReactionConfSuccess;
+	}
 
 	for (unsigned int par = 0; par < _nParType; par++)
 	{
@@ -662,195 +665,333 @@ void CSTRModel::consistentInitialState(const SimulationTime& simTime, double* co
 		}
 	}
 	else
+{
+	const auto& cm = _reactionSystemBulk.conservedMoieties("liquid");
+	if(cm.isEnabled() && cm.numEquilibriumReactions() > 0)
 	{
-		LinearBufferAllocator tlmAlloc = threadLocalMem.get();
-		BufferedArray<int> qsMask = tlmAlloc.array<int>(_nComp + _totalBound);
-
-		// Check whether quasi-stationary reactions are present and construct mask array
-		bool hasNoQSreactions = true;
-		std::fill_n(static_cast<int*>(qsMask), _nComp + _totalBound, false);
-		int* localMask = static_cast<int*>(qsMask) + _nComp;
-		for (unsigned int type = 0; type < _nParType; localMask += _strideBound[type], ++type)
+		if (_totalBound > 0)
 		{
-			if (!_binding[type]->hasQuasiStationaryReactions())
-				continue;
-
-			// Determine whether nonlinear solver is required
-			const ColumnPosition colPos{ 0.0, 0.0, 0.0 };
-			if (!_binding[type]->preConsistentInitialState(simTime.t, simTime.secIdx, colPos, c + _nComp + _offsetParType[type], c, tlmAlloc))
-				continue;
-
-			hasNoQSreactions = false;
-
-			// Construct mask
-			int const* const qsMaskSrc = _binding[type]->reactionQuasiStationarity();
-			std::copy_n(qsMaskSrc, _strideBound[type], localMask);
-
-			// Mark component for conserved moiety if it has a quasi-stationary bound state
-			unsigned int idx = 0;
-			for (unsigned int comp = 0; comp < _nComp; ++comp)
-			{
-				// Skip components that are already marked
-				if (qsMask[comp])
-				{
-					idx += _nBound[type * _nComp + comp];
-					continue;
-				}
-
-				for (unsigned int state = 0; state < _nBound[type * _nComp + comp]; ++state, ++idx)
-				{
-					if (qsMaskSrc[idx])
-					{
-						qsMask[comp] = true;
-						break;
-					}
-				}
-			}
-		}
-
-		// Consistent init is not required as we do not have quasi-stationary reactions
-		if (hasNoQSreactions)
-			return;
-
-		const linalg::ConstMaskArray mask{ static_cast<int*>(qsMask), static_cast<int>(_nComp + _totalBound) };
-		const int probSize = linalg::numMaskActive(mask);
-
-		// Extract initial values from current state
-		BufferedArray<double> solution = tlmAlloc.array<double>(probSize);
-		linalg::selectVectorSubset(c, mask, static_cast<double*>(solution));
-
-		// Save values of conserved moieties
-		const unsigned int numActiveComp = numMaskActive(mask, _nComp);
-		BufferedArray<double> conservedQuants = tlmAlloc.array<double>(numActiveComp);
-		const double epsQ = 1.0 - porosity;
-		unsigned int idx = 0;
-		for (unsigned int comp = 0; comp < _nComp; ++comp)
-		{
-			if (!qsMask[comp])
-				continue;
-
-			conservedQuants[idx] = porosity * c[comp];
 			for (unsigned int type = 0; type < _nParType; ++type)
 			{
-				const double factor = epsQ * static_cast<double>(_parTypeVolFrac[type]);
-				for (unsigned int state = 0; state < _nBound[type * _nComp + comp]; ++state)
-				{
-					const unsigned int bndIdx = _offsetParType[type] + _boundOffset[type * _nComp + comp] + state;
-					if (!qsMask[_nComp + bndIdx])
-						continue;
-
-					conservedQuants[idx] += factor * c[_nComp + bndIdx];
-				}
+				if (!_binding[type]->hasQuasiStationaryReactions())
+					throw InvalidParameterException("CSTR consistent initalisation: binding AND reactions in rapid equilibirum is not supported yet");
 			}
-
-			++idx;
 		}
+		LinearBufferAllocator tlmAlloc = threadLocalMem.get();
 
-		linalg::DenseMatrixView jacobianMatrix(_jacFact.data(), _jacFact.pivotData(), probSize, probSize);
+		const auto& L = cm.getConservedMoietiesMatrix();
 
-		BufferedArray<double> baFullX = tlmAlloc.array<double>(numDofs());
-		double* const fullX = static_cast<double*>(baFullX);
+		const unsigned int nMoieties = cm.numMoieties();
+		const unsigned int nEq = cm.numEquilibriumReactions();
+		
+		if (nMoieties + nEq != _nComp)
+			throw InvalidParameterException("CSTR consistent initalisation: Invalid equilibrium initialization size");
+		
+		const unsigned int probSize = _nComp;
 
-		BufferedArray<double> baFullResidual = tlmAlloc.array<double>(numDofs());
-		double* const fullResidual = static_cast<double*>(baFullResidual);
+		// x starts as current c0
+		BufferedArray<double> solution = tlmAlloc.array<double>(_nComp);
+		std::copy_n(c, _nComp, static_cast<double*>(solution));
+		
+		BufferedArray<double> conserved = tlmAlloc.array<double>(nMoieties);
 
+		for (unsigned int m = 0; m < nMoieties; m++)
+		{
+			conserved[m] = 0.0;
+			for(unsigned int i = 0; i < _nComp; i++)
+				conserved[m] += L(m, i) * c[i];
+		}
+		
 		BufferedArray<double> baNonlinMem = tlmAlloc.array<double>(_nonlinearSolver->workspaceSize(probSize));
 		double* const nonlinMem = static_cast<double*>(baNonlinMem);
+		linalg::DenseMatrixView jacobianMatrix(_jacFact.data(), _jacFact.pivotData(), probSize, probSize);
 
 		std::function<bool(double const* const, linalg::detail::DenseMatrixBase&)> jacFunc;
-		if (adJac.adY && adJac.adRes)
+		jacFunc = [&](double const* const x, linalg::detail::DenseMatrixBase& mat)
 		{
-			ad::copyToAd(vecStateY, adJac.adY, _nComp);
+			mat.setAll(0.0);
+			// upper part: conserved moites
+			for(unsigned int m = 0; m < nMoieties; m++)
+			{
+				for(unsigned int i = 0; i < _nComp; i++)
+					mat.native(m,i) = L(m,i);
+			}
+			unsigned int eqIdx = 0;
+			for (auto const* reaction : _reactionSystemBulk.getDynReactionVector("liquid"))
+			{
+				LinearBufferAllocator subAlloc = tlmAlloc.manageRemainingMemory();
+				reaction->analyticEquilibriumJacobian(simTime.t, simTime.secIdx, ColumnPosition{0.0, 0.0, 0.0}, _nComp, x, eqIdx, nMoieties, mat.row(nMoieties), subAlloc);
+			}
 
-			jacFunc = [&](double const* const x, linalg::detail::DenseMatrixBase& mat)
+			return true;
+		};
+
+		// Apply nonlinear solver
+		_nonlinearSolver->solve(
+			[&](double const* const x, double* const r)
+			{
+				// upper part: conserved moites
+				for(unsigned int m = 0; m < nMoieties; m++)
+				{	
+					r[m] = -conserved[m];
+					for(unsigned int i = 0; i < _nComp; i++)
+						r[m] += L(m,i) * x[i];
+				}
+				unsigned int eqIdx = 0;
+				for (auto const* reaction : _reactionSystemBulk.getDynReactionVector("liquid"))
 				{
-					active* const localAdY = adJac.adY + _nComp;
-					active* const localAdRes = adJac.adRes + _nComp;
+					LinearBufferAllocator subAlloc = tlmAlloc.manageRemainingMemory();
+					reaction->residualEquilibriumFlux(simTime.t, simTime.secIdx, ColumnPosition{0.0, 0.0, 0.0}, _nComp, x, r + nMoieties, eqIdx, subAlloc);
+				}
+				return true;
+			},
+			jacFunc, errorTol, static_cast<double*>(solution), nonlinMem, jacobianMatrix, probSize);
+			
+			std::copy_n(static_cast<double*>(solution), _nComp, c);
 
-					// Copy over state vector to AD state vector (without changing directional values to keep seed vectors)
-					// and initialize residuals with zero (also resetting directional values)
-					ad::copyToAd(c, localAdY, mask.len);
-					// @todo Check if this is necessary
-					ad::resetAd(localAdRes, mask.len);
-
-					// Prepare input vector by overwriting masked items
-					linalg::applyVectorSubset(x, mask, localAdY);
-
-					// Call residual function
-					residualImpl<active, active, double, false>(simTime.t, simTime.secIdx, adJac.adY, nullptr, adJac.adRes, tlmAlloc.manageRemainingMemory());
-
-#ifdef CADET_CHECK_ANALYTIC_JACOBIAN
-					std::copy_n(c, mask.len, fullX);
-					linalg::applyVectorSubset(x, mask, fullX);
-
-					// Compute analytic Jacobian
-					residualImpl<double, double, double, true>(simTime.t, simTime.secIdx, fullX, nullptr, fullResidual, tlmAlloc.manageRemainingMemory());
-
-					// Compare
-					const double diff = ad::compareDenseJacobianWithAd(localAdRes, adJac.adDirOffset, _jac);
-					LOG(Debug) << "MaxDiff: " << diff;
-#endif
-
-					// Extract Jacobian from AD
-					ad::extractDenseJacobianFromAd(localAdRes, adJac.adDirOffset, _jac);
-
-					// Extract Jacobian from full Jacobian
-					mat.setAll(0.0);
-					linalg::copyMatrixSubset(_jac, mask, mask, mat);
-
-					// Replace upper part with conservation relations
-					mat.submatrixSetAll(0.0, 0, 0, numActiveComp, probSize);
-
-					unsigned int rIdx = 0;
-					const double epsQ = 1.0 - porosity;
-
-					for (unsigned int comp = 0; comp < _nComp; ++comp)
-					{
-						if (!mask.mask[comp])
-							continue;
-
-						mat.native(rIdx, rIdx) = porosity;
-
-						for (unsigned int type = 0; type < _nParType; ++type)
-						{
-							const double factor = epsQ * static_cast<double>(_parTypeVolFrac[type]);
-
-							const unsigned int offset = _nComp + _offsetParType[type] + _boundOffset[type * _nComp + comp];
-							unsigned int bIdx = numActiveComp + numMaskActive(mask, _nComp, _boundOffset[type * _nComp + comp]);
-							for (unsigned int state = 0; state < _nBound[type * _nComp + comp]; ++state)
-							{
-								if (!mask.mask[offset + state])
-									continue;
-
-								mat.native(rIdx, bIdx) = factor;
-								++bIdx;
-							}
-						}
-
-						++rIdx;
-					}
-
-					return true;
-				};
 		}
 		else
 		{
-			jacFunc = [&](double const* const x, linalg::detail::DenseMatrixBase& mat)
+			LinearBufferAllocator tlmAlloc = threadLocalMem.get();
+			BufferedArray<int> qsMask = tlmAlloc.array<int>(_nComp + _totalBound);
+
+			// Check whether quasi-stationary reactions are present and construct mask array
+			bool hasNoQSreactions = true;
+			std::fill_n(static_cast<int*>(qsMask), _nComp + _totalBound, false);
+			int* localMask = static_cast<int*>(qsMask) + _nComp;
+			for (unsigned int type = 0; type < _nParType; localMask += _strideBound[type], ++type)
+			{
+				if (!_binding[type]->hasQuasiStationaryReactions())
+					continue;
+
+				// Determine whether nonlinear solver is required
+				const ColumnPosition colPos{ 0.0, 0.0, 0.0 };
+				if (!_binding[type]->preConsistentInitialState(simTime.t, simTime.secIdx, colPos, c + _nComp + _offsetParType[type], c, tlmAlloc))
+					continue;
+
+				hasNoQSreactions = false;
+
+				// Construct mask
+				int const* const qsMaskSrc = _binding[type]->reactionQuasiStationarity();
+				std::copy_n(qsMaskSrc, _strideBound[type], localMask);
+
+				// Mark component for conserved moiety if it has a quasi-stationary bound state
+				unsigned int idx = 0;
+				for (unsigned int comp = 0; comp < _nComp; ++comp)
+				{
+					// Skip components that are already marked
+					if (qsMask[comp])
+					{
+						idx += _nBound[type * _nComp + comp];
+						continue;
+					}
+
+					for (unsigned int state = 0; state < _nBound[type * _nComp + comp]; ++state, ++idx)
+					{
+						if (qsMaskSrc[idx])
+						{
+							qsMask[comp] = true;
+							break;
+						}
+					}
+				}
+			}
+
+			// Consistent init is not required as we do not have quasi-stationary reactions
+			if (hasNoQSreactions)
+				return;
+
+			const linalg::ConstMaskArray mask{ static_cast<int*>(qsMask), static_cast<int>(_nComp + _totalBound) };
+			const int probSize = linalg::numMaskActive(mask);
+
+			// Extract initial values from current state
+			BufferedArray<double> solution = tlmAlloc.array<double>(probSize);
+			linalg::selectVectorSubset(c, mask, static_cast<double*>(solution));
+
+			// Save values of conserved moieties
+			const unsigned int numActiveComp = numMaskActive(mask, _nComp);
+			BufferedArray<double> conservedQuants = tlmAlloc.array<double>(numActiveComp);
+			const double epsQ = 1.0 - porosity;
+			unsigned int idx = 0;
+			for (unsigned int comp = 0; comp < _nComp; ++comp)
+			{
+				if (!qsMask[comp])
+					continue;
+
+				conservedQuants[idx] = porosity * c[comp];
+				for (unsigned int type = 0; type < _nParType; ++type)
+				{
+					const double factor = epsQ * static_cast<double>(_parTypeVolFrac[type]);
+					for (unsigned int state = 0; state < _nBound[type * _nComp + comp]; ++state)
+					{
+						const unsigned int bndIdx = _offsetParType[type] + _boundOffset[type * _nComp + comp] + state;
+						if (!qsMask[_nComp + bndIdx])
+							continue;
+
+						conservedQuants[idx] += factor * c[_nComp + bndIdx];
+					}
+				}
+
+				++idx;
+			}
+
+			linalg::DenseMatrixView jacobianMatrix(_jacFact.data(), _jacFact.pivotData(), probSize, probSize);
+
+			BufferedArray<double> baFullX = tlmAlloc.array<double>(numDofs());
+			double* const fullX = static_cast<double*>(baFullX);
+
+			BufferedArray<double> baFullResidual = tlmAlloc.array<double>(numDofs());
+			double* const fullResidual = static_cast<double*>(baFullResidual);
+
+			BufferedArray<double> baNonlinMem = tlmAlloc.array<double>(_nonlinearSolver->workspaceSize(probSize));
+			double* const nonlinMem = static_cast<double*>(baNonlinMem);
+
+			std::function<bool(double const* const, linalg::detail::DenseMatrixBase&)> jacFunc;
+			if (adJac.adY && adJac.adRes)
+			{
+				ad::copyToAd(vecStateY, adJac.adY, _nComp);
+
+				jacFunc = [&](double const* const x, linalg::detail::DenseMatrixBase& mat)
+					{
+						active* const localAdY = adJac.adY + _nComp;
+						active* const localAdRes = adJac.adRes + _nComp;
+
+						// Copy over state vector to AD state vector (without changing directional values to keep seed vectors)
+						// and initialize residuals with zero (also resetting directional values)
+						ad::copyToAd(c, localAdY, mask.len);
+						// @todo Check if this is necessary
+						ad::resetAd(localAdRes, mask.len);
+
+						// Prepare input vector by overwriting masked items
+						linalg::applyVectorSubset(x, mask, localAdY);
+
+						// Call residual function
+						residualImpl<active, active, double, false>(simTime.t, simTime.secIdx, adJac.adY, nullptr, adJac.adRes, tlmAlloc.manageRemainingMemory());
+
+	#ifdef CADET_CHECK_ANALYTIC_JACOBIAN
+						std::copy_n(c, mask.len, fullX);
+						linalg::applyVectorSubset(x, mask, fullX);
+
+						// Compute analytic Jacobian
+						residualImpl<double, double, double, true>(simTime.t, simTime.secIdx, fullX, nullptr, fullResidual, tlmAlloc.manageRemainingMemory());
+
+						// Compare
+						const double diff = ad::compareDenseJacobianWithAd(localAdRes, adJac.adDirOffset, _jac);
+						LOG(Debug) << "MaxDiff: " << diff;
+	#endif
+
+						// Extract Jacobian from AD
+						ad::extractDenseJacobianFromAd(localAdRes, adJac.adDirOffset, _jac);
+
+						// Extract Jacobian from full Jacobian
+						mat.setAll(0.0);
+						linalg::copyMatrixSubset(_jac, mask, mask, mat);
+
+						// Replace upper part with conservation relations
+						mat.submatrixSetAll(0.0, 0, 0, numActiveComp, probSize);
+
+						unsigned int rIdx = 0;
+						const double epsQ = 1.0 - porosity;
+
+						for (unsigned int comp = 0; comp < _nComp; ++comp)
+						{
+							if (!mask.mask[comp])
+								continue;
+
+							mat.native(rIdx, rIdx) = porosity;
+
+							for (unsigned int type = 0; type < _nParType; ++type)
+							{
+								const double factor = epsQ * static_cast<double>(_parTypeVolFrac[type]);
+
+								const unsigned int offset = _nComp + _offsetParType[type] + _boundOffset[type * _nComp + comp];
+								unsigned int bIdx = numActiveComp + numMaskActive(mask, _nComp, _boundOffset[type * _nComp + comp]);
+								for (unsigned int state = 0; state < _nBound[type * _nComp + comp]; ++state)
+								{
+									if (!mask.mask[offset + state])
+										continue;
+
+									mat.native(rIdx, bIdx) = factor;
+									++bIdx;
+								}
+							}
+
+							++rIdx;
+						}
+
+						return true;
+					};
+			}
+			else
+			{
+				jacFunc = [&](double const* const x, linalg::detail::DenseMatrixBase& mat)
+					{
+						// Prepare input vector by overwriting masked items
+						std::copy_n(c, mask.len, fullX + _nComp);
+						linalg::applyVectorSubset(x, mask, fullX + _nComp);
+
+						// Call residual function
+						residualImpl<double, double, double, true>(simTime.t, simTime.secIdx, fullX, nullptr, fullResidual, tlmAlloc.manageRemainingMemory());
+
+						// Extract Jacobian from full Jacobian
+						mat.setAll(0.0);
+						linalg::copyMatrixSubset(_jac, mask, mask, mat);
+
+						// Replace upper part with conservation relations
+						mat.submatrixSetAll(0.0, 0, 0, numActiveComp, probSize);
+
+						unsigned int rIdx = 0;
+						const double epsQ = 1.0 - porosity;
+
+						for (unsigned int comp = 0; comp < _nComp; ++comp)
+						{
+							if (!mask.mask[comp])
+								continue;
+
+							mat.native(rIdx, rIdx) = porosity;
+
+							for (unsigned int type = 0; type < _nParType; ++type)
+							{
+								const double factor = epsQ * static_cast<double>(_parTypeVolFrac[type]);
+
+								const unsigned int offset = _nComp + _offsetParType[type] + _boundOffset[type * _nComp + comp];
+								unsigned int bIdx = numActiveComp + numMaskActive(mask, _nComp, _boundOffset[type * _nComp + comp]);
+								for (unsigned int state = 0; state < _nBound[type * _nComp + comp]; ++state)
+								{
+									if (!mask.mask[offset + state])
+										continue;
+
+									mat.native(rIdx, bIdx) = factor;
+									++bIdx;
+								}
+							}
+
+							++rIdx;
+						}
+
+						return true;
+					};
+			}
+
+			// Copy inlet values
+			std::copy_n(vecStateY, _nComp, fullX);
+
+			// Apply nonlinear solver
+			_nonlinearSolver->solve(
+				[&](double const* const x, double* const r)
 				{
 					// Prepare input vector by overwriting masked items
 					std::copy_n(c, mask.len, fullX + _nComp);
 					linalg::applyVectorSubset(x, mask, fullX + _nComp);
 
 					// Call residual function
-					residualImpl<double, double, double, true>(simTime.t, simTime.secIdx, fullX, nullptr, fullResidual, tlmAlloc.manageRemainingMemory());
+					residualImpl<double, double, double, false>(simTime.t, simTime.secIdx, fullX, nullptr, fullResidual, tlmAlloc.manageRemainingMemory());
 
-					// Extract Jacobian from full Jacobian
-					mat.setAll(0.0);
-					linalg::copyMatrixSubset(_jac, mask, mask, mat);
+					// Extract values from residual
+					linalg::selectVectorSubset(fullResidual + _nComp, mask, r);
 
-					// Replace upper part with conservation relations
-					mat.submatrixSetAll(0.0, 0, 0, numActiveComp, probSize);
-
+					// Calculate residual of conserved moieties
+					std::fill_n(r, numActiveComp, 0.0);
 					unsigned int rIdx = 0;
 					const double epsQ = 1.0 - porosity;
 
@@ -859,7 +1000,7 @@ void CSTRModel::consistentInitialState(const SimulationTime& simTime, double* co
 						if (!mask.mask[comp])
 							continue;
 
-						mat.native(rIdx, rIdx) = porosity;
+						r[rIdx] = porosity * x[rIdx] - conservedQuants[rIdx];
 
 						for (unsigned int type = 0; type < _nParType; ++type)
 						{
@@ -872,7 +1013,7 @@ void CSTRModel::consistentInitialState(const SimulationTime& simTime, double* co
 								if (!mask.mask[offset + state])
 									continue;
 
-								mat.native(rIdx, bIdx) = factor;
+								r[rIdx] += factor * x[bIdx];
 								++bIdx;
 							}
 						}
@@ -881,71 +1022,21 @@ void CSTRModel::consistentInitialState(const SimulationTime& simTime, double* co
 					}
 
 					return true;
-				};
-		}
+				},
+				jacFunc, errorTol, static_cast<double*>(solution), nonlinMem, jacobianMatrix, probSize);
 
-		// Copy inlet values
-		std::copy_n(vecStateY, _nComp, fullX);
+			// Apply solution
+			linalg::applyVectorSubset(static_cast<double*>(solution), mask, c);
 
-		// Apply nonlinear solver
-		_nonlinearSolver->solve(
-			[&](double const* const x, double* const r)
+			// Refine / correct solution
+			for (unsigned int type = 0; type < _nParType; ++type)
 			{
-				// Prepare input vector by overwriting masked items
-				std::copy_n(c, mask.len, fullX + _nComp);
-				linalg::applyVectorSubset(x, mask, fullX + _nComp);
-
-				// Call residual function
-				residualImpl<double, double, double, false>(simTime.t, simTime.secIdx, fullX, nullptr, fullResidual, tlmAlloc.manageRemainingMemory());
-
-				// Extract values from residual
-				linalg::selectVectorSubset(fullResidual + _nComp, mask, r);
-
-				// Calculate residual of conserved moieties
-				std::fill_n(r, numActiveComp, 0.0);
-				unsigned int rIdx = 0;
-				const double epsQ = 1.0 - porosity;
-
-				for (unsigned int comp = 0; comp < _nComp; ++comp)
-				{
-					if (!mask.mask[comp])
-						continue;
-
-					r[rIdx] = porosity * x[rIdx] - conservedQuants[rIdx];
-
-					for (unsigned int type = 0; type < _nParType; ++type)
-					{
-						const double factor = epsQ * static_cast<double>(_parTypeVolFrac[type]);
-
-						const unsigned int offset = _nComp + _offsetParType[type] + _boundOffset[type * _nComp + comp];
-						unsigned int bIdx = numActiveComp + numMaskActive(mask, _nComp, _boundOffset[type * _nComp + comp]);
-						for (unsigned int state = 0; state < _nBound[type * _nComp + comp]; ++state)
-						{
-							if (!mask.mask[offset + state])
-								continue;
-
-							r[rIdx] += factor * x[bIdx];
-							++bIdx;
-						}
-					}
-
-					++rIdx;
-				}
-
-				return true;
-			},
-			jacFunc, errorTol, static_cast<double*>(solution), nonlinMem, jacobianMatrix, probSize);
-
-		// Apply solution
-		linalg::applyVectorSubset(static_cast<double*>(solution), mask, c);
-
-		// Refine / correct solution
-		for (unsigned int type = 0; type < _nParType; ++type)
-		{
-			const ColumnPosition colPos{ 0.0, 0.0, 0.0 };
-			_binding[type]->postConsistentInitialState(simTime.t, simTime.secIdx, colPos, c + _nComp + _offsetParType[type], c, tlmAlloc);
+				const ColumnPosition colPos{ 0.0, 0.0, 0.0 };
+				_binding[type]->postConsistentInitialState(simTime.t, simTime.secIdx, colPos, c + _nComp + _offsetParType[type], c, tlmAlloc);
+			}
 		}
 	}
+	
 }
 
 void CSTRModel::consistentInitialTimeDerivative(const SimulationTime& simTime, double const* vecStateY, double* const vecStateYdot, util::ThreadLocalStorage& threadLocalMem)
@@ -959,12 +1050,60 @@ void CSTRModel::consistentInitialTimeDerivative(const SimulationTime& simTime, d
 	const double flowOut = static_cast<double>(_flowRateOut);
 
 	// Note that the residual has not been negated, yet. We will do that now.
+	// res = F(t_0,y_0,ydot_0) with  ydot_0 = 0
 	for (unsigned int i = 0; i < numDofs(); ++i)
 		vecStateYdot[i] = -vecStateYdot[i];
 
 	// Assemble time derivative Jacobian
 	_jacFact.setAll(0.0);
 	addTimeDerivativeJacobian(simTime.t, 1.0, ConstSimulationState{ vecStateY, nullptr }, _jacFact);
+
+	const auto& cm = _reactionSystemBulk.conservedMoieties("liquid");
+
+	if (cm.isEnabled() && cm.numEquilibriumReactions() > 0)
+	{
+		
+		if (_totalBound > 0)
+		{
+			for (unsigned int type = 0; type < _nParType; ++type)
+			{
+				if (!_binding[type]->hasQuasiStationaryReactions())
+					throw InvalidParameterException("CSTR consistent initalisation: binding AND reactions in rapid equilibirum is not supported yet");
+			}
+		}
+		
+		LinearBufferAllocator tlmAlloc = threadLocalMem.get();
+
+		const unsigned int nMoieties = cm.numMoieties();
+		const unsigned int nEq = cm.numEquilibriumReactions();
+
+		for (unsigned int r = 0; r < nEq; ++r)
+			_jacFact.row(nMoieties + r).setAll(0.0);
+
+		unsigned int eqIdx = 0;
+		for (auto const* reaction : _reactionSystemBulk.getDynReactionVector("liquid"))
+		{
+			if (!reaction)
+				continue;
+
+			LinearBufferAllocator subAlloc = tlmAlloc.manageRemainingMemory();
+
+			reaction->analyticEquilibriumJacobian(
+				simTime.t,
+				simTime.secIdx,
+				ColumnPosition{0.0, 0.0, 0.0},
+				_nComp,
+				c,
+				eqIdx,
+				nMoieties,
+				_jacFact.row(nMoieties),
+				subAlloc
+			);
+		}
+
+		for (unsigned int r = 0; r < nEq; ++r)
+			cDot[nMoieties + r] = 0.0; // for time dep. equilibria  -> -dg_eq/dt
+	}
 
 	// Check if volume is 0
 	if (vLiquid == 0.0)
@@ -1083,6 +1222,7 @@ void CSTRModel::consistentInitialTimeDerivative(const SimulationTime& simTime, d
 	}
 
 	// Solve
+	// [ dJac , deq_reac] ydot = - res(t_0,y_0, 0)
 	const bool result2 = _jacFact.robustSolve(vecStateYdot + _nComp, static_cast<double*>(dFluxDt));
 	if (!result2)
 	{
@@ -1099,7 +1239,7 @@ void CSTRModel::leanConsistentInitialState(const SimulationTime& simTime, double
 			const double vLiquid = c[_nComp];
 			const double vSolid = static_cast<double>(_constSolidVolume);
 	// Check if volume is 0
-			if (vLiquid == 0.0)
+	if (vLiquid == 0.0)
 	{
 		const double flowIn = static_cast<double>(_flowRateIn);
 		const double flowOut = static_cast<double>(_flowRateOut);
@@ -1247,20 +1387,20 @@ void CSTRModel::leanConsistentInitialTimeDerivative(double t, double const* cons
 		// => \dot{c} = (-res - V^s * [sum_j sum_m d_j \dot{q}_{j,m}] - \dot{V}^l * c) / V^l
 		for (unsigned int i = 0; i < _nComp; ++i)
 		{
-			double qSum = 0.0;
+			//double qSum = 0.0;
 			double qDotSum = 0.0;
 			for (unsigned int type = 0; type < _nParType; ++type)
 			{
-				double const* const localQ = c + _nComp + _offsetParType[type] + _boundOffset[type * _nComp + i];
+				//double const* const localQ = c + _nComp + _offsetParType[type] + _boundOffset[type * _nComp + i];
 				double const* const localQdot = cDot + _nComp + _offsetParType[type] + _boundOffset[type * _nComp + i];
-				double qSumType = 0.0;
+				//double qSumType = 0.0;
 				double qDotSumType = 0.0;
 				for (unsigned int j = 0; j < _nBound[type * _nComp + i]; ++j)
 				{
-					qSumType += localQ[j];
+					//qSumType += localQ[j];
 					qDotSumType += localQdot[j];
 				}
-				qSum += static_cast<double>(_parTypeVolFrac[type]) * qSumType;
+				//qSum += static_cast<double>(_parTypeVolFrac[type]) * qSumType;
 				qDotSum += static_cast<double>(_parTypeVolFrac[type]) * qDotSumType;
 			}
 
@@ -1563,6 +1703,85 @@ int CSTRModel::residualImpl(double t, unsigned int secIdx, StateType const* cons
 
 	// Volume: \dot{V} = F_{in} - F_{out} - F_{filter}
 	res[2 * _nComp + _totalBound] = vDot - flowIn + flowOut + static_cast<ParamType>(_curFlowRateFilter);
+
+	const auto& cm = _reactionSystemBulk.conservedMoieties("liquid");
+	if (cm.isEnabled() && cm.numEquilibriumReactions() > 0)
+	{ 
+		const Eigen::MatrixXd& L = cm.getConservedMoietiesMatrix();
+
+		const unsigned int nMoieties = cm.numMoieties() ;
+		const unsigned int nEq = cm.numEquilibriumReactions();
+
+		if (nMoieties + nEq != _nComp)
+		throw InvalidParameterException(
+			"CSTR equilibrium reactions require numMoieties + numEquilibriumReactions == nComp"
+		);
+
+		BufferedArray<ResidualType> oldRes = tlmAlloc.array<ResidualType>(_nComp);
+		std::copy_n(resC, _nComp, static_cast<ResidualType*>(oldRes));
+
+		for (unsigned int m = 0; m < nMoieties; ++m)
+		{
+			resC[m] = 0.0;
+			for (unsigned int i = 0; i < _nComp; ++i)
+				resC[m] += static_cast<double>(L(m, i)) * oldRes[i];
+		}
+
+		ResidualType* const eqRes = resC + nMoieties;
+		std::fill_n(eqRes, nEq, 0.0);
+		unsigned int eqIdx = 0;
+
+		for (auto const* reaction : _reactionSystemBulk.getDynReactionVector("liquid"))
+		{
+			if (!reaction)
+				continue;
+			
+			LinearBufferAllocator subAlloc = tlmAlloc.manageRemainingMemory();
+			reaction->residualEquilibriumFlux( t, secIdx, colPos, _nComp, c, eqRes, eqIdx, subAlloc);
+		}
+
+		if (wantJac)
+		{ // Save old concentration rows
+			LinearBufferAllocator subAlloc = tlmAlloc.manageRemainingMemory();
+			const unsigned int nPure = numPureDofs();
+			
+			BufferedArray<double> oldJacRowsBuf =
+			tlmAlloc.array<double>(_nComp * nPure);
+
+			double* oldJacRows = static_cast<double*>(oldJacRowsBuf);
+			for (unsigned int r = 0; r < _nComp; ++r)
+			{
+				for (unsigned int c = 0; c < nPure; ++c)
+					oldJacRows[r * nPure + c] = _jac.native(r, c);
+			}
+
+			// Moiety rows
+			for (unsigned int m = 0; m < nMoieties; ++m)
+			{
+				for (unsigned int col = 0; col < nPure; ++col)
+				{
+					double val = 0.0;
+					for (unsigned int i = 0; i < _nComp; ++i)
+						val += L(m, i) * oldJacRows[i * nPure + col];
+					_jac.native(m, col) = val;
+				}
+			}
+
+			// Equilibrium rows
+			for (unsigned int r = 0; r < nEq; ++r)
+				_jac.row(nMoieties + r).setAll(0.0);
+
+			unsigned int eqIdxJac = 0;
+			unsigned int eqRowOffset = nMoieties;
+			for (auto const* reaction : _reactionSystemBulk.getDynReactionVector("liquid"))
+			{
+				if (!reaction)
+					continue;
+				
+				reaction->analyticEquilibriumJacobian(t, secIdx, colPos, _nComp, reinterpret_cast<double const*>(c), eqIdxJac, eqRowOffset, _jac.row(nMoieties), subAlloc);
+			}
+		}
+	}	
 
 	return 0;
 }
@@ -1908,6 +2127,31 @@ void CSTRModel::multiplyWithDerivativeJacobian(const SimulationTime& simTime, co
 
 	// Volume: \dot{V} - F_{in} + F_{out} + F_{filter} == 0
 	r[_nComp + _totalBound] = s[_nComp + _totalBound];
+
+	const auto& cm = _reactionSystemBulk.conservedMoieties("liquid");
+	if (cm.isEnabled() && cm.numEquilibriumReactions() > 0)
+	{
+		const unsigned int nPure = numPureDofs();
+		const Eigen::MatrixXd& L = cm.getConservedMoietiesMatrix();
+		const unsigned int nMoieties = cm.numMoieties();
+		const unsigned int nEq = cm.numEquilibriumReactions();
+
+		std::vector<double> oldRes(nPure);
+		for (unsigned int i = 0; i < _nComp + _totalBound; ++i)
+		{
+			oldRes[i] = r[i];
+		}
+		for (unsigned int m = 0; m < nMoieties; ++m)
+		{
+			r[m] = 0.0;
+			for (unsigned int i = 0; i < _nComp; ++i)
+				r[m] += static_cast<double>(L(m, i)) * oldRes[i];
+		}
+		
+		// Equilibrium rows
+		for (unsigned int i = nMoieties; i < nEq; ++i)
+			r[i + nMoieties] = 0.0;
+	}
 }
 
 int CSTRModel::linearSolve(double t, double alpha, double tol, double* const rhs, double const* const weight,
@@ -1940,14 +2184,19 @@ int CSTRModel::linearSolve(double t, double alpha, double tol, double* const rhs
 template <typename MatrixType>
 void CSTRModel::addTimeDerivativeJacobian(double t, double alpha, const ConstSimulationState& simState, MatrixType& mat)
 {	
+	// Concentrations: \dot{V^l} * c_i + V^l * \dot{c}_i + V^s * [sum_j sum_m d_j \dot{q}_{j,i,m}]) - c_{in,i} * F_in + c_i * F_out == 0
+
 	double const* const c = simState.vecStateY + _nComp;
 	const double v = simState.vecStateY[2 * _nComp + _totalBound];
 	const double timeV = v * alpha;
 	const double timeVSolid = static_cast<double>(_constSolidVolume) * alpha;
 
-	// Assemble Jacobian: dRes / dyDot
+    const double vSolid = static_cast<double>(_constSolidVolume);
+
+    const unsigned int volumeIdx = _nComp + _totalBound;
+	const auto& cm = _reactionSystemBulk.conservedMoieties("liquid");
 	
-	// Concentrations: \dot{V^l} * c_i + V^l * \dot{c}_i + V^s * [sum_j sum_m d_j \dot{q}_{j,i,m}]) - c_{in,i} * F_in + c_i * F_out == 0
+	// Assemble Jacobian: dRes / dyDot
 	for (unsigned int i = 0; i < _nComp; ++i)
 	{
 		mat.native(i, i) += timeV; // dRes / dcDot
@@ -1993,6 +2242,35 @@ void CSTRModel::addTimeDerivativeJacobian(double t, double alpha, const ConstSim
 		}
 	}
 
+	if (cm.isEnabled() &&  (cm.numEquilibriumReactions() > 0))
+    {
+        const auto& L = cm.getConservedMoietiesMatrix();
+        const unsigned int nMoieties = cm.numMoieties();
+
+        //mat += alpha * L * dRes / dyDot
+        for (unsigned int m = 0; m < nMoieties; ++m)
+        {
+            for (unsigned int i = 0; i < _nComp; ++i)
+            {
+                const double factor = alpha * L(m, i);
+
+                // V * dc_comp / dt
+                mat.native(m, i) += factor * v; // dRes / dcDot
+                // c_comp * dV / dt
+                mat.native(m, volumeIdx) += factor * c[i]; // dRes / dVDot
+
+                // V_s * sum_j phi_j * dq_comp,j / dt
+                for (unsigned int type = 0; type < _nParType; ++type)
+                {
+                    const unsigned int localOffset = _nComp + _offsetParType[type] + _boundOffset[type * _nComp + i];
+                    const double boundFactor = factor * vSolid * static_cast<double>(_parTypeVolFrac[type]);
+                    for (unsigned int j = 0; j <  _nBound[type * _nComp + i]; ++j)
+                        mat.native(m, localOffset + j) += boundFactor; // dRes / dqDot
+                }
+            }
+        }
+        // dRes_eq / dyDot = 0 
+    }
 	// Volume: \dot{V} - F_{in} + F_{out} + F_{filter} == 0
 	mat.native(_nComp + _totalBound, _nComp + _totalBound) += alpha;
 }

--- a/src/libcadet/model/reaction/ConservedMoieties.hpp
+++ b/src/libcadet/model/reaction/ConservedMoieties.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "model/ReactionModel.hpp"
 #include "cadet/Exceptions.hpp"
 #include "ConfigurationHelper.hpp"
@@ -12,7 +14,6 @@
 #include <utility>
 #include <vector>
 
-
 namespace cadet
 {
 
@@ -25,11 +26,11 @@ class ConservedMoieties
     {
         
         private:
-        bool enabled = false;
+        bool _enabled = false;
 
-        unsigned int nStates = 0;
-        unsigned int nReactionTotal = 0; // 1. only one reaction model later: for all reaction models
-        unsigned int nReactionEquilibirum = 0;
+        unsigned int _nStates = 0;
+        unsigned int _nReactionTotal = 0;
+        unsigned int _nReactionEquilibirum = 0;
         
         std::vector<unsigned int> _reactionColumnOffset;
         std::vector<bool> _eqReactionMask;
@@ -38,32 +39,39 @@ class ConservedMoieties
         Eigen::MatrixXd _eqS; // N_eq dim: nStates x nEqreaction
         
         Eigen::MatrixXd _L; // L dim: nMoities x nStates
-        unsigned int _rank;
+        unsigned int _rank = 0;
 
-        double TOL = 1e-15; 
+        double _TOL = 1e-15;
 
         public:
-        const Eigen::MatrixXd& getConservedMoitiesMatrix() const { return _L; }
-        void setConservedMoitiesMatrix(Eigen::MatrixXd L){ _L = L; }
+        const Eigen::MatrixXd& getConservedMoietiesMatrix() const { return _L; }
+        const Eigen::MatrixXd& conservedMoietyMatrix() const { return _L; }
+        const Eigen::MatrixXd& stoichiometryMatrix() const { return _S; }
+        const Eigen::MatrixXd& equilibriumStoichiometryMatrix() const { return _eqS; }
 
-        const Eigen::MatrixXd& getStoichiomerie() const { return _S; }
-        void setStoichiomerie(Eigen::MatrixXd& S){ _S = S; }
+
+        bool isEnabled() const {return _enabled; }
+        unsigned int rank() const {return _rank; }
+        unsigned int numMoieties() const  {return static_cast<unsigned int>(_L.rows()); }
+        unsigned int numEquilibriumReactions() const {return static_cast<unsigned int>(_eqS.cols()); }
+
+        const std::vector<bool>& equilibriumReactionFlags() const { return _eqReactionMask;}
 
         bool configure(unsigned int states, std::vector<unsigned int>&& reactionColumnOffset,
             std::vector<bool>&& eqReactionFlags, Eigen::MatrixXd&& stoichiometry, double rankTol)
         {
-            enabled = false;
-            nStates = states;
-            nReactionTotal = static_cast<unsigned int>(eqReactionFlags.size());
+            _enabled = false;
+            _nStates = states;
+            _nReactionTotal = static_cast<unsigned int>(eqReactionFlags.size());
             _reactionColumnOffset = std::move(reactionColumnOffset);
             _eqReactionMask = std::move(eqReactionFlags);
             _S = std::move(stoichiometry);
-            TOL = rankTol;
+            _TOL = rankTol;
 
             extractEquilibriumStoichiometry();
             computeLeftNullspace();
 
-            enabled = true;
+            _enabled = true;
             return true;
         }
 
@@ -75,16 +83,14 @@ class ConservedMoieties
                 if (isEq) ++nEq;
             }
 
-            nReactionEquilibirum = nEq;
+            _nReactionEquilibirum = nEq;
             _eqS.resize(_S.rows(), nEq);
             unsigned int col = 0;
-
             for (unsigned int r = 0; r < _eqReactionMask.size(); ++r)
             {
                 if (!_eqReactionMask[r])
                     continue;
-                _eqS.col(col) = _S.col(r);
-                col++;
+                _eqS.col(col++) = _S.col(r);
             }
 
         }
@@ -106,9 +112,12 @@ class ConservedMoieties
             _rank = 0;
             for (int i = 0; i < singularValues.size(); ++i)
             {
-                if (singularValues(i) > TOL)
+                if (singularValues(i) > _TOL)
                     ++_rank;
             }
+
+            if (_nReactionEquilibirum != _rank)
+	            throw InvalidParameterException("Conserved Moieties: Redundant equilibrium reactions are not supported");
 
             const unsigned int nullity = static_cast<unsigned int>(A.cols()) - _rank;
             

--- a/src/libcadet/model/reaction/CrystallizationReaction.cpp
+++ b/src/libcadet/model/reaction/CrystallizationReaction.cpp
@@ -2620,6 +2620,13 @@ protected:
 	{
 		jacobianFluxImpl<RowIteratorLiquid>(t, secIdx, colPos, 0, yLiquid, factor, jacLiquid, workSpace);
 	}
+	
+	template <typename StateType, typename ResidualType, typename ParamType>
+	int residualEquilibriumImpl(double t, unsigned int secIdx, const ColumnPosition& colPos,
+		const unsigned int nStates, StateType const* y, ResidualType* res, unsigned int& eqIdx , LinearBufferAllocator workSpace) const {return 0;}
+
+	template <typename RowIterator>
+	void jacobianEquilibriumImpl(double t, unsigned int secIdx, const ColumnPosition& colPos, const unsigned int nState, double const* y, unsigned int& eqIdx, unsigned int eqRowOffset, const RowIterator& jac, LinearBufferAllocator workSpace) const{ }
 };
 
 namespace reaction

--- a/src/libcadet/model/reaction/DummyReaction.cpp
+++ b/src/libcadet/model/reaction/DummyReaction.cpp
@@ -94,6 +94,34 @@ public:
 	virtual void analyticJacobianCombinedAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* yLiquid, double const* ySolid, double factor, linalg::BandMatrix::RowIterator jacLiquid, linalg::DenseBandedRowIterator jacSolid, LinearBufferAllocator workSpace) const { }
 	virtual void analyticJacobianCombinedAdd(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* yLiquid, double const* ySolid, double factor, linalg::BandedEigenSparseRowIterator jacLiquid, linalg::DenseBandedRowIterator jacSolid, LinearBufferAllocator workSpace) const { }
 
+	virtual int residualEquilibriumFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, const unsigned int nStates, active const* y,
+		active* res, unsigned int& eqIdx, LinearBufferAllocator workSpace) const { return 0; }
+
+	virtual int residualEquilibriumFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, const unsigned int nStates, double const* y,
+		active* res, unsigned int& eqIdx, LinearBufferAllocator workSpace) const { return 0; }
+
+	virtual int residualEquilibriumFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, const unsigned int nStates, double const* y,
+		double* res, unsigned int& eqIdx, LinearBufferAllocator workSpace) const { return 0; }
+
+	virtual void analyticEquilibriumJacobian(double t, unsigned int secIdx, const ColumnPosition& colPos, const unsigned int nStates, double const* y,
+		unsigned int& eqIdx, unsigned int eqRowOffset,  linalg::BandMatrix::RowIterator jac, LinearBufferAllocator workSpace) const { }
+
+	virtual void analyticEquilibriumJacobian(double t, unsigned int secIdx, const ColumnPosition& colPos, const unsigned int nStates, double const* y,
+		unsigned int& eqIdx, unsigned int eqRowOffset,linalg::DenseBandedRowIterator jac, LinearBufferAllocator workSpace) const { }
+
+	virtual void analyticEquilibriumJacobian(double t, unsigned int secIdx, const ColumnPosition& colPos, const unsigned int nStates, double const* y,
+		unsigned int& eqIdx, unsigned int eqRowOffset,linalg::BandedSparseRowIterator jac, LinearBufferAllocator workSpace) const { }
+
+	virtual void analyticEquilibriumJacobian(double t, unsigned int secIdx, const ColumnPosition& colPos, const unsigned int nStates, double const* y,
+		unsigned int& eqIdx, unsigned int eqRowOffset,linalg::BandedEigenSparseRowIterator jac, LinearBufferAllocator workSpace) const { }
+
+	template <typename StateType, typename ResidualType, typename ParamType>
+	int residualEquilibriumImpl(double t, unsigned int secIdx, const ColumnPosition& colPos,
+		const unsigned int nStates, StateType const* y, ResidualType* res, unsigned int& eqIdx , LinearBufferAllocator workSpace) const {return 0;}
+	
+	template <typename RowIterator>
+	void jacobianEquilibriumImpl(double t, unsigned int secIdx, const ColumnPosition& colPos, const unsigned int nState, double const* y, unsigned int& eqIdx, unsigned int eqRowOffset, const RowIterator& jac, LinearBufferAllocator workSpace) const{ }
+	
 	virtual unsigned int numReactionsLiquid() const CADET_NOEXCEPT { return 0; }
 	virtual unsigned int numReactionsCombined() const CADET_NOEXCEPT { return 0; }
 

--- a/src/libcadet/model/reaction/MassActionLawReaction.cpp
+++ b/src/libcadet/model/reaction/MassActionLawReaction.cpp
@@ -178,10 +178,10 @@ namespace
 				for (unsigned int j = 0; j < c; ++j)
 					fluxGrad[j] *= v;
 
-				if (static_cast<double>(y[c]) > 0.0)
-					fluxGrad[c] *= exponentValue * pow(y[c], exponentValue - 1.0);
+				if (y[c] > 0.0)
+					fluxGrad[c] *= exponentValue * std::pow(y[c], exponentValue - 1.0);
 				else
-					fluxGrad[c] *= 0.0;
+					fluxGrad[c]*= 0.0;
 
 				for (unsigned int j = c + 1; j < nComp; ++j)
 					fluxGrad[j] *= v;
@@ -367,6 +367,11 @@ protected:
 
 		for (int r = 0; r < _stoichiometry.columns(); ++r)
 		{
+			if (_eqMaskVector[r])
+			{
+				fluxes[r] = 0.0;
+				continue;
+			}
 			flux_t fwd = rateConstantOrZero(static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(p->kFwd[r]), r, _expFwd, nStates);
 
 			for (int c = 0; c < nStates; ++c)
@@ -422,6 +427,9 @@ protected:
 		
 		for (int r = 0; r < _stoichiometry.columns(); ++r)
 		{
+			if (_eqMaskVector[r])
+				continue;
+			
 			// Calculate gradients of forward and backward fluxes
 			double kFwd = static_cast<double>(p->kFwd[r]);
 			double kBwd = static_cast<double>(p->kBwd[r]);
@@ -454,6 +462,87 @@ protected:
 
 	}
 
+	template <typename StateType, typename ResidualType, typename ParamType>
+	int residualEquilibriumImpl(double t, unsigned int secIdx, const ColumnPosition& colPos,
+		const unsigned int nStates, StateType const* y, ResidualType* res, unsigned int& eqIdx , LinearBufferAllocator workSpace) const
+	{
+		typename ParamHandler_t::ParamsHandle const p = _paramHandler.update(t, secIdx, colPos, _nComp, _nBoundStates, workSpace);
+
+		for (int r = 0; r < _stoichiometry.columns(); ++r)
+		{
+			if (!_eqMaskVector[r])
+				continue;
+			
+			ResidualType fwd = rateConstantOrZero(static_cast<ResidualType>(p->kFwd[r]), r, _expFwd, nStates);
+
+			for (int c = 0; c < nStates; ++c)
+			{
+				if (_expFwd.native(c, r) != 0.0)
+				{
+					if (static_cast<double>(y[c]) > 0.0)
+						fwd *= pow(static_cast<ResidualType>(y[c]), static_cast<ResidualType>(_expFwd.native(c, r)));
+					else
+					{
+						fwd *= 0.0;
+						break;
+					}
+				}
+			}
+
+			ResidualType bwd = rateConstantOrZero(static_cast<ResidualType>(p->kBwd[r]), r, _expBwd, nStates);
+			for (int c = 0; c < nStates; ++c)
+			{	
+
+				if (_expBwd.native(c, r) != 0.0)
+				{
+					if (static_cast<double>(y[c]) > 0.0)
+						bwd *= pow(static_cast<ResidualType>(y[c]),
+							static_cast<ResidualType>(_expBwd.native(c, r)));
+					else
+					{
+						bwd *= 0.0;
+						break;
+					}
+				}
+			}
+
+			res[eqIdx] = fwd - bwd;
+			eqIdx++;
+		}
+
+		return 0;
+	}
+
+	template <typename RowIterator>
+	void jacobianEquilibriumImpl(double t, unsigned int secIdx, const ColumnPosition& colPos, const unsigned int nState, double const* y, unsigned int& eqIdx, unsigned int eqRowOffset, const RowIterator& jac, LinearBufferAllocator workSpace) const
+	{
+		typename ParamHandler_t::ParamsHandle const p = _paramHandler.update(t, secIdx, colPos, _nComp, _nBoundStates, workSpace);
+
+		BufferedArray<double> fluxes = workSpace.array<double>(2 * nState);
+		double* const fluxGradFwd = static_cast<double*>(fluxes);
+		double* const fluxGradBwd = fluxGradFwd + nState;
+		
+		for (int r = 0; r < _stoichiometry.columns(); ++r)
+		{
+			if (!_eqMaskVector[r])
+				continue;
+			
+			// Calculate gradients of forward and backward fluxes
+			double kFwd = static_cast<double>(p->kFwd[r]);
+			double kBwd = static_cast<double>(p->kBwd[r]);
+			
+			fluxGrad(fluxGradFwd, r, nState, kFwd, _expFwd, y);
+			fluxGrad(fluxGradBwd, r, nState, kBwd, _expBwd, y);
+
+			// Add gradients to Jacobian
+			RowIterator curJac = jac + eqIdx;
+			const unsigned int row = eqRowOffset + eqIdx;
+			for (int col = 0; col < nState; ++col)
+					curJac[col - row] += (fluxGradFwd[col] - fluxGradBwd[col]);
+			eqIdx++;
+		}
+
+	}
 
 };
 

--- a/src/libcadet/model/reaction/MassActionLawReactionCrossPhase.cpp
+++ b/src/libcadet/model/reaction/MassActionLawReactionCrossPhase.cpp
@@ -712,7 +712,15 @@ namespace cadet
 					}
 				}
 			}
-		};
+
+		template <typename StateType, typename ResidualType, typename ParamType>
+		int residualEquilibriumImpl(double t, unsigned int secIdx, const ColumnPosition& colPos,
+			const unsigned int nStates, StateType const* y, ResidualType* res, unsigned int& eqIdx , LinearBufferAllocator workSpace) const {return 0;}
+		
+		template <typename RowIterator>
+		void jacobianEquilibriumImpl(double t, unsigned int secIdx, const ColumnPosition& colPos, const unsigned int nState, double const* y, unsigned int& eqIdx, unsigned int eqRowOffset, const RowIterator& jac, LinearBufferAllocator workSpace) const{ }
+		
+	};
 
 		typedef MassActionLawCrossPhaseReactionBase<MassActionLawCrossPhaseParamHandler> MassActionLawCrossPhaseReaction;
 		typedef MassActionLawCrossPhaseReactionBase<ExtMassActionLawCrossPhaseParamHandler> ExternalMassActionLawCrossPhaseReaction;

--- a/src/libcadet/model/reaction/MichaelisMentenReaction.cpp
+++ b/src/libcadet/model/reaction/MichaelisMentenReaction.cpp
@@ -593,6 +593,13 @@ protected:
     {
         // No combined phase reaction implemented
     }
+
+    template <typename StateType, typename ResidualType, typename ParamType>
+	int residualEquilibriumImpl(double t, unsigned int secIdx, const ColumnPosition& colPos,
+		const unsigned int nStates, StateType const* y, ResidualType* res, unsigned int& eqIdx , LinearBufferAllocator workSpace) const {return 0;}
+
+    template <typename RowIterator>
+	void jacobianEquilibriumImpl(double t, unsigned int secIdx, const ColumnPosition& colPos, const unsigned int nState, double const* y, unsigned int& eqIdx, unsigned int eqRowOffset, const RowIterator& jac, LinearBufferAllocator workSpace) const{ }
 };
 
 typedef MichaelisMentenBase<MichaelisMentenParamHandler> MichaelisMentenReaction;

--- a/src/libcadet/model/reaction/ReactionModelBase.hpp
+++ b/src/libcadet/model/reaction/ReactionModelBase.hpp
@@ -179,6 +179,42 @@ protected:
 		double factor, linalg::BandMatrix::RowIterator jacLiquid, linalg::DenseBandedRowIterator jacSolid, LinearBufferAllocator workSpace) const       \
 	{                                                                                                                                                   \
 		jacobianCombinedImpl(t, secIdx, colPos, yLiquid, ySolid, factor, jacLiquid, jacSolid, workSpace);                                               \
+	}																																					\
+	virtual int residualEquilibriumFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, const unsigned int nStates, active const* y,		\
+		active* res, unsigned int& eqIdx, LinearBufferAllocator workSpace) const 																		\
+	{																																					\
+		return residualEquilibriumImpl<active, active, double>(t, secIdx, colPos, nStates, y, res, eqIdx , workSpace);									\
+	}																																					\
+	virtual int residualEquilibriumFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, const unsigned int nStates, double const* y,		\
+		active* res, unsigned int& eqIdx, LinearBufferAllocator workSpace) const																		\
+	{																																					\
+		return residualEquilibriumImpl<double, active, active>(t, secIdx, colPos, nStates, y, res, eqIdx , workSpace);									\
+	}																																					\
+	virtual int residualEquilibriumFlux(double t, unsigned int secIdx, const ColumnPosition& colPos, const unsigned int nStates, double const* y,		\
+		double* res, unsigned int& eqIdx, LinearBufferAllocator workSpace) const																		\
+	{																																					\
+		return residualEquilibriumImpl<double, double, double>(t, secIdx, colPos, nStates, y, res, eqIdx , workSpace);\
+	}\
+	\
+	virtual void analyticEquilibriumJacobian(double t, unsigned int secIdx, const ColumnPosition& colPos, const unsigned int nStates, double const* y,\
+		unsigned int& eqIdx, unsigned int eqRowOffset,linalg::BandMatrix::RowIterator jac, LinearBufferAllocator workSpace) const\
+	{\
+		jacobianEquilibriumImpl(t,secIdx,colPos, nStates, y, eqIdx, eqRowOffset, jac,workSpace);\
+	}\
+	virtual void analyticEquilibriumJacobian(double t, unsigned int secIdx, const ColumnPosition& colPos, const unsigned int nStates, double const* y,\
+		unsigned int& eqIdx,unsigned int eqRowOffset, linalg::DenseBandedRowIterator jac, LinearBufferAllocator workSpace) const\
+	{\
+		jacobianEquilibriumImpl(t,secIdx,colPos, nStates, y, eqIdx, eqRowOffset, jac,workSpace);\
+	}\
+	virtual void analyticEquilibriumJacobian(double t, unsigned int secIdx, const ColumnPosition& colPos, const unsigned int nStates, double const* y,\
+		unsigned int& eqIdx,unsigned int eqRowOffset, linalg::BandedSparseRowIterator jac, LinearBufferAllocator workSpace) const\
+	{\
+		jacobianEquilibriumImpl(t,secIdx,colPos, nStates, y, eqIdx, eqRowOffset, jac,workSpace);\
+	}\
+	virtual void analyticEquilibriumJacobian(double t, unsigned int secIdx, const ColumnPosition& colPos, const unsigned int nStates, double const* y,\
+		unsigned int& eqIdx, unsigned int eqRowOffset,linalg::BandedEigenSparseRowIterator jac, LinearBufferAllocator workSpace) const \
+	{\
+		jacobianEquilibriumImpl(t,secIdx,colPos, nStates, y, eqIdx,eqRowOffset, jac,workSpace);\
 	}
 
 } // namespace model

--- a/src/libcadet/model/reaction/ReactionSystem.hpp
+++ b/src/libcadet/model/reaction/ReactionSystem.hpp
@@ -159,6 +159,16 @@ struct ReactionSystem
         {
             return getPhaseData(phase_type).dynReactions;
         }
+
+        const ConservedMoieties& conservedMoieties(const std::string& phaseType) const
+        {
+            return getPhaseData(phaseType).consMoities;
+        }
+
+        ConservedMoieties& conservedMoieties(const std::string& phaseType)
+        {
+            return getPhaseData(phaseType).consMoities;
+        }
                 
         /**
          * @brief Configures the dimensions of the dynamic reaction vector for a phase
@@ -291,12 +301,11 @@ struct ReactionSystem
 
                 if (!reaction)
                     continue;
-                if (!reaction->supportsConservedMoieties())
-                    throw InvalidParameterException("Reaction model does not support conserved moieties");
                 
                 totalCols += reaction->numReactions();
             }
             Eigen::MatrixXd S(nStates, totalCols);
+            S.setZero();
             std::vector<bool> eqReactionFlags(totalCols);
 
             unsigned int colOffset = 0;
@@ -309,6 +318,11 @@ struct ReactionSystem
                 for (unsigned int r = 0; r < nReac; ++r)
                 {
                     eqReactionFlags[colOffset + r]  = reaction->isInEquilibrium(r);
+                    if (!eqReactionFlags[colOffset + r])
+                        continue;
+
+                    if (!reaction->supportsConservedMoieties())
+                        throw InvalidParameterException("Reaction model does not support conserved moieties");
 
                     for (unsigned int s = 0; s < nStates; ++s)
                     {

--- a/test/CSTR-Residual.cpp
+++ b/test/CSTR-Residual.cpp
@@ -13,6 +13,7 @@
 #include <catch.hpp>
 #include "cadet/cadet.hpp"
 
+#include "Approx.hpp"
 #include "model/StirredTankModel.hpp"
 #include "ModelBuilderImpl.hpp"
 #include "SimulationTypes.hpp"
@@ -29,6 +30,7 @@
 #include <cmath>
 #include <functional>
 #include <algorithm>
+#include <vector>
 
 /**
  * @brief Creates a runnable CSTR model with given WENO order
@@ -507,6 +509,130 @@ TEST_CASE("StirredTankModel consistent initialization with SMA binding", "[CSTR]
 		cstr->setFlowRates(1.0, 1.0);
 		return cstr;
 	}, y.data(), 1e-14, 1e-5);
+}
+
+TEST_CASE("CSTR liquid equilibrium MAL consistent initialization", "[CSTR],[MassActionLaw],[ReactionModel],[ConsistentInit],[CI]")
+{
+	cadet::IModelBuilder* const mb = cadet::createModelBuilder();
+	REQUIRE(nullptr != mb);
+
+	for (int adMode = 0; adMode < 2; ++adMode)
+	{
+		const bool adEnabled = (adMode > 0);
+		SECTION(std::string("AD ") + (adEnabled ? "enabled" : "disabled"))
+		{
+			cadet::JsonParameterProvider jpp = createCSTR(2);
+	
+			jpp.set("NREAC_LIQUID", 1);
+			jpp.addScope("liquid_reaction_000");
+			jpp.pushScope("liquid_reaction_000");
+			jpp.set("TYPE", "MASS_ACTION_LAW");
+			jpp.set("MAL_KFWD", std::vector<double>{2.0});
+			jpp.set("MAL_KBWD", std::vector<double>{1.0});
+			jpp.set("MAL_STOICHIOMETRY", std::vector<double>{-1.0, 1.0});
+			jpp.set("MAL_IS_KINETIC", std::vector<int>{false ? 1 : 0});
+			jpp.popScope();
+
+			cadet::model::CSTRModel* const cstr = createAndConfigureCSTR(*mb, jpp);
+			cstr->setFlowRates(0.0, 0.0);
+			
+			std::vector<double> y(cstr->numDofs(), 0.0);
+			y[2] = 2.7;
+			y[3] = 0.3;
+			y[4] = 1.0;
+
+			cadet::test::unitoperation::testConsistentInitialization(cstr, adEnabled, y.data(), 1e-14, 1e-12);
+
+			CHECK(y[2] == cadet::test::makeApprox(1.0, 1e-12, 1e-12));
+			CHECK(y[3] == cadet::test::makeApprox(2.0, 1e-12, 1e-12));
+			CHECK((y[2] + y[3]) == cadet::test::makeApprox(3.0, 1e-12, 1e-12));
+
+			mb->destroyUnitOperation(cstr);
+		}
+	}
+
+	destroyModelBuilder(mb);
+}
+
+TEST_CASE("CSTR liquid equilibrium MAL Jacobian vs AD", "[CSTR],[MassActionLaw],[ReactionModel],[Jacobian],[AD],[CI]")
+{
+	checkJacobianAD(1.0, 1.0, 0.0, [](cadet::JsonParameterProvider& jpp, unsigned int nComp) {
+		
+		jpp.set("NREAC_LIQUID", 1);
+		jpp.addScope("liquid_reaction_000");
+		jpp.pushScope("liquid_reaction_000");
+		jpp.set("TYPE", "MASS_ACTION_LAW");
+		jpp.set("MAL_KFWD", std::vector<double>{2.0});
+		jpp.set("MAL_KBWD", std::vector<double>{1.0});
+		jpp.set("MAL_STOICHIOMETRY", std::vector<double>{-1.0, 1.0});
+		jpp.set("MAL_IS_KINETIC", std::vector<int>{false ? 1 : 0});
+		jpp.popScope();
+
+	});
+}
+
+TEST_CASE("CSTR kinetic and equilibrium MAL share liquid equilibrium", "[CSTR],[MassActionLaw],[ReactionModel],[ConsistentInit],[CI]")
+{
+	cadet::IModelBuilder* const mb = cadet::createModelBuilder();
+	REQUIRE(nullptr != mb);
+
+	cadet::JsonParameterProvider eqJpp = createCSTR(2);
+	
+	eqJpp.set("NREAC_LIQUID", 1);
+	eqJpp.addScope("liquid_reaction_000");
+	eqJpp.pushScope("liquid_reaction_000");
+	eqJpp.set("TYPE", "MASS_ACTION_LAW");
+	eqJpp.set("MAL_KFWD", std::vector<double>{2.0});
+	eqJpp.set("MAL_KBWD", std::vector<double>{1.0});
+	eqJpp.set("MAL_STOICHIOMETRY", std::vector<double>{-1.0, 1.0});
+	eqJpp.set("MAL_IS_KINETIC", std::vector<int>{false ? 1 : 0});
+	eqJpp.popScope();
+
+	cadet::model::CSTRModel* const eqCstr = createAndConfigureCSTR(*mb, eqJpp);
+	eqCstr->setFlowRates(0.0, 0.0);
+	
+	std::vector<double> yEq(eqCstr->numDofs(), 0.0);
+	yEq[2] = 2.7;
+	yEq[3] = 0.3;
+	yEq[4] = 1.0;
+	cadet::test::unitoperation::testConsistentInitialization(eqCstr, false, yEq.data(), 1e-14, 1e-12);
+	
+	cadet::JsonParameterProvider kinjpp = createCSTR(2);
+	
+	kinjpp.set("NREAC_LIQUID", 1);
+	kinjpp.addScope("liquid_reaction_000");
+	kinjpp.pushScope("liquid_reaction_000");
+	kinjpp.set("TYPE", "MASS_ACTION_LAW");
+	kinjpp.set("MAL_KFWD", std::vector<double>{2.0});
+	kinjpp.set("MAL_KBWD", std::vector<double>{1.0});
+	kinjpp.set("MAL_STOICHIOMETRY", std::vector<double>{-1.0, 1.0});
+	kinjpp.set("MAL_IS_KINETIC", std::vector<int>{true ? 1 : 0});
+	kinjpp.popScope();
+
+	cadet::model::CSTRModel* const kinCstr = createAndConfigureCSTR(*mb, kinjpp);
+	kinCstr->setFlowRates(0.0, 0.0);
+
+	// Use the equilibrium model's consistently initialized state
+	std::vector<double> yKin = yEq;
+	yKin[2] = 1.0;
+	yKin[3] = 2.0;
+	
+	std::vector<double> res(kinCstr->numDofs(), 0.0);
+	cadet::util::ThreadLocalStorage tls;
+	tls.resize(kinCstr->threadLocalMemorySize());
+
+	kinCstr->notifyDiscontinuousSectionTransition(0.0, 0u, {yKin.data(), nullptr}, cadet::AdJacobianParams{nullptr, nullptr, 0u});
+	kinCstr->residual(cadet::SimulationTime{0.0, 0u}, cadet::ConstSimulationState{yKin.data(), nullptr}, res.data(), tls);
+
+	CHECK(yKin[2] == cadet::test::makeApprox(1.0, 1e-12, 1e-12));
+	CHECK(yKin[3] == cadet::test::makeApprox(2.0, 1e-12, 1e-12));
+	
+	for (double val : res)
+		CHECK(std::abs(val) <= 1e-12);
+	
+	mb->destroyUnitOperation(eqCstr);
+	mb->destroyUnitOperation(kinCstr);
+	destroyModelBuilder(mb);
 }
 
 TEST_CASE("StirredTankModel consistent sensitivity initialization with linear binding", "[CSTR],[ConsistentInit],[Sensitivity],[CI]")

--- a/test/ReactionModelTests.cpp
+++ b/test/ReactionModelTests.cpp
@@ -525,7 +525,7 @@ namespace reaction
 		cadet::model::ConservedMoieties cm;
 		REQUIRE(cm.configure(nComp, std::vector<unsigned int>{0u}, std::move(eqReactionFlags), std::move(stoichiometry), 1e-14));
 
-		return cm.getConservedMoitiesMatrix();
+		return cm.getConservedMoietiesMatrix();
 	}
 
 	void checkNullSpace(const Eigen::MatrixXd& left, const Eigen::MatrixXd& right)


### PR DESCRIPTION
This PR introduces rapid equilibrium for the mass action law (MAL) in a CSTR unit involving the liquid phase.

When rapid equilibrium is present, the conserved moieties matrix is multiplied by the residuum and the equilibrium reaction equations are incorporated into the rest of the state vector.

Consistent initialisations for the state and derivatives, as well as the residuum Jacobian and time derivative Jacobian, have all been adjusted accordingly.

Furthermore, new equilibrium residuum functions are added to the reaction interface and implemented for the mass action law reaction model.


Three new tests were added: 
- reference test for consistent initialisation
-  analytic versus AD Jacobian comparison 
-  steady-state test with kinetic MAL matching steady-state with rapid equilibrium MAL.
