### PR TITLE
Add frustum DG discretization

### DIFF
--- a/src/libcadet/model/ColumnModel1D.cpp
+++ b/src/libcadet/model/ColumnModel1D.cpp
@@ -1763,6 +1763,7 @@ namespace model
 
 template class ColumnModel1D<parts::AxialConvectionDispersionOperatorBaseDG>;
 template class ColumnModel1D<parts::RadialConvectionDispersionOperatorBaseDG>;
+template class ColumnModel1D<parts::FrustumConvectionDispersionOperatorBaseDG>;
 template class ColumnModel1D<parts::AxialConvectionDispersionOperatorBaseFV>;
 template class ColumnModel1D<parts::RadialConvectionDispersionOperatorBaseFV>;
 template class ColumnModel1D<parts::FrustumConvectionDispersionOperatorBaseFV>;
@@ -1779,6 +1780,12 @@ IUnitOperation* createRadialCol1DDG(UnitOpIdx uoId)
 	typedef ColumnModel1D<parts::RadialConvectionDispersionOperatorBaseDG> RadialCol1DDG;
 
 	return new RadialCol1DDG(uoId);
+}
+
+IUnitOperation* createFrustumCol1DDG(UnitOpIdx uoId)
+{
+	typedef ColumnModel1D<parts::FrustumConvectionDispersionOperatorBaseDG> FrustumCol1DDG;
+	return new FrustumCol1DDG(uoId);
 }
 
 IUnitOperation* createAxialCol1DFV(UnitOpIdx uoId)

--- a/src/libcadet/model/ColumnModel1D.hpp
+++ b/src/libcadet/model/ColumnModel1D.hpp
@@ -58,6 +58,12 @@ namespace
 	};
 
 	template <>
+	struct ColumnModel1DName<cadet::model::parts::FrustumConvectionDispersionOperatorBaseDG>
+	{
+		static const char* identifier() CADET_NOEXCEPT { return "FRUSTUM_COLUMN_MODEL_1D"; }
+	};
+
+	template <>
 	struct ColumnModel1DName<cadet::model::parts::AxialConvectionDispersionOperatorBaseFV>
 	{
 		static const char* identifier() CADET_NOEXCEPT { return "COLUMN_MODEL_1D"; }
@@ -637,12 +643,14 @@ protected:
 
 extern template class ColumnModel1D<parts::AxialConvectionDispersionOperatorBaseDG>;
 extern template class ColumnModel1D<parts::RadialConvectionDispersionOperatorBaseDG>;
+extern template class ColumnModel1D<parts::FrustumConvectionDispersionOperatorBaseDG>;
 extern template class ColumnModel1D<parts::AxialConvectionDispersionOperatorBaseFV>;
 extern template class ColumnModel1D<parts::RadialConvectionDispersionOperatorBaseFV>;
 extern template class ColumnModel1D<parts::FrustumConvectionDispersionOperatorBaseFV>;
 
 IUnitOperation* createAxialCol1DDG(UnitOpIdx uoId);
 IUnitOperation* createRadialCol1DDG(UnitOpIdx uoId);
+IUnitOperation* createFrustumCol1DDG(UnitOpIdx uoId);
 IUnitOperation* createAxialCol1DFV(UnitOpIdx uoId);
 IUnitOperation* createRadialCol1DFV(UnitOpIdx uoId);
 IUnitOperation* createFrustumCol1DFV(UnitOpIdx uoId);

--- a/src/libcadet/model/ColumnModelBuilder.cpp
+++ b/src/libcadet/model/ColumnModelBuilder.cpp
@@ -266,6 +266,9 @@ namespace model
 
 		const std::string discName = paramProvider.getString("SPATIAL_METHOD");
 
+		if (discName != "DG" && discName != "FV")
+			LOG(Error) << "Unknown bulk discretization type " << discName << " for unit " << uoId;
+
 		// ARROW_HEAD_OPTIMIZATION defaults to true, preserving the existing block-structured
 		// (arrow-head) Jacobian solver in the dedicated FV unit operation classes.
 		// Set it to false to route FV through ColumnModel1D (unified path, global sparse solver).
@@ -273,8 +276,15 @@ namespace model
 			? paramProvider.getBool("FV_ARROW_HEAD_OPTIMIZATION")
 			: discName == "FV";
 
-		if (discName != "FV")
-			throw InvalidParameterException("Only FV discretization supported for Frustum geometry but " + discName + " was asked for unit " + std::to_string(uoId));
+		if (discName == "FV")
+		{
+			if (!arrowHeadOpt)
+				LOG(Info) << "FV_ARROW_HEAD_OPTIMIZATION is set to false, possibly resulting in a less efficient computation";
+		}
+		else if (arrowHeadOpt)
+		{
+			throw InvalidParameterException("FV_ARROW_HEAD_OPTIMIZATION is only available for FV discretization but " + discName + " was specified for " + uoType);
+		}
 
 		paramProvider.popScope(); // discretization
 
@@ -282,11 +292,6 @@ namespace model
 		{
 			if (paramProvider.getInt("NPARTYPE") > 0)
 			{
-				if (discName == "DG")
-					LOG(Error) << "Frustum flow not implemented for DG discretization yet, was called for unit " << uoId;
-				else if (discName != "FV")
-					LOG(Error) << "Unknown bulk discretization type " << discName << " for unit " << uoId;
-
 				paramProvider.pushScope("particle_type_000");
 
 				const bool filmDiffusion = paramProvider.getBool("HAS_FILM_DIFFUSION");
@@ -295,6 +300,15 @@ namespace model
 
 				const std::string particleType = ParticleModel(filmDiffusion, poreDiffusion, surfaceDiffusion).getParticleTransportType();
 
+				if (discName == "DG")
+				{
+					if (particleType == "EQUILIBRIUM_PARTICLE")
+						model = createFrustumLRMDG(uoId);
+					else
+						model = createFrustumCol1DDG(uoId);
+				}
+				else if (discName == "FV")
+				{
 					if (particleType == "EQUILIBRIUM_PARTICLE")
 						model = createFrustumFVLRM(uoId);
 					else if (particleType == "HOMOGENEOUS_PARTICLE")
@@ -303,16 +317,31 @@ namespace model
 						model = arrowHeadOpt ? createFrustumFVGRM(uoId) : createFrustumCol1DFV(uoId);
 					else
 						LOG(Error) << "Unknown particle type " << particleType << " for unit " << uoId;
+				}
+				else
+					LOG(Error) << "Unknown bulk discretization type " << discName << " for unit " << uoId;
 
 				paramProvider.popScope();
 			}
 			else
+			{
+				if (discName == "DG")
+					model = createFrustumCol1DDG(uoId);
+				else
 				model = arrowHeadOpt ? createFrustumFVLRM(uoId) : createFrustumCol1DFV(uoId);
+		}
 		}
 		else
 		{
 			if (discName == "DG")
-				LOG(Error) << "Frustum flow not implemented for DG discretization yet, was called for unit " << uoId;
+			{
+				if (uoType == "Frustum_LUMPED_RATE_MODEL_WITHOUT_PORES")
+					model = createFrustumLRMDG(uoId);
+				else if (uoType == "Frustum_LUMPED_RATE_MODEL_WITH_PORES" || uoType == "RADIAL_GENERAL_RATE_MODEL")
+					model = createFrustumCol1DDG(uoId);
+				else
+					LOG(Error) << "Frustum DG discretization supports LRM, LRMP, and GRM but " << uoType << " was specified for unit " << uoId;
+			}
 			else if (discName == "FV")
 			{
 				if (uoType == "FRUSTUM_LUMPED_RATE_MODEL_WITHOUT_PORES")
@@ -341,12 +370,16 @@ namespace model
 		models["COLUMN_MODEL_2D"] = selectAxialFlowColumnUnitOperation;
 
 		typedef LumpedRateModelWithoutPoresDG<parts::RadialConvectionDispersionOperatorBaseDG> RadialLRMDG;
+		typedef LumpedRateModelWithoutPoresDG<parts::FrustumConvectionDispersionOperatorBaseDG> FrustumLRMDG;
 
 		models[LumpedRateModelWithoutPoresDG<>::identifier()] = selectAxialFlowColumnUnitOperation;
 		models["LRM_DG"] = selectAxialFlowColumnUnitOperation;
 
 		models[RadialLRMDG::identifier()] = selectRadialFlowColumnUnitOperation;
 		models["RLRM_DG"] = selectRadialFlowColumnUnitOperation;
+
+		models[FrustumLRMDG::identifier()] = selectFrustumFlowColumnUnitOperation;
+		models["FLRM_DG"] = selectFrustumFlowColumnUnitOperation;
 
 		typedef GeneralRateModel<parts::AxialConvectionDispersionOperator> AxialGRM;
 		typedef GeneralRateModel<parts::RadialConvectionDispersionOperator> RadialGRM;

--- a/src/libcadet/model/LumpedRateModelWithoutPoresDG.cpp
+++ b/src/libcadet/model/LumpedRateModelWithoutPoresDG.cpp
@@ -1976,6 +1976,7 @@ namespace cadet
 		// Template instantiations
 		template class LumpedRateModelWithoutPoresDG<parts::AxialConvectionDispersionOperatorBaseDG>;
 		template class LumpedRateModelWithoutPoresDG<parts::RadialConvectionDispersionOperatorBaseDG>;
+		template class LumpedRateModelWithoutPoresDG<parts::FrustumConvectionDispersionOperatorBaseDG>;
 
 		IUnitOperation* createAxialLRMDG(UnitOpIdx uoId)
 		{
@@ -1987,6 +1988,12 @@ namespace cadet
 		{
 			typedef LumpedRateModelWithoutPoresDG<parts::RadialConvectionDispersionOperatorBaseDG> RadialLRM;
 			return new RadialLRM(uoId);
+		}
+
+		IUnitOperation* createFrustumLRMDG(UnitOpIdx uoId)
+		{
+			typedef LumpedRateModelWithoutPoresDG<parts::FrustumConvectionDispersionOperatorBaseDG> FrustumLRM;
+			return new FrustumLRM(uoId);
 		}
 
 	}  // namespace model

--- a/src/libcadet/model/LumpedRateModelWithoutPoresDG.cpp
+++ b/src/libcadet/model/LumpedRateModelWithoutPoresDG.cpp
@@ -880,7 +880,7 @@ namespace cadet
 		unsigned int LumpedRateModelWithoutPoresDG<ConvDispOperator>::localOutletComponentIndex(unsigned int port) const CADET_NOEXCEPT
 		{
 			// Inlets are duplicated so need to be accounted for
-			if (static_cast<double>(_convDispOp.currentVelocity()) >= 0.0)
+			if (static_cast<double>(_convDispOp.forwardFlow()))
 				// Forward Flow: outlet is last cell
 				return _disc.nComp + (_disc.nPoints - 1) * (_disc.nComp + _disc.strideBound);
 			else
@@ -1954,7 +1954,7 @@ namespace cadet
 		{
 			cadet_assert(port == 0);
 
-			if (_model._convDispOp.currentVelocity() >= 0)
+			if (_model._convDispOp.forwardFlow())
 				std::copy_n(&_idx.c(_data, _disc.nPoints - 1, 0), _disc.nComp, buffer);
 			else
 				std::copy_n(&_idx.c(_data, 0, 0), _disc.nComp, buffer);
@@ -1965,7 +1965,7 @@ namespace cadet
 		template <typename ConvDispOperator>
 		int LumpedRateModelWithoutPoresDG<ConvDispOperator>::Exporter::writeOutlet(double* buffer) const
 		{
-			if (_model._convDispOp.currentVelocity() >= 0)
+			if (_model._convDispOp.forwardFlow())
 				std::copy_n(&_idx.c(_data, _disc.nPoints - 1, 0), _disc.nComp, buffer);
 			else
 				std::copy_n(&_idx.c(_data, 0, 0), _disc.nComp, buffer);

--- a/src/libcadet/model/LumpedRateModelWithoutPoresDG.hpp
+++ b/src/libcadet/model/LumpedRateModelWithoutPoresDG.hpp
@@ -60,6 +60,12 @@ namespace
 	{
 		static const char* identifier() CADET_NOEXCEPT { return "RADIAL_LUMPED_RATE_MODEL_WITHOUT_PORES_DG"; }
 	};
+
+	template <>
+	struct LumpedRateModelWithoutPoresDGName<cadet::model::parts::FrustumConvectionDispersionOperatorBaseDG>
+	{
+		static const char* identifier() CADET_NOEXCEPT { return "FRUSTUM_LUMPED_RATE_MODEL_WITHOUT_PORES_DG"; }
+	};
 }
 
 namespace cadet
@@ -551,6 +557,7 @@ namespace cadet
 
 		IUnitOperation* createAxialLRMDG(UnitOpIdx uoId);
 		IUnitOperation* createRadialLRMDG(UnitOpIdx uoId);
+		IUnitOperation* createFrustumLRMDG(UnitOpIdx uoId);
 
 	} // namespace model
 } // namespace cadet

--- a/src/libcadet/model/parts/ConvectionDispersionOperatorDG.cpp
+++ b/src/libcadet/model/parts/ConvectionDispersionOperatorDG.cpp
@@ -1789,13 +1789,746 @@ void RadialConvectionDispersionOperatorBaseDG::calcConvDispRadialDGSEMJacobian(E
 			}
 		}
 	}
+}
 
+FrustumConvectionDispersionOperatorBaseDG::FrustumConvectionDispersionOperatorBaseDG()
+	: _auxState(nullptr), _subsState(nullptr), _dispersionDep(nullptr)
+{
+}
+
+FrustumConvectionDispersionOperatorBaseDG::~FrustumConvectionDispersionOperatorBaseDG() CADET_NOEXCEPT
+{
+	if (_dispersionDep)
+		delete _dispersionDep;
+	delete[] _auxState;
+	delete[] _subsState;
+}
+
+bool FrustumConvectionDispersionOperatorBaseDG::configureModelDiscretization(IParameterProvider& paramProvider, const IConfigHelper& helper, unsigned int nComp, unsigned int nElem, unsigned int polyDeg, unsigned int strideNode)
+{
+	const bool firstConfigCall = (_auxState == nullptr);
+
+	_nComp = nComp;
+	_nElem = nElem;
+	_polyDeg = polyDeg;
+	_nNodes = _polyDeg + 1u;
+	_nPoints = _nNodes * _nElem;
+	_strideNode = strideNode;
+	_strideElem = _nNodes * strideNode;
+
+	// Read quadrature parameters
+	_axDispQuadDeg = paramProvider.exists("DISPERSION_SPATIAL_DEPENDENCE_POLYDEG") ? paramProvider.getInt("DISPERSION_SPATIAL_DEPENDENCE_POLYDEG") : 0;
+	_filmDiffQuadDeg = paramProvider.exists("FILM_DIFFUSION_SPATIAL_DEPENDENCE_POLYDEG") ? paramProvider.getInt("FILM_DIFFUSION_SPATIAL_DEPENDENCE_POLYDEG") : 0;
+
+	// Read frustum geometry parameters
+	_radiusXStart = paramProvider.getDouble("COL_RADIUS_LARGE_END");
+	_radiusXEnd = paramProvider.getDouble("COL_RADIUS_SMALL_END");
+	_bedLength = paramProvider.getDouble("COL_LENGTH");
+	_colHeight = _bedLength;
+
+	if (!(static_cast<double>(_radiusXStart) > 0.0 &&
+		static_cast<double>(_radiusXStart) >= static_cast<double>(_radiusXEnd) &&
+		static_cast<double>(_bedLength) > 0.0))
+		throw InvalidParameterException("Geometry parameters for AXIAL_FLOW_FRUSTUM must satisfy 0 < COL_RADIUS_SMALL_END <= COL_RADIUS_LARGE_END, COL_LENGTH > 0.0");
+
+	_deltaX = static_cast<double>(_bedLength) / static_cast<double>(_nElem);
+
+	// Allocate DG matrices
+	_nodes.resize(_nNodes);
+	_nodes.setZero();
+	_invWeights.resize(_nNodes);
+	_invWeights.setZero();
+	_polyDerM.resize(_nNodes, _nNodes);
+	_polyDerM.setZero();
+	_M00.resize(_nNodes, _nNodes);
+	_M00.setZero();
+
+	if (firstConfigCall)
+	{
+		_auxState = new active[_nPoints];
+		_subsState = new active[_nPoints];
+	}
+	for (unsigned int i = 0; i < _nPoints; i++) {
+		_auxState[i] = 0.0;
+		_subsState[i] = 0.0;
+	}
+
+	_surfaceFluxC.resize(_nElem + 1u);
+	_surfaceFluxC.setZero();
+	_surfaceFluxG.resize(_nElem + 1u);
+	_surfaceFluxG.setZero();
+
+	_newStaticJac = true;
+
+	// LGL nodes and DG operators (except geometry dependent ones)
+	dgtoolbox::lglNodesWeights(_polyDeg, _nodes, _invWeights, /*invertWeights=*/true);
+	_polyDerM = dgtoolbox::derivativeMatrix(_polyDeg, _nodes);
+	_M00 = dgtoolbox::mMatrix(_polyDeg, _nodes, 0.0, 0.0);
+	_invM00 = _M00.inverse();
+
+	// Dispersion parameter dependence (optional)
+	if (paramProvider.exists("COL_DISPERSION_DEP"))
+	{
+		const std::string paramDepName = paramProvider.getString("COL_DISPERSION_DEP");
+		_dispersionDep = helper.createParameterParameterDependence(paramDepName);
+		if (!_dispersionDep)
+			throw InvalidParameterException("Unknown parameter dependence " + paramDepName + " in COL_DISPERSION_DEP");
+		_dispersionDep->configureModelDiscretization(paramProvider);
+	}
+	else
+		_dispersionDep = helper.createParameterParameterDependence("CONSTANT_ONE");
+
+	// Allocate per-cell Jacobian blocks
+	_DGjacFrustumDispBlocks.resize(_nElem);
+	_DGjacFrustumConvBlocks.resize(_nElem);
+
+	return true;
+}
+
+bool FrustumConvectionDispersionOperatorBaseDG::configure(UnitOpIdx unitOpIdx, IParameterProvider& paramProvider, std::unordered_map<ParameterId, active*>& parameters)
+{
+	readScalarParameterOrArray(_colDispersion, paramProvider, "COL_DISPERSION", 1);
+
+	readScalarParameterOrArray(_forwardFlow, paramProvider, "FORWARD_FLOW", 1);
+	_curFwdFlow = _forwardFlow[0];
+
+	if (paramProvider.exists("COL_DISPERSION_MULTIPLEX"))
+	{
+		const int mode = paramProvider.getInt("COL_DISPERSION_MULTIPLEX");
+		if (mode == 0 || mode == 2)
+			_dispersionCompIndep = true;
+		else
+			_dispersionCompIndep = false;
+
+		if (!_dispersionCompIndep && (_colDispersion.size() % _nComp != 0))
+			throw InvalidParameterException("Number of elements in field COL_DISPERSION is not a positive multiple of NCOMP (" + std::to_string(_nComp) + ")");
+	}
+	else
+	{
+		_dispersionCompIndep = ((_colDispersion.size() % _nComp) != 0);
+	}
+
+	if (_dispersionCompIndep)
+	{
+		std::vector<active> expanded(_colDispersion.size() * _nComp);
+		for (std::size_t i = 0; i < _colDispersion.size(); ++i)
+			std::fill(expanded.begin() + i * _nComp, expanded.begin() + (i + 1) * _nComp, _colDispersion[i]);
+		_colDispersion = std::move(expanded);
+	}
+
+	if (_dispersionDep)
+	{
+		if (!_dispersionDep->configure(paramProvider, unitOpIdx, ParTypeIndep, BoundStateIndep, "COL_DISPERSION_DEP"))
+			throw InvalidParameterException("Failed to configure dispersion parameter dependency (COL_DISPERSION_DEP)");
+	}
+
+	// Register parameters
+	if (_dispersionCompIndep)
+	{
+		if (_colDispersion.size() > _nComp)
+		{
+			for (std::size_t i = 0; i < _colDispersion.size() / _nComp; ++i)
+				parameters[makeParamId(hashString("COL_DISPERSION"), unitOpIdx, CompIndep, ParTypeIndep, BoundStateIndep, ReactionIndep, static_cast<int>(i))] = &_colDispersion[i * _nComp];
+		}
+		else
+		{
+			parameters[makeParamId(hashString("COL_DISPERSION"), unitOpIdx, CompIndep, ParTypeIndep, BoundStateIndep, ReactionIndep, SectionIndep)] = &_colDispersion[0];
+		}
+	}
+	else
+		registerParam2DArray(parameters, _colDispersion, [=](bool multi, unsigned int sec, unsigned int comp) {
+		return makeParamId(hashString("COL_DISPERSION"), unitOpIdx, comp, ParTypeIndep, BoundStateIndep, ReactionIndep, multi ? static_cast<int>(sec) : SectionIndep);
+			}, _nComp);
+
+	parameters[makeParamId(hashString("COL_LENGTH"), unitOpIdx, CompIndep, ParTypeIndep, BoundStateIndep, ReactionIndep, SectionIndep)] = &_bedLength;
+	parameters[makeParamId(hashString("COL_RADIUS_SMALL_END"), unitOpIdx, CompIndep, ParTypeIndep, BoundStateIndep, ReactionIndep, SectionIndep)] = &_radiusXStart;
+	parameters[makeParamId(hashString("COL_RADIUS_LARGE_END"), unitOpIdx, CompIndep, ParTypeIndep, BoundStateIndep, ReactionIndep, SectionIndep)] = &_radiusXEnd;
+
+	// Geometry dependent operators
+	computeGeometryFrustum();
+	computeOperatorsFrustum();
+
+	return true;
+}
+
+bool FrustumConvectionDispersionOperatorBaseDG::notifyDiscontinuousSectionTransition(double t, unsigned int secIdx, Eigen::MatrixXd& jacInlet)
+{
+	_curSection = secIdx;
+	_newStaticJac = true;
+
+	// note: flow direction is set by setFlowRates() before notifyDiscontinuousSectionTransition() is called
+	_curFwdFlow = _forwardFlow.size() > 1 ? _forwardFlow[secIdx] : _forwardFlow[0];
+
+	// Recompute direction dependent Jacobian blocks.
+	for (unsigned int elem = 0; elem < _nElem; elem++)
+		_DGjacFrustumConvBlocks[elem] = DGjacobianConvBlockFrustum(elem);
+
+	if (_curFwdFlow)
+		jacInlet = _DGjacFrustumConvBlocks[0].col(0);
+	else
+		jacInlet = _DGjacFrustumConvBlocks[_nElem - 1].col(_DGjacFrustumConvBlocks[_nElem - 1].cols() - 1);
+
+	return true;
+}
+
+void FrustumConvectionDispersionOperatorBaseDG::setFlowRates(const active& in, const active& out, const active& colPorosity) CADET_NOEXCEPT
+{
+	_flowRate = in;
+	_QOverEps = _curFwdFlow ? _flowRate / colPorosity : -_flowRate / colPorosity;
+}
+
+unsigned int FrustumConvectionDispersionOperatorBaseDG::jacobianLowerBandwidth() const CADET_NOEXCEPT
+{
+	return 2 * _nNodes * strideColNode();
+}
+
+unsigned int FrustumConvectionDispersionOperatorBaseDG::jacobianUpperBandwidth() const CADET_NOEXCEPT
+{
+	return jacobianLowerBandwidth();
+}
+
+unsigned int FrustumConvectionDispersionOperatorBaseDG::nJacEntries(bool pureNNZ) const CADET_NOEXCEPT
+{
+	if (pureNNZ)
+		return _nComp * ((3u * _nElem - 2u) * _nNodes * _nNodes + (2u * _nElem - 3u) * _nNodes);
+	return _nComp * _nNodes * _nNodes + _nNodes
+		+ _nComp * ((3u * _nElem - 2u) * _nNodes * _nNodes + (2u * _nElem - 3u) * _nNodes);
+}
+
+void FrustumConvectionDispersionOperatorBaseDG::convDispJacPattern(
+	std::vector<T>& tripletList, const int bulkOffset) const
+{
+	const int lowerBW = static_cast<int>(jacobianLowerBandwidth());
+	const int upperBW = static_cast<int>(jacobianUpperBandwidth());
+
+	for (unsigned int point = 0; point < _nPoints; ++point)
+	{
+		for (unsigned int comp = 0; comp < _nComp; ++comp)
+		{
+			const int row = bulkOffset + static_cast<int>(point) * strideColNode() + static_cast<int>(comp);
+			for (int diag = -lowerBW; diag <= upperBW; ++diag)
+			{
+				const int col = row + diag;
+				if (col >= bulkOffset && col < static_cast<int>(bulkOffset + _nPoints * strideColNode()))
+					tripletList.push_back(T(row, col, 0.0));
+			}
+		}
+	}
+}
+
+void FrustumConvectionDispersionOperatorBaseDG::multiplyWithDerivativeJacobian(const SimulationTime& simTime, double const* sDot, double* ret) const
+{
+	double const* localSdot = sDot + offsetC();
+	double* localRet = ret + offsetC();
+	const int gapElem = strideColNode() - static_cast<int>(_nComp) * strideColComp();
+
+	for (unsigned int i = 0; i < _nPoints; ++i, localRet += gapElem, localSdot += gapElem)
+		for (unsigned int j = 0; j < _nComp; ++j, ++localRet, ++localSdot)
+			*localRet = *localSdot;
+}
+
+void FrustumConvectionDispersionOperatorBaseDG::addTimeDerivativeToJacobian(double alpha, Eigen::SparseMatrix<double, Eigen::RowMajor>& jacDisc, unsigned int blockOffset) const
+{
+	const int gapElem = strideColNode() - static_cast<int>(_nComp) * strideColComp();
+	linalg::BandedEigenSparseRowIterator jac(jacDisc, blockOffset);
+
+	for (unsigned int point = 0; point < _nPoints; ++point, jac += gapElem)
+		for (unsigned int comp = 0; comp < _nComp; ++comp, ++jac)
+			jac[0] += alpha;
+}
+
+void FrustumConvectionDispersionOperatorBaseDG::computeGeometryFrustum()
+{
+	const double H = static_cast<double>(_bedLength);
+	const double r0 = static_cast<double>(_radiusXStart);
+	const double rH = static_cast<double>(_radiusXEnd);
+	const double dx = static_cast<double>(_deltaX);
+	const double pi = 3.14159265358979323846;
+
+	_crossSectionArea.resize(_nPoints);
+
+	for (int elem = 0; elem < _nElem; ++elem)
+	{
+		for (int node = 0; node < _nNodes; ++node)
+		{
+			const double x = elem * dx + 0.5 * dx * (1.0 + _nodes[node]);
+			const double r = r0 + (x / H) * (rH - r0);
+
+			_crossSectionArea[elem * _nNodes + node] = pi * r * r;
+		}
+	}
+}
+
+void FrustumConvectionDispersionOperatorBaseDG::computeOperatorsFrustum()
+{
+	const double pi = 3.14159265358979323846;
+	const double H = static_cast<double>(_bedLength);
+	const double dx = static_cast<double>(_deltaX);
+	const double r0 = static_cast<double>(_radiusXStart);
+	const double rH = static_cast<double>(_radiusXEnd);
+	const double rDiff = rH - r0;
+
+	Eigen::MatrixXd M01 = dgtoolbox::mMatrix(_polyDeg, _nodes, 0.0, 1.0);
+	Eigen::MatrixXd M02 = dgtoolbox::mMatrix(_polyDeg, _nodes, 0.0, 2.0);
+
+	_invMM_A.resize(_nElem);
+	_invMM_A_times_ST_AD.resize(_nElem);
+	_invMM_A_times_DT_timesM00.resize(_nElem);
+
+	for (unsigned int elem = 0; elem < _nElem; ++elem)
+	{
+		const double x_L = elem * dx;
+
+		Eigen::MatrixXd M_A = (r0 * r0 + 2.0 * r0 * x_L / H * rDiff + x_L * x_L / H / H * rDiff * rDiff) * _M00;
+		M_A += (r0 * rDiff * dx / H + rDiff * rDiff / H / H * x_L * dx) * M01;
+		M_A += (rDiff * rDiff / H / H * dx * dx / 2.0 / 2.0) * M02;
+		M_A *= pi;
+		_invMM_A[elem] = M_A.inverse();
+
+		// \tilde{M}^(AD)_{i,j} = \int_{-1}^1 \ell_i(\xi) \frac{\partial \ell_j(\xi)}{\partial \xi} w(\xi) d\xi
+		// with w(\xi) = A(x^e_i(\xi) D^{ax}(x^e_i(\xi)
+		// with x^e_i(\xi) = (\xi + 1) * dx_i / 2 + x_i, and A(x) = \pi * r(x)^2, D^{ax} being the spatially dependent dispersion parameter,
+		// and r(x) = _radiusXEnd + x / _bedLength * (_radiusXStart - _radiusXEnd)
+		// matrix computed with gauss quadrature
+		// const int nGaussQuadNodes = _nNodes + 2 + _axDispQuadDeg; // accurate up to degree 2N - 1, ie exact if _axDispQuadDeg is the polynomial degree of the spatially dependent dispersion parameter
+		// ... wip
+		// for now, we assume constant dispersion, ie \tilde{M}^(AD) can be computed exactly as D^{ax} * M_A
+		Eigen::MatrixXd gaussMM_AD = static_cast<double>(_colDispersion[0]) * M_A;
+
+		// Matrix product (M^A)^-1 * D^T * \tilde{S}^(AD) = (M^A)^-1 * D^T * \tilde{M}^(AD)
+		_invMM_A_times_ST_AD[elem] = _invMM_A[elem] * _polyDerM.transpose() * gaussMM_AD;
+		// Matrix product (M^A)^-1 D^T * M00
+		_invMM_A_times_DT_timesM00[elem] = _invMM_A[elem] * _polyDerM.transpose() * _M00;
+	}
+}
+
+// ============================================================================
+//  Jacobian block helpers
+// ============================================================================
+
+Eigen::MatrixXd FrustumConvectionDispersionOperatorBaseDG::getGBlockFrustum(unsigned int elemIdx)
+{
+	// Identical to radial getGBlockRadial — auxiliary equation uses standard M^{(0,0)} inverse.
+	// g = (2/deltaX) * [D*c + M^{-1} * B * (c* - c)]
+	Eigen::MatrixXd gBlock = Eigen::MatrixXd::Zero(_nNodes, _nNodes + 2);
+	const double deltaX = static_cast<double>(_deltaX);
+
+	gBlock.block(0, 1, _nNodes, _nNodes) = _polyDerM;
+
+	if (elemIdx > 0 && elemIdx < _nElem - 1)
+	{
+		gBlock.block(0, 0, _nNodes, 1) -= 0.5 * _invM00.col(0);
+		gBlock.block(0, 1, _nNodes, 1) += 0.5 * _invM00.col(0);
+		gBlock.block(0, _nNodes, _nNodes, 1) -= 0.5 * _invM00.col(_nNodes - 1);
+		gBlock.block(0, _nNodes + 1, _nNodes, 1) += 0.5 * _invM00.col(_nNodes - 1);
+	}
+	else if (elemIdx == 0)
+	{
+		if (_nElem == 1) return gBlock * 2.0 / deltaX;
+		gBlock.block(0, _nNodes, _nNodes, 1) -= 0.5 * _invM00.col(_nNodes - 1);
+		gBlock.block(0, _nNodes + 1, _nNodes, 1) += 0.5 * _invM00.col(_nNodes - 1);
+	}
+	else // last cell
+	{
+		gBlock.block(0, 0, _nNodes, 1) -= 0.5 * _invM00.col(0);
+		gBlock.block(0, 1, _nNodes, 1) += 0.5 * _invM00.col(0);
+	}
+
+	return gBlock * (2.0 / deltaX);
+}
+
+Eigen::MatrixXd FrustumConvectionDispersionOperatorBaseDG::DGjacobianConvBlockFrustum(unsigned int elemIdx)
+{
+	const double invHalfDeltaX = 2.0 / static_cast<double>(_deltaX);
+	const double QOverEps = static_cast<double>(_QOverEps);
+
+	Eigen::MatrixXd convBlock = Eigen::MatrixXd::Zero(_nNodes, _nNodes + 1);
+
+	if (_curFwdFlow)
+	{
+		convBlock.block(0, 1, _nNodes, _nNodes) -= QOverEps * _invMM_A_times_DT_timesM00[elemIdx];
+
+		convBlock.block(0, 0, _nNodes, 1) = -QOverEps * _invMM_A[elemIdx].col(0);
+
+		convBlock.block(0, _nNodes, _nNodes, 1) += QOverEps * _invMM_A[elemIdx].col(_nNodes - 1);
+	}
+	else // backward flow
+	{
+		convBlock.block(0, 0, _nNodes, _nNodes) -= QOverEps * _invMM_A_times_DT_timesM00[elemIdx];
+
+		convBlock.block(0, 0, _nNodes, 1) -= QOverEps * _invMM_A[elemIdx].col(0);
+
+		convBlock.block(0, _nNodes, _nNodes, 1) = QOverEps * _invMM_A[elemIdx].col(_nNodes - 1);
+	}
+
+	return invHalfDeltaX * convBlock;
+}
+
+Eigen::MatrixXd FrustumConvectionDispersionOperatorBaseDG::DGjacobianDispBlockFrustum(unsigned int elemIdx)
+{
+	const double invHalfDeltaX = 2.0 / static_cast<double>(_deltaX);
+
+	Eigen::MatrixXd dispBlock = Eigen::MatrixXd::Zero(_nNodes, 3 * _nNodes + 2);
+	Eigen::MatrixXd G_curr = getGBlockFrustum(elemIdx);
+
+	// Volume: invMA * S_g * G_curr
+	dispBlock.block(0, _nNodes, _nNodes, _nNodes + 2) = invHalfDeltaX * (_invMM_A_times_ST_AD[elemIdx] * G_curr);
+
+	const double Aleft = _crossSectionArea[elemIdx * _nNodes];
+	const double Aright = _crossSectionArea[(elemIdx + 1) * _nNodes - 1];
+
+	// Left surface
+	if (elemIdx > 0)
+	{
+		Eigen::MatrixXd G_prev = getGBlockFrustum(elemIdx - 1);
+		dispBlock.block(0, 0, _nNodes, _nNodes + 2) +=
+			invHalfDeltaX * 0.5 * Aleft * static_cast<double>(_colDispersion[0]) * _invMM_A[elemIdx].col(0) * G_prev.row(_nNodes - 1);
+		dispBlock.block(0, _nNodes, _nNodes, _nNodes + 2) +=
+			invHalfDeltaX * 0.5 * Aleft * static_cast<double>(_colDispersion[0]) * _invMM_A[elemIdx].col(0) * G_curr.row(0);
+	}
+
+	// Right surface
+	if (elemIdx < _nElem - 1)
+	{
+		Eigen::MatrixXd G_next = getGBlockFrustum(elemIdx + 1);
+		dispBlock.block(0, _nNodes, _nNodes, _nNodes + 2) -=
+			invHalfDeltaX * 0.5 * Aright * static_cast<double>(_colDispersion[0]) * _invMM_A[elemIdx].col(_nNodes - 1) * G_curr.row(_nNodes - 1);
+		dispBlock.block(0, 2 * _nNodes, _nNodes, _nNodes + 2) -=
+			invHalfDeltaX * 0.5 * Aright * static_cast<double>(_colDispersion[0]) * _invMM_A[elemIdx].col(_nNodes - 1) * G_next.row(0);
+	}
+
+	return dispBlock;
+}
+
+void FrustumConvectionDispersionOperatorBaseDG::calcConvDispFrustumDGSEMJacobian(Eigen::SparseMatrix<double, Eigen::RowMajor>& jacobian, Eigen::MatrixXd& jacInlet, const int offC)
+{
+	const int strideNode = strideColNode();
+	const int strideElem = strideColElement();
+	const int strideColBound = strideNode - static_cast<int>(_nComp);
+
+	for (unsigned int elem = 0; elem < _nElem; elem++)
+	{
+		_DGjacFrustumConvBlocks[elem] = DGjacobianConvBlockFrustum(elem);
+		_DGjacFrustumDispBlocks[elem] = DGjacobianDispBlockFrustum(elem);
+	}
+
+	/*======================================================*/
+	/*         Dispersion Jacobian                          */
+	/*======================================================*/
+
+	for (unsigned int cell = 0; cell < _nElem; cell++)
+	{
+		const Eigen::MatrixXd& dispBlock = _DGjacFrustumDispBlocks[cell];
+		linalg::BandedEigenSparseRowIterator cellJac(jacobian, offC + cell * strideElem);
+
+		for (unsigned int i = 0; i < _nNodes; i++, cellJac += strideColBound)
+		{
+			for (unsigned int comp = 0; comp < _nComp; comp++, ++cellJac)
+			{
+				for (unsigned int j = 0; j < 3 * _nNodes + 2; j++)
+				{
+					const double val = dispBlock(i, j);
+					if (std::abs(val) > 1e-15)
+					{
+						const int relOffset = static_cast<int>(j) - static_cast<int>(_nNodes) - 1 - static_cast<int>(i);
+						cellJac[relOffset * strideNode] += val;
+					}
+				}
+			}
+		}
+	}
+
+	/*======================================================*/
+	/*         Convection Jacobian                          */
+	/*======================================================*/
+
+	linalg::BandedEigenSparseRowIterator jacConv(jacobian, offC);
+
+	if (_curFwdFlow)
+	{
+		jacInlet = _DGjacFrustumConvBlocks[0].col(0);
+
+		const Eigen::MatrixXd& firstBlock = _DGjacFrustumConvBlocks[0];
+		for (unsigned int i = 0; i < _nNodes; i++, jacConv += strideColBound)
+		{
+			for (unsigned int comp = 0; comp < _nComp; comp++, ++jacConv)
+			{
+				for (unsigned int j = 1; j <= _nNodes; j++)
+				{
+					const int nodeOffset = static_cast<int>(j - 1) - static_cast<int>(i);
+					jacConv[nodeOffset * strideNode] += firstBlock(i, j);
+				}
+			}
+		}
+
+		for (unsigned int cell = 1; cell < _nElem; cell++)
+		{
+			const Eigen::MatrixXd& convBlock = _DGjacFrustumConvBlocks[cell];
+			for (unsigned int i = 0; i < _nNodes; i++, jacConv += strideColBound)
+			{
+				for (unsigned int comp = 0; comp < _nComp; comp++, ++jacConv)
+				{
+					for (unsigned int j = 0; j < static_cast<unsigned int>(convBlock.cols()); j++)
+					{
+						const int nodeOffset = static_cast<int>(j) - 1 - static_cast<int>(i);
+						jacConv[nodeOffset * strideNode] += convBlock(i, j);
+					}
+				}
+			}
+		}
+	}
+	else // backward flow
+	{
+		for (unsigned int cell = 0; cell < _nElem - 1; cell++)
+		{
+			const Eigen::MatrixXd& convBlock = _DGjacFrustumConvBlocks[cell];
+			for (unsigned int i = 0; i < _nNodes; i++, jacConv += strideColBound)
+			{
+				for (unsigned int comp = 0; comp < _nComp; comp++, ++jacConv)
+				{
+					for (unsigned int j = 0; j < static_cast<unsigned int>(convBlock.cols()); j++)
+					{
+						const int nodeOffset = static_cast<int>(j) - static_cast<int>(i);
+						jacConv[nodeOffset * strideNode] += convBlock(i, j);
+					}
+				}
+			}
+		}
+
+		const Eigen::MatrixXd& lastBlock = _DGjacFrustumConvBlocks[_nElem - 1];
+		jacInlet = lastBlock.col(lastBlock.cols() - 1);
+
+		for (unsigned int i = 0; i < _nNodes; i++, jacConv += strideColBound)
+		{
+			for (unsigned int comp = 0; comp < _nComp; comp++, ++jacConv)
+			{
+				for (unsigned int j = 0; j < _nNodes; j++)
+				{
+					const int nodeOffset = static_cast<int>(j) - static_cast<int>(i);
+					jacConv[nodeOffset * strideNode] += lastBlock(i, j);
+				}
+			}
+		}
+	}
+
+	_newStaticJac = false;
+}
+
+// ============================================================================
+//  calcTransportJacobian
+// ============================================================================
+
+template <typename StateType>
+int FrustumConvectionDispersionOperatorBaseDG::calcTransportJacobian(const IModel&, double t, unsigned int secIdx, Eigen::SparseMatrix<double, RowMajor>& jacobian, Eigen::MatrixXd& jacInlet, const int bulkOffset, const StateType* const /*y*/)
+{
+	calcConvDispFrustumDGSEMJacobian(jacobian, jacInlet, bulkOffset);
+	return jacobian.isCompressed();
+}
+
+int FrustumConvectionDispersionOperatorBaseDG::calcTransportJacobian(
+	const IModel& model, double t, unsigned int secIdx,
+	Eigen::SparseMatrix<double, Eigen::RowMajor>& jacobian,
+	Eigen::MatrixXd& jacInlet, int bulkOffset, double const* y)
+{
+	return calcTransportJacobian<double>(model, t, secIdx, jacobian, jacInlet, bulkOffset, y);
+}
+
+int FrustumConvectionDispersionOperatorBaseDG::calcTransportJacobian(
+	const IModel& model, double t, unsigned int secIdx,
+	Eigen::SparseMatrix<double, Eigen::RowMajor>& jacobian,
+	Eigen::MatrixXd& jacInlet, int bulkOffset, active const* y)
+{
+	return calcTransportJacobian<active>(model, t, secIdx, jacobian, jacInlet, bulkOffset, y);
+}
+
+// ============================================================================
+//  residual overloads
+// ============================================================================
+
+int FrustumConvectionDispersionOperatorBaseDG::residual(const IModel& model, double t, unsigned int secIdx, double const* y, double const* yDot, double* res, Eigen::SparseMatrix<double, Eigen::RowMajor>& jac)
+{
+	return residualImpl<double, double, double, linalg::BandedEigenSparseRowIterator, true>(model, t, secIdx, y, yDot, res, linalg::BandedEigenSparseRowIterator(jac, offsetC()));
+}
+
+int FrustumConvectionDispersionOperatorBaseDG::residual(const IModel& model, double t, unsigned int secIdx, double const* y, double const* yDot, active* res, Eigen::SparseMatrix<double, Eigen::RowMajor>& jac)
+{
+	return residualImpl<double, active, active, linalg::BandedEigenSparseRowIterator, true>(model, t, secIdx, y, yDot, res, linalg::BandedEigenSparseRowIterator(jac, offsetC()));
+}
+
+int FrustumConvectionDispersionOperatorBaseDG::residual(const IModel& model, double t, unsigned int secIdx, double const* y, double const* yDot, double* res, WithoutParamSensitivity)
+{
+	return residualImpl<double, double, double, linalg::BandedEigenSparseRowIterator, false>(model, t, secIdx, y, yDot, res, linalg::BandedEigenSparseRowIterator());
+}
+
+int FrustumConvectionDispersionOperatorBaseDG::residual(const IModel& model, double t, unsigned int secIdx, double const* y, double const* yDot, active* res, WithParamSensitivity)
+{
+	return residualImpl<double, active, active, linalg::BandedEigenSparseRowIterator, false>(model, t, secIdx, y, yDot, res, linalg::BandedEigenSparseRowIterator());
+}
+
+int FrustumConvectionDispersionOperatorBaseDG::residual(const IModel& model, double t, unsigned int secIdx, active const* y, double const* yDot, active* res, WithParamSensitivity)
+{
+	return residualImpl<active, active, active, linalg::BandedEigenSparseRowIterator, false>(model, t, secIdx, y, yDot, res, linalg::BandedEigenSparseRowIterator());
+}
+
+int FrustumConvectionDispersionOperatorBaseDG::residual(const IModel& model, double t, unsigned int secIdx, active const* y, double const* yDot, active* res, WithoutParamSensitivity)
+{
+	return residualImpl<active, active, active, linalg::BandedEigenSparseRowIterator, false>(model, t, secIdx, y, yDot, res, linalg::BandedEigenSparseRowIterator());
+}
+
+template <typename StateType, typename ResidualType, typename ParamType, typename RowIteratorType, bool wantJac>
+int FrustumConvectionDispersionOperatorBaseDG::residualImpl(const IModel& model, double t, unsigned int secIdx, StateType const* y, double const* yDot, ResidualType* res, RowIteratorType /*jacBegin*/)
+{
+
+	for (unsigned int comp = 0; comp < _nComp; comp++)
+	{
+		StateType const* yBulk = y + offsetC() + comp;
+		ResidualType* resBulk = res + offsetC() + comp;
+
+		// Initialise residual with dc/dt
+		if (yDot)
+		{
+			for (unsigned int i = 0; i < _nPoints; i++)
+				resBulk[i * _strideNode] = static_cast<ResidualType>(yDot[offsetC() + comp + i * _strideNode]);
+		}
+		else
+		{
+			for (unsigned int i = 0; i < _nPoints; i++)
+				resBulk[i * _strideNode] = ResidualType(0.0);
+		}
+
+		// Copy over inlet ghost node
+		_inletC = y[comp];
+
+		// ----------------------------------------------------------------
+		// Step 1: auxiliary variable g = (2/deltaX) * dc/dx
+		// ----------------------------------------------------------------
+
+		StateType* g = reinterpret_cast<StateType*>(_auxState);
+		int strideNode_g = 1u;
+		int strideElem_g = _nNodes;
+
+		for (int i = 0; i < _nPoints; i++)
+			g[i] = StateType(0.0);
+
+		Eigen::Map<const Vector<StateType, Dynamic>, 0, InnerStride<Dynamic>> yMap(yBulk, _nPoints, InnerStride<Dynamic>(_strideNode));
+		Eigen::Map<Vector<StateType, Dynamic>, 0, InnerStride<>> gMap(g, _nPoints, InnerStride<>(strideNode_g));
+
+		// g = - D c
+		volumeIntegralAuxFrustumImpl<StateType, StateType>(yMap, gMap);
+
+		// c^{*,d} = 0.5 (c^- + c^+)
+		InterfaceFluxAuxiliaryFrustumImpl<StateType>(yBulk, _strideNode, _strideElem);
+
+		// g = - D c - M^{(0,0),-1} * B * [c - c*]
+		surfaceIntegralAuxFrustumImpl<StateType, StateType>(yBulk, g, _strideNode, _strideElem, strideNode_g, strideElem_g);
+
+		// g = 2/dx_i * (- D c - M^{(0,0),-1} * B * [c - c*])
+		gMap *= static_cast<StateType>(2.0 / _deltaX);
+
+		// ----------------------------------------------------------------
+		// Step 2: numerical fluxes c^{*,a} and g^{*,d}
+		// ----------------------------------------------------------------
+
+		// c^{*,a} = c^-, g^{*,d} = 0.5 (g^- + g^+)
+		computeNumericalFluxesFrustum<StateType>(yBulk);
+
+		// ----------------------------------------------------------------
+		// Step 3: main equation volume and surface integrals
+		// ----------------------------------------------------------------
+
+		surfaceIntegralMainFrustumImpl<StateType, ResidualType>(resBulk);
+
+		volumeIntegralMainFrustumImpl<StateType, ResidualType>(yBulk, resBulk, g);
+	}
+
+	return 0;
+}
+
+bool FrustumConvectionDispersionOperatorBaseDG::setParameter(const ParameterId& pId, double value)
+{
+	if (_dispersionDep && _dispersionDep->hasParameter(pId))
+	{
+		_dispersionDep->setParameter(pId, value);
+		return true;
+	}
+
+	if (!_dispersionCompIndep)
+		return false;
+
+	if ((pId.name != hashString("COL_DISPERSION")) || (pId.component != CompIndep) ||
+		(pId.boundState != BoundStateIndep) || (pId.reaction != ReactionIndep) ||
+		(pId.particleType != ParTypeIndep))
+		return false;
+
+	if (_colDispersion.size() > _nComp)
+	{
+		if (pId.section == SectionIndep) return false;
+		for (unsigned int i = 0; i < _nComp; ++i)
+			_colDispersion[pId.section * _nComp + i].setValue(value);
+	}
+	else
+	{
+		if (pId.section != SectionIndep) return false;
+		for (unsigned int i = 0; i < _nComp; ++i)
+			_colDispersion[i].setValue(value);
+	}
+	return true;
+}
+
+bool FrustumConvectionDispersionOperatorBaseDG::setSensitiveParameterValue(const std::unordered_set<active*>& sensParams, const ParameterId& pId, double value)
+{
+	if (_dispersionDep)
+	{
+		active* const param = _dispersionDep->getParameter(pId);
+		if (param) { param->setValue(value); return true; }
+				}
+
+	if (!_dispersionCompIndep)
+		return false;
+
+	if ((pId.name != hashString("COL_DISPERSION")) || (pId.component != CompIndep) ||
+		(pId.boundState != BoundStateIndep) || (pId.reaction != ReactionIndep) ||
+		(pId.particleType != ParTypeIndep))
+		return false;
+
+	if (_colDispersion.size() > _nComp)
+	{
+		if (pId.section == SectionIndep) return false;
+		if (!contains(sensParams, &_colDispersion[pId.section * _nComp])) return false;
+		for (unsigned int i = 0; i < _nComp; ++i)
+			_colDispersion[pId.section * _nComp + i].setValue(value);
+	}
+	else
+	{
+		if (pId.section != SectionIndep) return false;
+		if (!contains(sensParams, &_colDispersion[0])) return false;
+		for (unsigned int i = 0; i < _nComp; ++i)
+			_colDispersion[i].setValue(value);
+		}
+	return true;
+	}
+
+bool FrustumConvectionDispersionOperatorBaseDG::setSensitiveParameter(std::unordered_set<active*>& sensParams, const ParameterId& pId, unsigned int adDirection, double adValue)
+{
+	// No geometric and axial diffusion sensitivities available since that would dispatch active type DG operators which is currently not implemented
+	if (pId.name == hashString("COL_DISPERSION"))
+		throw InvalidParameterException("Sensitivities for COL_DISPERSION in frustum geometry are not supported.");
+	else if (pId.name == hashString("COL_RADIUS_LARGE_END"))
+		throw InvalidParameterException("Sensitivities for COL_RADIUS_LARGE_END in frustum geometry are not supported.");
+	else if (pId.name == hashString("COL_RADIUS_SMALL_END"))
+		throw InvalidParameterException("Sensitivities for COL_RADIUS_SMALL_END in frustum geometry are not supported.");
+	else if (pId.name == hashString("COL_LENGTH"))
+		throw InvalidParameterException("Sensitivities for COL_LENGTH in frustum geometry are not supported.");
+
+	return true;
 }
 
 template int AxialConvectionDispersionOperatorBaseDG::calcTransportJacobian<double>(const IModel&, double t, unsigned int secIdx, Eigen::SparseMatrix<double, RowMajor>&, Eigen::MatrixXd&, const int, const double* const);
 template int AxialConvectionDispersionOperatorBaseDG::calcTransportJacobian<active>(const IModel&, double t, unsigned int secIdx, Eigen::SparseMatrix<double, RowMajor>&, Eigen::MatrixXd&, const int, const active* const);
 template int RadialConvectionDispersionOperatorBaseDG::calcTransportJacobian<double>(const IModel&, double t, unsigned int secIdx, Eigen::SparseMatrix<double, RowMajor>&, Eigen::MatrixXd&, const int, const double* const);
 template int RadialConvectionDispersionOperatorBaseDG::calcTransportJacobian<active>(const IModel&, double t, unsigned int secIdx, Eigen::SparseMatrix<double, RowMajor>&, Eigen::MatrixXd&, const int, const active* const);
+template int FrustumConvectionDispersionOperatorBaseDG::calcTransportJacobian<double>(const IModel&, double, unsigned int, Eigen::SparseMatrix<double, RowMajor>&, Eigen::MatrixXd&, const int, const double* const);
+template int FrustumConvectionDispersionOperatorBaseDG::calcTransportJacobian<active>(const IModel&, double, unsigned int, Eigen::SparseMatrix<double, RowMajor>&, Eigen::MatrixXd&, const int, const active* const);
 
 }  // namespace parts
 

--- a/src/libcadet/model/parts/ConvectionDispersionOperatorDG.hpp
+++ b/src/libcadet/model/parts/ConvectionDispersionOperatorDG.hpp
@@ -1687,6 +1687,305 @@ namespace cadet
 				int residualImpl(const IModel& model, double t, unsigned int secIdx, StateType const* y, double const* yDot, ResidualType* res, RowIteratorType jacBegin);
 			};
 
+			/**
+			 * @brief Frustum convection dispersion transport operator based on a DG discretization
+			 * @details Implements the frustum (truncated cone) geometry transport equation.
+			 *          The cross-sectional area varies quadratically along the axial coordinate x:
+			 *          A(x) = pi * r(x)^2, where r(x) = r_0 + x/H * (r_H - r_0)
+			 *          Velocity: u(x) = velCoeff / r(x)^2, velCoeff = Q / (pi * eps)
+			 */
+			class FrustumConvectionDispersionOperatorBaseDG : public IConvectionDispersionOperatorBase1D
+			{
+			public:
+
+				FrustumConvectionDispersionOperatorBaseDG();
+				~FrustumConvectionDispersionOperatorBaseDG() CADET_NOEXCEPT;
+
+				void setFlowRates(const active& in, const active& out, const active& colPorosity) CADET_NOEXCEPT;
+
+				bool configureModelDiscretization(IParameterProvider& paramProvider, const IConfigHelper& helper, unsigned int nComp, unsigned int nelements, unsigned int polyDeg, unsigned int strideNode);
+				bool configure(UnitOpIdx unitOpIdx, IParameterProvider& paramProvider, std::unordered_map<ParameterId, active*>& parameters);
+				bool notifyDiscontinuousSectionTransition(double t, unsigned int secIdx, Eigen::MatrixXd& jacInlet);
+
+				int residual(const IModel& model, double t, unsigned int secIdx, double const* y, double const* yDot, double* res, Eigen::SparseMatrix<double, Eigen::RowMajor>& jac);
+				int residual(const IModel& model, double t, unsigned int secIdx, double const* y, double const* yDot, active* res, Eigen::SparseMatrix<double, Eigen::RowMajor>& jac);
+				int residual(const IModel& model, double t, unsigned int secIdx, double const* y, double const* yDot, double* res, WithoutParamSensitivity);
+				int residual(const IModel& model, double t, unsigned int secIdx, double const* y, double const* yDot, active* res, WithParamSensitivity);
+				int residual(const IModel& model, double t, unsigned int secIdx, active const* y, double const* yDot, active* res, WithParamSensitivity);
+				int residual(const IModel& model, double t, unsigned int secIdx, active const* y, double const* yDot, active* res, WithoutParamSensitivity);
+
+				template <typename StateType>
+				int calcTransportJacobian(const IModel&, double t, unsigned int secIdx, Eigen::SparseMatrix<double, RowMajor>& jacobian, Eigen::MatrixXd& jacInlet, const int bulkOffset, const StateType* const y);
+				int calcTransportJacobian(const IModel& model, double t, unsigned int secIdx, Eigen::SparseMatrix<double, RowMajor>& jacobian, Eigen::MatrixXd& jacInlet, int bulkOffset, double const* y) override;
+				int calcTransportJacobian(const IModel& model, double t, unsigned int secIdx, Eigen::SparseMatrix<double, RowMajor>& jacobian, Eigen::MatrixXd& jacInlet, int bulkOffset, active const* y) override;
+
+				typedef Eigen::Triplet<double> T;
+				void convDispJacPattern(std::vector<T>& tripletList, const int bulkOffset = 0) const override;
+				unsigned int nJacEntries(bool pureNNZ = false) const CADET_NOEXCEPT override;
+				void multiplyWithDerivativeJacobian(const SimulationTime& simTime, double const* sDot, double* ret) const override;
+				void addTimeDerivativeToJacobian(double alpha, Eigen::SparseMatrix<double, Eigen::RowMajor>& jacDisc, unsigned int blockOffset = 0) const override;
+
+				// Geometry accessors
+
+				inline double elemLeftBound(unsigned int idx) const CADET_NOEXCEPT
+				{
+					return idx * static_cast<double>(_deltaX);
+				}
+
+				double relativeCoordinate(unsigned int idx) const CADET_NOEXCEPT
+				{
+					const double x = floor(idx / _nNodes) * static_cast<double>(_deltaX)
+						+ 0.5 * static_cast<double>(_deltaX) * (1.0 + _nodes[idx % _nNodes]);
+					return x / static_cast<double>(_bedLength);
+				}
+
+				inline const double* nodes() const CADET_NOEXCEPT { return &_nodes[0]; }
+				inline const active* currentDispersion(const int secIdx) const CADET_NOEXCEPT { return getSectionDependentSlice(_colDispersion, _nComp, secIdx); }
+				inline bool dispersionCompIndep() const CADET_NOEXCEPT { return _dispersionCompIndep; }
+				inline bool forwardFlow() const CADET_NOEXCEPT { return _curFwdFlow; }
+				inline int flowDirection() const CADET_NOEXCEPT { return _curFwdFlow ? 1 : -1; }
+
+				inline unsigned int nComp() const CADET_NOEXCEPT { return _nComp; }
+				inline unsigned int nelements() const CADET_NOEXCEPT { return _nElem; }
+				inline unsigned int nNodes() const CADET_NOEXCEPT { return _nNodes; }
+				inline unsigned int nPoints() const CADET_NOEXCEPT { return _nPoints; }
+				inline bool hasSmoothnessIndicator() const CADET_NOEXCEPT { return false; }
+				inline int writeSmoothnessIndicator(double* buffer) const CADET_NOEXCEPT { return 0; }
+				inline int writeCoordinates(double* buffer) const CADET_NOEXCEPT
+				{
+					for (unsigned int i = 0; i < _nElem; i++)
+						for (unsigned int j = 0; j < _nNodes; j++)
+							buffer[i * _nNodes + j] = i * static_cast<double>(_deltaX)
+							+ 0.5 * static_cast<double>(_deltaX) * (1.0 + nodes()[j]);
+					return _nPoints;
+				}
+
+				// Indexer functionality
+				inline int strideColElement() const CADET_NOEXCEPT { return static_cast<int>(_strideElem); }
+				inline int strideColNode() const CADET_NOEXCEPT { return static_cast<int>(_strideNode); }
+				inline int strideColComp() const CADET_NOEXCEPT { return 1; }
+				inline int offsetC() const CADET_NOEXCEPT { return _nComp; }
+
+				unsigned int jacobianLowerBandwidth() const CADET_NOEXCEPT;
+				unsigned int jacobianUpperBandwidth() const CADET_NOEXCEPT;
+				double inletJacobianFactor() const CADET_NOEXCEPT;
+
+				unsigned int requiredADdirs() const CADET_NOEXCEPT override { return 4 * _nNodes * strideColNode() + 1; }
+
+				bool setParameter(const ParameterId& pId, double value);
+				bool setSensitiveParameter(std::unordered_set<active*>& sensParams, const ParameterId& pId, unsigned int adDirection, double adValue);
+				bool setSensitiveParameterValue(const std::unordered_set<active*>& sensParams, const ParameterId& id, double value);
+
+			protected:
+
+				// Discretization parameters
+				unsigned int _nComp;
+				unsigned int _polyDeg;
+				unsigned int _nElem;
+				unsigned int _nNodes;
+				unsigned int _nPoints;
+				unsigned int _filmDiffQuadDeg;
+				unsigned int _axDispQuadDeg;
+
+				unsigned int _strideNode;
+				unsigned int _strideElem;
+
+				// Column geometry
+				active _bedLength;						//!< bed length H (axial length)
+				active _colHeight;						//!< column height H, only applicable for radial flow geometry
+				active _radiusXStart;					//!< radius at domain start
+				active _radiusXEnd;					    //!< radius at domain end
+				std::vector<double> _crossSectionArea;	//!< Cross section area at each node
+
+				// DG operators
+				active _deltaX;					//!< Axial element spacing
+				Eigen::VectorXd _nodes;			//!< LGL nodes on [-1,1]
+				Eigen::VectorXd _invWeights;	//!< inverse LGL quadrature weights
+				Eigen::MatrixXd _polyDerM;		//!< polynomial derivative matrix D
+				Eigen::MatrixXd _M00;			//!< mass matrix M^{(0,0)}
+				Eigen::MatrixXd _invM00;		//!< inverse mass matrix (M^{(0,0)})^-1
+				std::vector<Eigen::MatrixXd> _invMM_A;						//!< per element inverse of the weighted mass matrix (w0 M^{(0,0) + w1 M^{(0,1) + w2 M^{(0,2)})^{-1}
+				std::vector<Eigen::MatrixXd> _invMM_A_times_ST_AD;			//!< Per-element matrix product (M^A)^-1 * D^T * \tilde{S}^{AD}
+				std::vector<Eigen::MatrixXd> _invMM_A_times_DT_timesM00;	//!< Per-element matrix product (M^A)^-1 * D^T * M^(0,0)
+
+				// Per-element Jacobian blocks
+				std::vector<Eigen::MatrixXd> _DGjacFrustumDispBlocks;
+				std::vector<Eigen::MatrixXd> _DGjacFrustumConvBlocks;
+
+				// Auxiliary state
+				active* _auxState;
+				active* _subsState;
+				Eigen::Vector<active, Eigen::Dynamic> _surfaceFluxC; // numerical interface flux used for c^{*,d} and c^{*,a}
+				Eigen::Vector<active, Eigen::Dynamic> _surfaceFluxG; // numerical interface flux used for g^{*,d}
+				active _inletC;
+
+				// Section dependent parameters
+				std::vector<active> _colDispersion;	//!< column dispersion D^x
+				active _flowRate;
+				active _QOverEps;	//!< flow rate divided by porosity (Q/eps)
+				std::vector<bool> _forwardFlow;
+				bool _curFwdFlow;
+
+				int _curSection;
+				bool _newStaticJac;
+
+				bool _dispersionCompIndep;
+				IParameterParameterDependence* _dispersionDep;
+
+				/* ===================================================================
+				 *  Geometry helpers
+				 * =================================================================== */
+
+				void computeGeometryFrustum();
+				void computeOperatorsFrustum();
+
+				/* ===================================================================
+				 *  Jacobian block helpers
+				 * =================================================================== */
+
+				Eigen::MatrixXd DGjacobianConvBlockFrustum(unsigned int elemIdx);
+				Eigen::MatrixXd DGjacobianDispBlockFrustum(unsigned int elemIdx);
+				Eigen::MatrixXd getGBlockFrustum(unsigned int elemIdx);
+				void calcConvDispFrustumDGSEMJacobian(Eigen::SparseMatrix<double, Eigen::RowMajor>& jacobian, Eigen::MatrixXd& jacInlet, const int offC);
+
+				/* ===================================================================
+				 *  Residual helpers (shared pattern with radial)
+				 * =================================================================== */
+
+				template<typename StateType>
+				void InterfaceFluxAuxiliaryFrustumImpl(const StateType* C, unsigned int strideNode, unsigned int strideElem)
+				{
+					// Central average for interior interfaces
+					for (unsigned int elem = 1; elem < _nElem; elem++)
+						_surfaceFluxC[elem] = 0.5 * (C[elem * strideElem - strideNode] + C[elem * strideElem]);
+					_surfaceFluxC[0] = C[0];
+					_surfaceFluxC[_nElem] = C[_nElem * strideElem - strideNode];
+				}
+
+				template<typename StateType, typename ResidualType>
+				void surfaceIntegralAuxFrustumImpl(const StateType* state, ResidualType* stateDer,
+					unsigned int strideNode_state, unsigned int strideElem_state,
+					unsigned int strideNode_stateDer, unsigned int strideElem_stateDer)
+				{
+					// g -= M^{(0,0),-1} * B * [c - c*]   (standard, no area weighting for aux eq)
+					for (unsigned int elem = 0; elem < _nElem; elem++)
+					{
+						for (unsigned int node = 0; node < _nNodes; node++)
+						{
+							stateDer[elem * strideElem_stateDer + node * strideNode_stateDer]
+								-= static_cast<ResidualType>(
+									_invM00(node, 0) * (state[elem * strideElem_state] - _surfaceFluxC[elem])
+									- _invM00(node, _polyDeg) * (state[elem * strideElem_state + _polyDeg * strideNode_state] - _surfaceFluxC[elem + 1])
+									);
+						}
+					}
+				}
+
+				template<typename StateType, typename ResidualType>
+				void volumeIntegralAuxFrustumImpl(
+					Eigen::Map<const Vector<StateType, Dynamic>, 0, InnerStride<Dynamic>>& state,
+					Eigen::Map<Vector<ResidualType, Dynamic>, 0, InnerStride<Dynamic>>& stateDer)
+				{
+					// g -= D * c   (standard derivative matrix, no area weighting)
+					for (unsigned int elem = 0; elem < _nElem; elem++)
+					{
+						if constexpr (std::is_same_v<StateType, double>)
+						{
+							if constexpr (std::is_same_v<ResidualType, double>)
+								stateDer.segment(elem * _nNodes, _nNodes) -= _polyDerM * state.segment(elem * _nNodes, _nNodes);
+							else
+								stateDer.segment(elem * _nNodes, _nNodes) -= (_polyDerM * state.segment(elem * _nNodes, _nNodes)).template cast<ResidualType>();
+						}
+						else
+							stateDer.segment(elem * _nNodes, _nNodes) -= _polyDerM.template cast<ResidualType>() * state.segment(elem * _nNodes, _nNodes);
+					}
+				}
+
+				template<typename StateType>
+				void computeNumericalFluxesFrustum(const StateType* C)
+				{
+					StateType* g = reinterpret_cast<StateType*>(_auxState);
+					const unsigned int strideNode_g = 1u;
+					const unsigned int strideElem_g = _nNodes;
+
+					// Interior interfaces: upwind c*, central g*
+					for (unsigned int elem = 1; elem < _nElem; elem++)
+					{
+						if (_curFwdFlow)
+							_surfaceFluxC[elem] = C[elem * _strideElem - _strideNode];
+						else
+							_surfaceFluxC[elem] = C[elem * _strideElem];
+
+						_surfaceFluxG[elem] = 0.5 * (g[elem * strideElem_g - strideNode_g] + g[elem * strideElem_g]);
+					}
+
+					// Boundary interfaces
+					if (_curFwdFlow)
+					{
+						// Inlet at x=0
+						_surfaceFluxC[0] = static_cast<StateType>(_inletC);
+						_surfaceFluxG[0] = StateType(0.0);
+						// Outlet at x=H
+						_surfaceFluxC[_nElem] = C[_nElem * _strideElem - _strideNode];
+						_surfaceFluxG[_nElem] = StateType(0.0);
+					}
+					else
+					{
+						// Inlet at x=H for backward flow
+						_surfaceFluxC[_nElem] = static_cast<StateType>(_inletC);
+						_surfaceFluxG[_nElem] = StateType(0.0);
+						// Outlet at x=0
+						_surfaceFluxC[0] = C[0];
+						_surfaceFluxG[0] = StateType(0.0);
+					}
+				}
+
+				template<typename StateType, typename ResidualType>
+				void surfaceIntegralMainFrustumImpl(ResidualType* res)
+				{
+					for (unsigned int elem = 0; elem < _nElem; elem++)
+					{
+						const double Aleft = _crossSectionArea[elem * _nNodes];
+						const double Aright = _crossSectionArea[(elem + 1) * _nNodes - 1];
+
+						ResidualType left_flux = static_cast<ResidualType>(
+							-_QOverEps * _surfaceFluxC[elem]
+							- Aleft * _colDispersion[0] * _surfaceFluxG[elem]
+							);
+
+						ResidualType right_flux = static_cast<ResidualType>(
+							+_QOverEps * _surfaceFluxC[elem + 1]
+							+ Aright * _colDispersion[0] * _surfaceFluxG[elem + 1]
+							);
+
+						for (unsigned int node = 0; node < _nNodes; node++)
+						{
+							res[elem * _strideElem + node * _strideNode]
+								+= static_cast<ResidualType>(2.0 / _deltaX) * (
+									_invMM_A[elem](node, 0) * left_flux
+									+ _invMM_A[elem](node, _nNodes - 1) * right_flux
+									);
+						}
+					}
+				}
+
+				template<typename StateType, typename ResidualType>
+				void volumeIntegralMainFrustumImpl(const StateType* c, ResidualType* res, const StateType* g)
+				{
+					for (int elem = 0; elem < _nElem; elem++)
+					{
+						Eigen::Map<const Vector<StateType, Dynamic>, 0, InnerStride<Dynamic>> cMap(c + elem * strideColElement(), _nNodes, InnerStride<Dynamic>(strideColNode()));
+						Eigen::Map<const Vector<StateType, Dynamic>, 0, InnerStride<Dynamic>> gMap(g + elem * _nNodes, _nNodes, InnerStride<Dynamic>(1));
+						Eigen::Map<Vector<ResidualType, Dynamic>, 0, InnerStride<Dynamic>> resMap(res + elem * strideColElement(), _nNodes, InnerStride<Dynamic>(strideColNode()));
+
+						resMap -= 2.0 / static_cast<ResidualType>(_deltaX) * (static_cast<ResidualType>(_QOverEps) * (_invMM_A_times_DT_timesM00[elem] * cMap).template cast<ResidualType>()
+							+ (_invMM_A_times_ST_AD[elem] * gMap).template cast<ResidualType>());
+					}
+				}
+
+				template <typename StateType, typename ResidualType, typename ParamType, typename RowIteratorType, bool wantJac>
+				int residualImpl(const IModel& model, double t, unsigned int secIdx, StateType const* y, double const* yDot, ResidualType* res, RowIteratorType jacBegin);
+			};
 
 		} // namespace parts
 	} // namespace model

--- a/test/ColumnModel1D.cpp
+++ b/test/ColumnModel1D.cpp
@@ -861,6 +861,9 @@ TEST_CASE("Radial Column_1D as GRM LWE forward vs backward flow", "[RadialColumn
 {
 	cadet::test::column::DGParams disc;
 
+	// Note that we don't get the exact same result for forward and backward flow due to the radial geometry,
+	// which is why we have to apply rather loose tolerances here.
+
 	// Test both interpolation nodes
 	disc.setBulkDiscParam("POLYNOMIAL_INTERPOLATION_NODES", "LEGENDRE_GAUSS_LOBATTO");
 	cadet::test::column::testForwardBackward("RADIAL_COLUMN_MODEL_1D_GRM", disc, 1e-9, 1e-4);
@@ -1206,4 +1209,22 @@ TEST_CASE("Radial Column_1D pure convection dispersion numerical benchmark", "[R
 
 	cadet::test::column::DGParams disc(1, 3, 16);
 	cadet::test::column::testReferenceBenchmark(modelFilePath, refFilePath, "001", absTol, relTol, disc, false);
+}
+
+TEST_CASE("Frustum Column_1D as GRM transport Jacobian", "[FrustumColumn1D],[DG],[UnitOp],[Jacobian],[CI]")
+{
+	cadet::JsonParameterProvider jpp = createColumnLinearBenchmark(false, true, "FRUSTUM_COLUMN_MODEL_1D_GRM", "DG");
+
+	std::vector<double> flowRate;
+	flowRate.push_back(0.01);
+
+	cadet::test::column::testJacobianAD(jpp, std::numeric_limits<float>::epsilon() * 100.0, std::numeric_limits<float>::epsilon() * 100.0, flowRate);
+}
+
+TEST_CASE("Frustum Column_1D as GRM LWE forward vs backward flow", "[FrustumColumn1D],[DG],[DG1D],[Simulation],[CI]")
+{
+	cadet::test::column::DGParams disc;
+	// Note: this test internally sets COL_RADIUS_SMALL_END=COL_RADIUS_LARGE_END so that forward and backward flow
+	// actually yield the same result for the frustum geometry.
+	cadet::test::column::testForwardBackward("FRUSTUM_COLUMN_MODEL_1D_GRM", disc, 1e-10, 1e-6);
 }

--- a/test/ColumnModel1D.cpp
+++ b/test/ColumnModel1D.cpp
@@ -58,7 +58,7 @@ TEST_CASE("Column_1D as GRM with FV equivalence with arrow head implementation",
 	jpp1.popScope();
 	jpp1.popScope();
 
-	cadet::test::column::testEqualResults(jpp1, jpp2, 1e-10, 1e-8);
+	cadet::test::column::testEqualResults(jpp1, jpp2, 1e-10, 1e-8, 0);
 }
 
 TEST_CASE("Column_1D as radial flow LRMP with FV equivalence with arrow head implementation", "[Column_1D],[FV],[Simulation],[CI]")
@@ -94,7 +94,7 @@ TEST_CASE("Column_1D as radial flow LRMP with FV equivalence with arrow head imp
 	jpp1.popScope();
 	jpp1.popScope();
 
-	cadet::test::column::testEqualResults(jpp1, jpp2, 1e-10, 1e-8);
+	cadet::test::column::testEqualResults(jpp1, jpp2, 1e-10, 1e-8, 0);
 }
 
 TEST_CASE("Column_1D as frustum LRMP with FV equivalence with arrow head implementation", "[Column_1D],[FV],[Simulation],[CI]")
@@ -130,7 +130,7 @@ TEST_CASE("Column_1D as frustum LRMP with FV equivalence with arrow head impleme
 	jpp1.popScope();
 	jpp1.popScope();
 
-	cadet::test::column::testEqualResults(jpp1, jpp2, 1e-10, 1e-8);
+	cadet::test::column::testEqualResults(jpp1, jpp2, 1e-10, 1e-8, 0);
 }
 
 TEST_CASE("Column_1D as GRM with FV transport Jacobian", "[Column_1D],[FV],[UnitOp],[Jacobian],[CI]")

--- a/test/ColumnModel1D.cpp
+++ b/test/ColumnModel1D.cpp
@@ -25,7 +25,7 @@
 #include "common/Driver.hpp"
 
 
-TEST_CASE("Column_1D as GRM with FV equivalence with arrow head implementation", "[Column_1D],[FV],[Simulation],[CI]")
+TEST_CASE("Column_1D as axial GRM with FV equivalence with arrow head implementation", "[AxialColumn1D],[FV],[Simulation],[CI]")
 {
 	cadet::JsonParameterProvider jpp1 = createLWE("COLUMN_MODEL_1D_GRM", "FV");
 	cadet::JsonParameterProvider jpp2 = createLWE("COLUMN_MODEL_1D_GRM", "FV");
@@ -61,7 +61,7 @@ TEST_CASE("Column_1D as GRM with FV equivalence with arrow head implementation",
 	cadet::test::column::testEqualResults(jpp1, jpp2, 1e-10, 1e-8, 0);
 }
 
-TEST_CASE("Column_1D as radial flow LRMP with FV equivalence with arrow head implementation", "[Column_1D],[FV],[Simulation],[CI]")
+TEST_CASE("Column_1D as radial flow LRMP with FV equivalence with arrow head implementation", "[AxialColumn1D],[FV],[Simulation],[CI]")
 {
 	cadet::JsonParameterProvider jpp1 = createLWE("RADIAL_COLUMN_MODEL_1D_LRMP", "FV");
 	cadet::JsonParameterProvider jpp2 = createLWE("RADIAL_COLUMN_MODEL_1D_LRMP", "FV");
@@ -97,7 +97,7 @@ TEST_CASE("Column_1D as radial flow LRMP with FV equivalence with arrow head imp
 	cadet::test::column::testEqualResults(jpp1, jpp2, 1e-10, 1e-8, 0);
 }
 
-TEST_CASE("Column_1D as frustum LRMP with FV equivalence with arrow head implementation", "[Column_1D],[FV],[Simulation],[CI]")
+TEST_CASE("Column_1D as frustum LRMP with FV equivalence with arrow head implementation", "[AxialColumn1D],[FV],[Simulation],[CI]")
 {
 	cadet::JsonParameterProvider jpp1 = createLWE("FRUSTUM_COLUMN_MODEL_1D_LRMP", "FV");
 	cadet::JsonParameterProvider jpp2 = createLWE("FRUSTUM_COLUMN_MODEL_1D_LRMP", "FV");
@@ -133,7 +133,7 @@ TEST_CASE("Column_1D as frustum LRMP with FV equivalence with arrow head impleme
 	cadet::test::column::testEqualResults(jpp1, jpp2, 1e-10, 1e-8, 0);
 }
 
-TEST_CASE("Column_1D as GRM with FV transport Jacobian", "[Column_1D],[FV],[UnitOp],[Jacobian],[CI]")
+TEST_CASE("Column_1D as GRM with FV transport Jacobian", "[AxialColumn1D],[FV],[UnitOp],[Jacobian],[CI]")
 {
 	cadet::JsonParameterProvider jpp = createColumnLinearBenchmark(false, true, "COLUMN_MODEL_1D_GRM", "FV");
 
@@ -144,7 +144,7 @@ TEST_CASE("Column_1D as GRM with FV transport Jacobian", "[Column_1D],[FV],[Unit
 	cadet::test::column::testJacobianAD(jpp, std::numeric_limits<float>::epsilon() * 100.0);
 }
 
-TEST_CASE("Column_1D as GRM LWE forward vs backward flow", "[Column_1D],[DG],[DG1D],[Simulation],[CI]")
+TEST_CASE("Column_1D as GRM LWE forward vs backward flow", "[AxialColumn1D],[DG],[DG1D],[Simulation],[CI]")
 {
 	cadet::test::column::DGParams disc;
 
@@ -156,7 +156,7 @@ TEST_CASE("Column_1D as GRM LWE forward vs backward flow", "[Column_1D],[DG],[DG
 	}
 }
 
-TEST_CASE("Column_1D as GRM linear pulse vs analytic solution", "[Column_1D],[DG],[DG1D],[Simulation],[Analytic],[CI]")
+TEST_CASE("Column_1D as GRM linear pulse vs analytic solution", "[AxialColumn1D],[DG],[DG1D],[Simulation],[Analytic],[CI]")
 {
 	cadet::test::column::DGParams disc;
 	cadet::test::column::testAnalyticBenchmark("COLUMN_MODEL_1D_GRM", "/data/grm-pulseBenchmark.data", true, true, disc, 6e-5, 1e-7);
@@ -165,7 +165,7 @@ TEST_CASE("Column_1D as GRM linear pulse vs analytic solution", "[Column_1D],[DG
 	cadet::test::column::testAnalyticBenchmark("COLUMN_MODEL_1D_GRM", "/data/grm-pulseBenchmark.data", false, false, disc, 6e-5, 1e-7);
 }
 
-TEST_CASE("Column_1D as GRM linear pulse vs analytic solution with bulk DG and particle FV discretization", "[Column_1D],[DGFV],[Simulation],[Analytic],[CI]")
+TEST_CASE("Column_1D as GRM linear pulse vs analytic solution with bulk DG and particle FV discretization", "[AxialColumn1D],[DGFV],[Simulation],[Analytic],[CI]")
 {
 	auto discDGFV = cadet::test::column::createDGFVParams(0, 3, 15, 0, 0, 5);
 	cadet::test::column::testAnalyticBenchmark("COLUMN_MODEL_1D_GRM", "/data/grm-pulseBenchmark.data", true, true, *discDGFV, "DGFV", 6e-5, 1e-7);
@@ -174,7 +174,7 @@ TEST_CASE("Column_1D as GRM linear pulse vs analytic solution with bulk DG and p
 	cadet::test::column::testAnalyticBenchmark("COLUMN_MODEL_1D_GRM", "/data/grm-pulseBenchmark.data", false, false, *discDGFV, "DGFV", 6e-5, 1e-7);
 }
 
-TEST_CASE("Column_1D as LRMP linear pulse vs analytic solution", "[Column_1D],[DG],[DG1D],[Simulation],[Analytic],[CI]")
+TEST_CASE("Column_1D as LRMP linear pulse vs analytic solution", "[AxialColumn1D],[DG],[DG1D],[Simulation],[Analytic],[CI]")
 {
 	cadet::test::column::DGParams disc;
 	cadet::test::column::testAnalyticBenchmark("COLUMN_MODEL_1D_LRMP", "/data/lrmp-pulseBenchmark.data", true, true, disc, 6e-5, 1e-7);
@@ -183,28 +183,28 @@ TEST_CASE("Column_1D as LRMP linear pulse vs analytic solution", "[Column_1D],[D
 	cadet::test::column::testAnalyticBenchmark("COLUMN_MODEL_1D_LRMP", "/data/lrmp-pulseBenchmark.data", false, false, disc, 6e-5, 1e-7);
 }
 
-TEST_CASE("Column_1D as GRM non-binding linear pulse vs analytic solution", "[Column_1D],[DG],[DG1D],[Simulation],[Analytic],[NonBinding],[CI]")
+TEST_CASE("Column_1D as GRM non-binding linear pulse vs analytic solution", "[AxialColumn1D],[DG],[DG1D],[Simulation],[Analytic],[NonBinding],[CI]")
 {
 	cadet::test::column::DGParams disc;
 	cadet::test::column::testAnalyticNonBindingBenchmark("COLUMN_MODEL_1D_GRM", "/data/grm-nonBinding.data", true, disc, 6e-5, 1e-7);
 	cadet::test::column::testAnalyticNonBindingBenchmark("COLUMN_MODEL_1D_GRM", "/data/grm-nonBinding.data", false, disc, 6e-5, 1e-7);
 }
 
-TEST_CASE("Column_1D as LRMP non-binding linear pulse vs analytic solution", "[Column_1D],[DG],[DG1D],[Simulation],[Analytic],[NonBinding],[CI]")
+TEST_CASE("Column_1D as LRMP non-binding linear pulse vs analytic solution", "[AxialColumn1D],[DG],[DG1D],[Simulation],[Analytic],[NonBinding],[CI]")
 {
 	cadet::test::column::DGParams disc;
 	cadet::test::column::testAnalyticNonBindingBenchmark("COLUMN_MODEL_1D_LRMP", "/data/lrmp-nonBinding.data", true, disc, 6e-5, 1e-7);
 	cadet::test::column::testAnalyticNonBindingBenchmark("COLUMN_MODEL_1D_LRMP", "/data/lrmp-nonBinding.data", false, disc, 6e-5, 1e-7);
 }
 
-TEST_CASE("Column_1D as GRM Jacobian forward vs backward flow", "[Column_1D],[DG],[DG1D],[UnitOp],[Residual],[Jacobian],[AD],[CI]")
+TEST_CASE("Column_1D as GRM Jacobian forward vs backward flow", "[AxialColumn1D],[DG],[DG1D],[UnitOp],[Residual],[Jacobian],[AD],[CI]")
 {
 	cadet::test::column::DGParams disc;
 	disc.setBulkDiscParam("POLYNOMIAL_INTEGRATION_TYPE", 1);
 	cadet::test::column::testJacobianForwardBackward("COLUMN_MODEL_1D_GRM", disc, std::numeric_limits<float>::epsilon() * 100.0);
 }
 
-TEST_CASE("Column_1D as DPF numerical Benchmark1", "[Column_1D],[DG],[DG1D],[Simulation],[Reference],[Sensitivity],[CI]")
+TEST_CASE("Column_1D as DPF numerical Benchmark1", "[AxialColumn1D],[DG],[DG1D],[Simulation],[Reference],[Sensitivity],[CI]")
 {
 	std::string modelFilePath = std::string("/data/model_COL1D_DPFR_1comp_benchmark1.json");
 	std::string refFilePath = std::string("/data/ref_COL1D_DPFR_1comp_benchmark1_DG_P3Z8.h5");
@@ -215,7 +215,7 @@ TEST_CASE("Column_1D as DPF numerical Benchmark1", "[Column_1D],[DG],[DG1D],[Sim
 	cadet::test::column::testReferenceBenchmark(modelFilePath, refFilePath, "001", absTol, relTol, disc, true);
 }
 
-TEST_CASE("Column_1D as GRM numerical Benchmark1 with parameter sensitivities for linear case", "[Column_1D],[DG],[DG1D],[Simulation],[Reference],[Sensitivity],[CI_sens17]")
+TEST_CASE("Column_1D as GRM numerical Benchmark1 with parameter sensitivities for linear case", "[AxialColumn1D],[DG],[DG1D],[Simulation],[Reference],[Sensitivity],[CI_sens17]")
 {
 	std::string modelFilePath = std::string("/data/model_COL1D_GRM_dynLin_1comp_benchmark1.json");
 	std::string refFilePath = std::string("/data/ref_GRM_dynLin_1comp_sensbenchmark1_cDG_P3Z8_GSM_parP3parZ1.h5");
@@ -226,7 +226,7 @@ TEST_CASE("Column_1D as GRM numerical Benchmark1 with parameter sensitivities fo
 	cadet::test::column::testReferenceBenchmark(modelFilePath, refFilePath, "001", absTol, relTol, disc, true);
 }
 
-TEST_CASE("Column_1D as GRM numerical Benchmark1 for linear case with surface diffusion", "[Column_1D],[DG],[DG1D],[Simulation],[Reference],[Sensitivity],[CI]")
+TEST_CASE("Column_1D as GRM numerical Benchmark1 for linear case with surface diffusion", "[AxialColumn1D],[DG],[DG1D],[Simulation],[Reference],[Sensitivity],[CI]")
 {
 	std::string modelFilePath = std::string("/data/model_COL1D_GRMsd_dynLin_1comp_benchmark1.json");
 	std::string refFilePath = std::string("/data/ref_COL1D_GRMsd_dynLin_1comp_benchmark1_cDG_P3Z8_GSM_parP3parZ1.h5");
@@ -237,7 +237,7 @@ TEST_CASE("Column_1D as GRM numerical Benchmark1 for linear case with surface di
 	cadet::test::column::testReferenceBenchmark(modelFilePath, refFilePath, "001", absTol, relTol, disc, false);
 }
 
-TEST_CASE("Column_1D as LRMP numerical Benchmark with parameter sensitivities for linear case", "[Column_1D],[DG],[DG1D],[Simulation],[Reference],[Sensitivity],[CI_sens22]")
+TEST_CASE("Column_1D as LRMP numerical Benchmark with parameter sensitivities for linear case", "[AxialColumn1D],[DG],[DG1D],[Simulation],[Reference],[Sensitivity],[CI_sens22]")
 {
 	const std::string& modelFilePath = std::string("/data/model_COL1D_LRMP_dynLin_1comp_benchmark1.json");
 	const std::string& refFilePath = std::string("/data/ref_LRMP_dynLin_1comp_sensbenchmark1_DG_P3Z8.h5");
@@ -248,7 +248,7 @@ TEST_CASE("Column_1D as LRMP numerical Benchmark with parameter sensitivities fo
 	cadet::test::column::testReferenceBenchmark(modelFilePath, refFilePath, "001", absTol, relTol, disc, true);
 }
 
-TEST_CASE("Column_1D as pseudo-LRMP (GRM with single FV cell) numerical Benchmark with parameter sensitivities for linear case", "[Column_1D],[DGFV],[Simulation],[Reference],[Sensitivity],[CI_sens25]")
+TEST_CASE("Column_1D as pseudo-LRMP (GRM with single FV cell) numerical Benchmark with parameter sensitivities for linear case", "[AxialColumn1D],[DGFV],[Simulation],[Reference],[Sensitivity],[CI_sens25]")
 {
 	const std::string& modelFilePath = std::string("/data/model_COL1D_pseudoGRM_dynLin_1comp_benchmark1.json");
 	const std::string& refFilePath = std::string("/data/ref_LRMP_dynLin_1comp_sensbenchmark1_DG_P3Z8.h5");
@@ -261,7 +261,7 @@ TEST_CASE("Column_1D as pseudo-LRMP (GRM with single FV cell) numerical Benchmar
 	cadet::test::column::testReferenceBenchmark(modelFilePath, refFilePath, "001", absTol, relTol, *discDGFV, true);
 }
 
-TEST_CASE("Column_1D as GRM numerical Benchmark2 with parameter sensitivities for linear case", "[Column_1D],[DG],[DG1D],[Simulation],[Reference],[Sensitivity],[CI_sens18]")
+TEST_CASE("Column_1D as GRM numerical Benchmark2 with parameter sensitivities for linear case", "[AxialColumn1D],[DG],[DG1D],[Simulation],[Reference],[Sensitivity],[CI_sens18]")
 {
 	std::string modelFilePath = std::string("/data/model_COL1D_GRM_dynLin_1comp_sensbenchmark2.json");
 	std::string refFilePath = std::string("/data/ref_GRM_dynLin_1comp_sensbenchmark2_cDG_P3Z8_GSM_parP3parZ1.h5");
@@ -272,7 +272,7 @@ TEST_CASE("Column_1D as GRM numerical Benchmark2 with parameter sensitivities fo
 	cadet::test::column::testReferenceBenchmark(modelFilePath, refFilePath, "001", absTol, relTol, disc, true);
 }
 
-TEST_CASE("Column_1D as GRM numerical Benchmark with parameter sensitivities and multiplexing for 2parType 2comp linear case", "[Column_1D],[DG],[DG1D],[Simulation],[Reference],[Sensitivity],[CI_sens19]")
+TEST_CASE("Column_1D as GRM numerical Benchmark with parameter sensitivities and multiplexing for 2parType 2comp linear case", "[AxialColumn1D],[DG],[DG1D],[Simulation],[Reference],[Sensitivity],[CI_sens19]")
 {
 	const std::string modelFilePath = std::string("/data/model_COL1DparType2_GRM_dynLin_2comp_sensbenchmark1.json");
 	const std::string refFilePath = std::string("/data/ref_GRMparType2_dynLin_2comp_sensbenchmark1_cDG_P3Z4_DGexInt_parP3parZ2.h5");
@@ -283,7 +283,7 @@ TEST_CASE("Column_1D as GRM numerical Benchmark with parameter sensitivities and
 	cadet::test::column::testReferenceBenchmark(modelFilePath, refFilePath, "001", absTol, relTol, disc, true);
 }
 
-TEST_CASE("Column_1D as GRM numerical Benchmark with parameter sensitivities for SMA LWE case", "[Column_1D],[DG],[DG1D],[Simulation],[Reference],[Sensitivity],[CI_sens20]")
+TEST_CASE("Column_1D as GRM numerical Benchmark with parameter sensitivities for SMA LWE case", "[AxialColumn1D],[DG],[DG1D],[Simulation],[Reference],[Sensitivity],[CI_sens20]")
 {
 	const std::string modelFilePath = std::string("/data/model_COL1D_GRM_reqSMA_4comp_benchmark1.json");
 	const std::string refFilePath = std::string("/data/ref_GRM_reqSMA_4comp_sensbenchmark1_exIntDG_P3Z8_GSM_parP3parZ1.h5");
@@ -294,7 +294,7 @@ TEST_CASE("Column_1D as GRM numerical Benchmark with parameter sensitivities for
 	cadet::test::column::testReferenceBenchmark(modelFilePath, refFilePath, "000", absTol, relTol, disc, true);
 }
 
-TEST_CASE("Column_1D as LRMP numerical Benchmark with parameter sensitivities for SMA LWE case", "[Column_1D],[DG],[DG1D],[Simulation],[Reference],[Sensitivity],[CI_sens23]")
+TEST_CASE("Column_1D as LRMP numerical Benchmark with parameter sensitivities for SMA LWE case", "[AxialColumn1D],[DG],[DG1D],[Simulation],[Reference],[Sensitivity],[CI_sens23]")
 {
 	const std::string& modelFilePath = std::string("/data/model_COL1D_LRMP_reqSMA_4comp_benchmark1.json");
 	const std::string& refFilePath = std::string("/data/ref_LRMP_reqSMA_4comp_sensbenchmark1_DG_P3Z8.h5");
@@ -305,7 +305,7 @@ TEST_CASE("Column_1D as LRMP numerical Benchmark with parameter sensitivities fo
 	cadet::test::column::testReferenceBenchmark(modelFilePath, refFilePath, "000", absTol, relTol, disc, true);
 }
 
-TEST_CASE("Column_1D with mixed general rate and homogeneous particle types and linear binding numerical Benchmark with parameter sensitivities", "[Column_1D],[DG],[DG1D],[Simulation],[Reference],[Sensitivity],[CI_sens24]")
+TEST_CASE("Column_1D with mixed general rate and homogeneous particle types and linear binding numerical Benchmark with parameter sensitivities", "[AxialColumn1D],[DG],[DG1D],[Simulation],[Reference],[Sensitivity],[CI_sens24]")
 {
 	const std::string& modelFilePath = std::string("/data/model_COL1D_2parTypeMixed_2comp_benchmark1.json");
 	const std::string& refFilePath = std::string("/data/ref_COL1D_2parTypeMixed_2comp_benchmark1.h5");
@@ -316,7 +316,7 @@ TEST_CASE("Column_1D with mixed general rate and homogeneous particle types and 
 	cadet::test::column::testReferenceBenchmark(modelFilePath, refFilePath, "001", absTol, relTol, disc, true);
 }
 
-TEST_CASE("Column_1D as GRM LWE DGSEM and GSM particle discretization yields similar accuracy", "[Column_1D],[DG],[DG1D],[Simulation],[CI]")
+TEST_CASE("Column_1D as GRM LWE DGSEM and GSM particle discretization yields similar accuracy", "[AxialColumn1D],[DG],[DG1D],[Simulation],[CI]")
 {
 	cadet::JsonParameterProvider jpp = createLWE("COLUMN_MODEL_1D_GRM", "DG");
 	cadet::test::column::DGParams disc(0, 4, 2, 3, 1); // Note that we want to employ only a single particle element
@@ -358,24 +358,24 @@ TEST_CASE("Column_1D as GRM LWE DGSEM and GSM particle discretization yields sim
 	}
 }
 
-TEST_CASE("Column_1D as GRM time derivative Jacobian vs FD", "[Column_1D],[DG],[DG1D],[UnitOp],[Residual],[Jacobian],[CI],[FD]")
+TEST_CASE("Column_1D as GRM time derivative Jacobian vs FD", "[AxialColumn1D],[DG],[DG1D],[UnitOp],[Residual],[Jacobian],[CI],[FD]")
 {
 	cadet::test::column::testTimeDerivativeJacobianFD("COLUMN_MODEL_1D_GRM", "DG", 1e-6, 0.0, 9e-4);
 }
 
-TEST_CASE("Column_1D as LRMP time derivative Jacobian vs FD", "[Column_1D],[DG],[DG1D],[UnitOp],[Residual],[Jacobian],[CI]")
+TEST_CASE("Column_1D as LRMP time derivative Jacobian vs FD", "[AxialColumn1D],[DG],[DG1D],[UnitOp],[Residual],[Jacobian],[CI]")
 {
 	cadet::test::column::testTimeDerivativeJacobianFD("COLUMN_MODEL_1D_LRMP", "DG");
 }
 
-TEST_CASE("Column_1D as GRM sensitivity Jacobians", "[Column_1D],[DG],[DG1D],[UnitOp],[Sensitivity],[CI]")
+TEST_CASE("Column_1D as GRM sensitivity Jacobians", "[AxialColumn1D],[DG],[DG1D],[UnitOp],[Sensitivity],[CI]")
 {
 	cadet::JsonParameterProvider jpp = createColumnWithTwoCompLinearBinding("COLUMN_MODEL_1D_GRM", "DG");
 
 	cadet::test::column::testFwdSensJacobians(jpp, 1e-4, 6e-7, 1e-4);
 }
 
-TEST_CASE("Column_1D as LRMP sensitivity Jacobians", "[Column_1D],[DG],[DG1D],[UnitOp],[Sensitivity],[CI]")
+TEST_CASE("Column_1D as LRMP sensitivity Jacobians", "[AxialColumn1D],[DG],[DG1D],[UnitOp],[Sensitivity],[CI]")
 {
 	cadet::JsonParameterProvider jpp = createColumnWithTwoCompLinearBinding("COLUMN_MODEL_1D_LRMP", "DG");
 
@@ -383,7 +383,7 @@ TEST_CASE("Column_1D as LRMP sensitivity Jacobians", "[Column_1D],[DG],[DG1D],[U
 }
 
 //// todo fix: not just adjust tolerances as in FV but theres an actual error here: access violation in densematrix
-//TEST_CASE("Column_1D as GRM forward sensitivity vs FD", "[Column_1D],[DG],[DG1D],[Sensitivity],[Simulation],[todo]")
+//TEST_CASE("Column_1D as GRM forward sensitivity vs FD", "[AxialColumn1D],[DG],[DG1D],[Sensitivity],[Simulation],[todo]")
 //{
 //	// Relative error is checked first, we use high absolute error for letting
 //	// some points that are far off pass the error test, too. This is required
@@ -396,7 +396,7 @@ TEST_CASE("Column_1D as LRMP sensitivity Jacobians", "[Column_1D],[DG],[DG1D],[U
 //}
 
 //// todo fix: not just adjust tolerances as in FV but theres an actual error here: access violation in densematrix
-//TEST_CASE("Column_1D as GRM forward sensitivity forward vs backward flow", "[Column_1D],[DG],[DG1D],[Sensitivity],[Simulation],[todo]")
+//TEST_CASE("Column_1D as GRM forward sensitivity forward vs backward flow", "[AxialColumn1D],[DG],[DG1D],[Sensitivity],[Simulation],[todo]")
 //{
 //	const double absTols[] = { 4e-5, 1e-11, 1e-11, 8e-9 };
 //	const double relTols[] = { 6e-9, 5e-8, 5e-6, 5e-10 };
@@ -405,7 +405,7 @@ TEST_CASE("Column_1D as LRMP sensitivity Jacobians", "[Column_1D],[DG],[DG1D],[U
 //}
 
 // todo fix consistent initialization for AD with req binding
-TEST_CASE("Column_1D as GRM consistent initialization with linear binding", "[Column_1D],[DG],[DG1D],[ConsistentInit],[CI]")
+TEST_CASE("Column_1D as GRM consistent initialization with linear binding", "[AxialColumn1D],[DG],[DG1D],[ConsistentInit],[CI]")
 {
 	cadet::test::column::testConsistentInitializationLinearBinding("COLUMN_MODEL_1D_GRM", "DG", 1e-12, 1e-14, 0, 0);
 	cadet::test::column::testConsistentInitializationLinearBinding("COLUMN_MODEL_1D_GRM", "DG", 1e-12, 1e-12, 1, 0);
@@ -414,7 +414,7 @@ TEST_CASE("Column_1D as GRM consistent initialization with linear binding", "[Co
 }
 
 // todo fix consistent initialization for AD with req binding
-TEST_CASE("Column_1D as LRMP consistent initialization with linear binding", "[Column_1D],[DG],[DG1D],[ConsistentInit],[CI]")
+TEST_CASE("Column_1D as LRMP consistent initialization with linear binding", "[AxialColumn1D],[DG],[DG1D],[ConsistentInit],[CI]")
 {
 	cadet::test::column::testConsistentInitializationLinearBinding("COLUMN_MODEL_1D_LRMP", "DG", 1e-12, 1e-12, 0, 0);
 	cadet::test::column::testConsistentInitializationLinearBinding("COLUMN_MODEL_1D_LRMP", "DG", 1e-12, 1e-12, 1, 0);
@@ -423,7 +423,7 @@ TEST_CASE("Column_1D as LRMP consistent initialization with linear binding", "[C
 }
 
 //// todo fix consistent initialization for SMA (initialization not completely correct; AD gives assertion error)
-//TEST_CASE("Column_1D as GRM consistent initialization with SMA binding", "[Column_1D],[DG],[DG1D],[ConsistentInit],[todo]")
+//TEST_CASE("Column_1D as GRM consistent initialization with SMA binding", "[AxialColumn1D],[DG],[DG1D],[ConsistentInit],[todo]")
 //{
 //	std::vector<double> y(4 + 4 * 16 + 16 * 4 * (4 + 4) + 4 * 16, 0.0);
 //	// Optimal values:
@@ -439,7 +439,7 @@ TEST_CASE("Column_1D as LRMP consistent initialization with linear binding", "[C
 //}
 
 // todo fix kinetic binding sensitivity init
-TEST_CASE("Column_1D as GRM consistent sensitivity initialization with linear binding", "[Column_1D],[DG],[DG1D],[ConsistentInit],[Sensitivity],[CI]")
+TEST_CASE("Column_1D as GRM consistent sensitivity initialization with linear binding", "[AxialColumn1D],[DG],[DG1D],[ConsistentInit],[Sensitivity],[CI]")
 {
 	// Fill state vector with given initial values
 	const unsigned int numDofs = 4 + 4 * 16 + 16 * 4 * (4 + 4) + 4 * 16;
@@ -455,7 +455,7 @@ TEST_CASE("Column_1D as GRM consistent sensitivity initialization with linear bi
 }
 
 // todo fix kinetic binding sensitivity init
-TEST_CASE("Column_1D LRMP consistent sensitivity initialization with linear binding", "[Column_1D],[DG],[DG1D],[ConsistentInit],[Sensitivity],[CI]")
+TEST_CASE("Column_1D LRMP consistent sensitivity initialization with linear binding", "[AxialColumn1D],[DG],[DG1D],[ConsistentInit],[Sensitivity],[CI]")
 {
 	// Fill state vector with given initial values
 	const unsigned int numDofs = 2 + 2 * 10 + 10 * (2 + 2);
@@ -471,7 +471,7 @@ TEST_CASE("Column_1D LRMP consistent sensitivity initialization with linear bind
 }
 
 //// todo fix memory stuff (works for FV) 
-//TEST_CASE("Column_1D as GRM consistent sensitivity initialization with SMA binding", "[Column_1D],[DG],[DG1D],[ConsistentInit],[Sensitivity],[fffffffiujbnlk]")
+//TEST_CASE("Column_1D as GRM consistent sensitivity initialization with SMA binding", "[AxialColumn1D],[DG],[DG1D],[ConsistentInit],[Sensitivity],[fffffffiujbnlk]")
 //{
 //	// Fill state vector with given initial values
 //	const unsigned int numDofs = 4 + 4 * 16 + 16 * 4 * (4 + 4) + 4 * 16;
@@ -488,128 +488,128 @@ TEST_CASE("Column_1D LRMP consistent sensitivity initialization with linear bind
 //	cadet::test::column::testConsistentInitializationSensitivity("COLUMN_MODEL_1D_GRM", "DG", y.data(), yDot.data(), false, 1e-9);
 //}
 
-TEST_CASE("Column_1D Jacobian for 2ParType with general rate and homogeneous particle with two component linear binding", "[Column_1D],[DG],[DG1D],[UnitOp],[Jacobian],[CI]")
+TEST_CASE("Column_1D Jacobian for 2ParType with general rate and homogeneous particle with two component linear binding", "[AxialColumn1D],[DG],[DG1D],[UnitOp],[Jacobian],[CI]")
 {
 	cadet::JsonParameterProvider jpp = createColumn2ParType1GeneralRate1HomoParticleBothWithTwoCompLinearJson("COLUMN_MODEL_1D", "DG");
 	cadet::test::column::testJacobianAD(jpp, std::numeric_limits<float>::epsilon() * 100.0);
 }
 
-TEST_CASE("Column_1D as GRM inlet DOF Jacobian", "[Column_1D],[DG],[DG1D],[UnitOp],[Jacobian],[Inlet],[CI]")
+TEST_CASE("Column_1D as GRM inlet DOF Jacobian", "[AxialColumn1D],[DG],[DG1D],[UnitOp],[Jacobian],[Inlet],[CI]")
 {
 	cadet::test::column::testInletDofJacobian("COLUMN_MODEL_1D_GRM", "DG");
 }
 
-TEST_CASE("Column_1D as GRM transport Jacobian", "[Column_1D],[DG],[DG1D],[UnitOp],[Jacobian],[CI]")
+TEST_CASE("Column_1D as GRM transport Jacobian", "[AxialColumn1D],[DG],[DG1D],[UnitOp],[Jacobian],[CI]")
 {
 	cadet::JsonParameterProvider jpp = createColumnLinearBenchmark(false, true, "COLUMN_MODEL_1D_GRM", "DG");
 	cadet::test::column::testJacobianAD(jpp, std::numeric_limits<float>::epsilon() * 100.0);
 }
 
-TEST_CASE("Column_1D as GRM with two component linear binding Jacobian", "[Column_1D],[DG],[DG1D],[UnitOp],[Jacobian],[CI]")
+TEST_CASE("Column_1D as GRM with two component linear binding Jacobian", "[AxialColumn1D],[DG],[DG1D],[UnitOp],[Jacobian],[CI]")
 {
 	cadet::JsonParameterProvider jpp = createColumnWithTwoCompLinearBinding("COLUMN_MODEL_1D_GRM", "DG");
 	cadet::test::column::testJacobianAD(jpp, std::numeric_limits<float>::epsilon() * 100.0);
 }
 
-TEST_CASE("Column_1D as GRM transport Jacobian with bulk DG and par FV discretization", "[Column_1D],[DGFV],[UnitOp],[Jacobian],[CI]")
+TEST_CASE("Column_1D as GRM transport Jacobian with bulk DG and par FV discretization", "[AxialColumn1D],[DGFV],[UnitOp],[Jacobian],[CI]")
 {
 	cadet::JsonParameterProvider jpp = createColumnLinearBenchmark(false, true, "COLUMN_MODEL_1D_GRM", "DGFV");
 	cadet::test::column::testJacobianAD(jpp, 1e+10);
 }
 
-TEST_CASE("Column_1D as GRM with equilibrium linear binding Jacobian with bulk DG and par FV discretization", "[Column_1D],[DGFV],[UnitOp],[Jacobian],[CI]")
+TEST_CASE("Column_1D as GRM with equilibrium linear binding Jacobian with bulk DG and par FV discretization", "[AxialColumn1D],[DGFV],[UnitOp],[Jacobian],[CI]")
 {
 	cadet::JsonParameterProvider jpp = createColumnLinearBenchmark(false, false, "COLUMN_MODEL_1D_GRM", "DGFV");
 	cadet::test::column::testJacobianAD(jpp, 1e+10);
 }
 
-TEST_CASE("Column_1D as GRM with two component kinetic linear binding Jacobian with bulk DG and par FV discretization", "[Column_1D],[DGFV],[UnitOp],[Jacobian],[CI]")
+TEST_CASE("Column_1D as GRM with two component kinetic linear binding Jacobian with bulk DG and par FV discretization", "[AxialColumn1D],[DGFV],[UnitOp],[Jacobian],[CI]")
 {
 	cadet::JsonParameterProvider jpp = createColumnWithTwoCompLinearBinding("COLUMN_MODEL_1D_GRM", "DGFV");
 	cadet::test::column::testJacobianAD(jpp, 1e+10);
 }
 
-TEST_CASE("Column_1D as GRM LWE one vs two identical particle types match", "[Column_1D],[DG],[DG1D],[Simulation],[ParticleType],[CI]")
+TEST_CASE("Column_1D as GRM LWE one vs two identical particle types match", "[AxialColumn1D],[DG],[DG1D],[Simulation],[ParticleType],[CI]")
 {
 	cadet::test::particle::testOneVsTwoIdenticalParticleTypes("COLUMN_MODEL_1D_GRM", "DG", 2e-8, 5e-5);
 }
 
-TEST_CASE("Column_1D as GRM LWE separate identical particle types match", "[Column_1D],[DG],[DG1D],[Simulation],[ParticleType],[CI]")
+TEST_CASE("Column_1D as GRM LWE separate identical particle types match", "[AxialColumn1D],[DG],[DG1D],[Simulation],[ParticleType],[CI]")
 {
 	cadet::test::particle::testSeparateIdenticalParticleTypes("COLUMN_MODEL_1D_GRM", "DG", 2e-8, 5e-5);
 }
 
-TEST_CASE("Column_1D as GRM linear binding single particle matches particle distribution", "[Column_1D],[DG],[DG1D],[Simulation],[ParticleType],[CI]")
+TEST_CASE("Column_1D as GRM linear binding single particle matches particle distribution", "[AxialColumn1D],[DG],[DG1D],[Simulation],[ParticleType],[CI]")
 {
 	cadet::test::particle::testLinearMixedParticleTypes("COLUMN_MODEL_1D_GRM", "DG", 5e-8, 5e-5);
 }
 
-TEST_CASE("Column_1D as GRM multiple particle types Jacobian analytic vs AD", "[Column_1D],[DG],[DG1D],[Jacobian],[AD],[ParticleType],[CI]")
+TEST_CASE("Column_1D as GRM multiple particle types Jacobian analytic vs AD", "[AxialColumn1D],[DG],[DG1D],[Jacobian],[AD],[ParticleType],[CI]")
 {
 	cadet::test::particle::testJacobianMixedParticleTypes("COLUMN_MODEL_1D_GRM", "DG", 5e-12);
 }
 
-TEST_CASE("Column_1D as GRM multiple particle types time derivative Jacobian vs FD", "[Column_1D],[DG],[DG1D],[UnitOp],[Residual],[Jacobian],[ParticleType],[CI]")
+TEST_CASE("Column_1D as GRM multiple particle types time derivative Jacobian vs FD", "[AxialColumn1D],[DG],[DG1D],[UnitOp],[Residual],[Jacobian],[ParticleType],[CI]")
 {
 	cadet::test::particle::testTimeDerivativeJacobianMixedParticleTypesFD("COLUMN_MODEL_1D_GRM", "DG", 1e-6, 0.0, 9e-4);
 }
 
-TEST_CASE("Column_1D as GRM multiple spatially dependent particle types Jacobian analytic vs AD", "[Column_1D],[DG],[DG1D],[Jacobian],[AD],[ParticleType],[CI]")
+TEST_CASE("Column_1D as GRM multiple spatially dependent particle types Jacobian analytic vs AD", "[AxialColumn1D],[DG],[DG1D],[Jacobian],[AD],[ParticleType],[CI]")
 {
 	cadet::test::particle::testJacobianSpatiallyMixedParticleTypes("COLUMN_MODEL_1D_GRM", "DG", 1e-11);
 }
 
-TEST_CASE("Column_1D as GRM linear binding single particle matches spatially dependent particle distribution", "[Column_1D],[DG],[DG1D],[Simulation],[ParticleType],[CI]")
+TEST_CASE("Column_1D as GRM linear binding single particle matches spatially dependent particle distribution", "[AxialColumn1D],[DG],[DG1D],[Simulation],[ParticleType],[CI]")
 {
 	cadet::test::particle::testLinearSpatiallyMixedParticleTypes("COLUMN_MODEL_1D_GRM", "DG", 5e-8, 5e-5);
 }
 
-TEST_CASE("Column_1D as GRM dynamic reactions Jacobian vs AD bulk", "[Column_1D],[DG],[DG1D],[Jacobian],[AD],[ReactionModel],[CI]")
+TEST_CASE("Column_1D as GRM dynamic reactions Jacobian vs AD bulk", "[AxialColumn1D],[DG],[DG1D],[Jacobian],[AD],[ReactionModel],[CI]")
 {
 	cadet::test::reaction::testUnitJacobianDynamicReactionsAD("COLUMN_MODEL_1D_GRM", "DG", true, false, false, 2e-12);
 }
 
-TEST_CASE("Column_1D as GRM dynamic reactions Jacobian vs AD particle", "[Column_1D],[DG],[DG1D],[Jacobian],[AD],[ReactionModel],[CI]")
+TEST_CASE("Column_1D as GRM dynamic reactions Jacobian vs AD particle", "[AxialColumn1D],[DG],[DG1D],[Jacobian],[AD],[ReactionModel],[CI]")
 {
 	cadet::test::reaction::testUnitJacobianDynamicReactionsAD("COLUMN_MODEL_1D_GRM", "DG", false, true, false, 1e-14);
 }
 
-TEST_CASE("Column_1D as GRM dynamic reactions Jacobian vs AD modified particle", "[Column_1D],[DG],[DG1D],[Jacobian],[AD],[ReactionModel],[CI]")
+TEST_CASE("Column_1D as GRM dynamic reactions Jacobian vs AD modified particle", "[AxialColumn1D],[DG],[DG1D],[Jacobian],[AD],[ReactionModel],[CI]")
 {
 	cadet::test::reaction::testUnitJacobianDynamicReactionsAD("COLUMN_MODEL_1D_GRM", "DG", false, true, true, 1e-14);
 }
 
-TEST_CASE("Column_1D as GRM dynamic reactions Jacobian vs AD bulk and particle", "[Column_1D],[DG],[DG1D],[Jacobian],[AD],[ReactionModel],[CI]")
+TEST_CASE("Column_1D as GRM dynamic reactions Jacobian vs AD bulk and particle", "[AxialColumn1D],[DG],[DG1D],[Jacobian],[AD],[ReactionModel],[CI]")
 {
 	cadet::test::reaction::testUnitJacobianDynamicReactionsAD("COLUMN_MODEL_1D_GRM", "DG", true, true, false, 1e-14);
 }
 
-TEST_CASE("Column_1D as GRM dynamic reactions Jacobian vs AD bulk and modified particle", "[Column_1D],[DG],[DG1D],[Jacobian],[AD],[ReactionModel],[CI]")
+TEST_CASE("Column_1D as GRM dynamic reactions Jacobian vs AD bulk and modified particle", "[AxialColumn1D],[DG],[DG1D],[Jacobian],[AD],[ReactionModel],[CI]")
 {
 	cadet::test::reaction::testUnitJacobianDynamicReactionsAD("COLUMN_MODEL_1D_GRM", "DG", true, true, true, 1e-14);
 }
 
-TEST_CASE("Column_1D as GRM dynamic reactions time derivative Jacobian vs FD bulk", "[Column_1D],[DG],[DG1D],[Jacobian],[Residual],[ReactionModel],[CI],[FD]")
+TEST_CASE("Column_1D as GRM dynamic reactions time derivative Jacobian vs FD bulk", "[AxialColumn1D],[DG],[DG1D],[Jacobian],[Residual],[ReactionModel],[CI],[FD]")
 {
 	cadet::test::reaction::testTimeDerivativeJacobianDynamicReactionsFD("COLUMN_MODEL_1D_GRM", "DG", true, false, false, 1e-6, 1e-14, 9e-4);
 }
 
-TEST_CASE("Column_1D as GRM dynamic reactions time derivative Jacobian vs FD particle", "[Column_1D],[DG],[DG1D],[Jacobian],[Residual],[ReactionModel],[CI],[FD]")
+TEST_CASE("Column_1D as GRM dynamic reactions time derivative Jacobian vs FD particle", "[AxialColumn1D],[DG],[DG1D],[Jacobian],[Residual],[ReactionModel],[CI],[FD]")
 {
 	cadet::test::reaction::testTimeDerivativeJacobianDynamicReactionsFD("COLUMN_MODEL_1D_GRM", "DG", false, true, false, 1e-6, 1e-14, 9e-4);
 }
 
-TEST_CASE("Column_1D as GRM dynamic reactions time derivative Jacobian vs FD modified particle", "[Column_1D],[DG],[DG1D],[Jacobian],[Residual],[ReactionModel],[CI],[FD]")
+TEST_CASE("Column_1D as GRM dynamic reactions time derivative Jacobian vs FD modified particle", "[AxialColumn1D],[DG],[DG1D],[Jacobian],[Residual],[ReactionModel],[CI],[FD]")
 {
 	cadet::test::reaction::testTimeDerivativeJacobianDynamicReactionsFD("COLUMN_MODEL_1D_GRM", "DG", false, true, true, 1e-6, 1e-14, 9e-4);
 }
 
-TEST_CASE("Column_1D as GRM dynamic reactions time derivative Jacobian vs FD bulk and particle", "[Column_1D],[DG],[DG1D],[Jacobian],[Residual],[ReactionModel],[CI],[FD]")
+TEST_CASE("Column_1D as GRM dynamic reactions time derivative Jacobian vs FD bulk and particle", "[AxialColumn1D],[DG],[DG1D],[Jacobian],[Residual],[ReactionModel],[CI],[FD]")
 {
 	cadet::test::reaction::testTimeDerivativeJacobianDynamicReactionsFD("COLUMN_MODEL_1D_GRM", "DG", true, true, false, 1e-6, 1e-14, 9e-4);
 }
 
-TEST_CASE("Column_1D as GRM dynamic reactions time derivative Jacobian vs FD bulk and modified particle", "[Column_1D],[DG],[DG1D],[Jacobian],[Residual],[ReactionModel],[CI],[FD]")
+TEST_CASE("Column_1D as GRM dynamic reactions time derivative Jacobian vs FD bulk and modified particle", "[AxialColumn1D],[DG],[DG1D],[Jacobian],[Residual],[ReactionModel],[CI],[FD]")
 {
 	cadet::test::reaction::testTimeDerivativeJacobianDynamicReactionsFD("COLUMN_MODEL_1D_GRM", "DG", true, true, true, 1e-6, 1e-14, 9e-4);
 }
@@ -625,163 +625,163 @@ inline cadet::JsonParameterProvider create1DColumnWithTwoCompLinearBindingThreeP
 	return jpp;
 }
 
-TEST_CASE("Column_1D as GRM multi particle types dynamic reactions Jacobian vs AD bulk", "[Column_1D],[DG],[DG1D],[Jacobian],[AD],[ReactionModel],[ParticleType],[CI]")
+TEST_CASE("Column_1D as GRM multi particle types dynamic reactions Jacobian vs AD bulk", "[AxialColumn1D],[DG],[DG1D],[Jacobian],[AD],[ReactionModel],[ParticleType],[CI]")
 {
 	cadet::JsonParameterProvider jpp = create1DColumnWithTwoCompLinearBindingThreeParticleTypes();
 	cadet::test::reaction::testUnitJacobianDynamicReactionsAD(jpp, true, false, false);
 }
 
-TEST_CASE("Column_1D as GRM multi particle types dynamic reactions Jacobian vs AD particle", "[Column_1D],[DG],[DG1D],[Jacobian],[AD],[ReactionModel],[ParticleType],[CI]")
+TEST_CASE("Column_1D as GRM multi particle types dynamic reactions Jacobian vs AD particle", "[AxialColumn1D],[DG],[DG1D],[Jacobian],[AD],[ReactionModel],[ParticleType],[CI]")
 {
 	cadet::JsonParameterProvider jpp = create1DColumnWithTwoCompLinearBindingThreeParticleTypes();
 	cadet::test::reaction::testUnitJacobianDynamicReactionsAD(jpp, false, true, false);
 }
 
-TEST_CASE("Column_1D as GRM multi particle types dynamic reactions Jacobian vs AD modified particle", "[Column_1D],[DG],[DG1D],[Jacobian],[AD],[ReactionModel],[ParticleType],[CI]")
+TEST_CASE("Column_1D as GRM multi particle types dynamic reactions Jacobian vs AD modified particle", "[AxialColumn1D],[DG],[DG1D],[Jacobian],[AD],[ReactionModel],[ParticleType],[CI]")
 {
 	cadet::JsonParameterProvider jpp = create1DColumnWithTwoCompLinearBindingThreeParticleTypes();
 	cadet::test::reaction::testUnitJacobianDynamicReactionsAD(jpp, false, true, true);
 }
 
-TEST_CASE("Column_1D as GRM multi particle types dynamic reactions Jacobian vs AD bulk and particle", "[Column_1D],[DG],[DG1D],[Jacobian],[AD],[ReactionModel],[ParticleType],[CI]")
+TEST_CASE("Column_1D as GRM multi particle types dynamic reactions Jacobian vs AD bulk and particle", "[AxialColumn1D],[DG],[DG1D],[Jacobian],[AD],[ReactionModel],[ParticleType],[CI]")
 {
 	cadet::JsonParameterProvider jpp = create1DColumnWithTwoCompLinearBindingThreeParticleTypes();
 	cadet::test::reaction::testUnitJacobianDynamicReactionsAD(jpp, true, true, false);
 }
 
-TEST_CASE("Column_1D as GRM multi particle types dynamic reactions Jacobian vs AD bulk and modified particle", "[Column_1D],[DG],[DG1D],[Jacobian],[AD],[ReactionModel],[ParticleType],[CI]")
+TEST_CASE("Column_1D as GRM multi particle types dynamic reactions Jacobian vs AD bulk and modified particle", "[AxialColumn1D],[DG],[DG1D],[Jacobian],[AD],[ReactionModel],[ParticleType],[CI]")
 {
 	cadet::JsonParameterProvider jpp = create1DColumnWithTwoCompLinearBindingThreeParticleTypes();
 	cadet::test::reaction::testUnitJacobianDynamicReactionsAD(jpp, true, true, true);
 }
 
-TEST_CASE("Column_1D as GRM multi particle types dynamic reactions time derivative Jacobian vs FD bulk", "[Column_1D],[DG],[DG1D],[Jacobian],[Residual],[ReactionModel],[ParticleType],[CI]")
+TEST_CASE("Column_1D as GRM multi particle types dynamic reactions time derivative Jacobian vs FD bulk", "[AxialColumn1D],[DG],[DG1D],[Jacobian],[Residual],[ReactionModel],[ParticleType],[CI]")
 {
 	cadet::JsonParameterProvider jpp = create1DColumnWithTwoCompLinearBindingThreeParticleTypes();
 	cadet::test::reaction::testTimeDerivativeJacobianDynamicReactionsFD(jpp, true, false, false, 1e-6, 1e-14, 9e-4);
 }
 
-TEST_CASE("Column_1D as GRM multi particle types dynamic reactions time derivative Jacobian vs FD particle", "[Column_1D],[DG],[DG1D],[Jacobian],[Residual],[ReactionModel],[ParticleType],[CI]")
+TEST_CASE("Column_1D as GRM multi particle types dynamic reactions time derivative Jacobian vs FD particle", "[AxialColumn1D],[DG],[DG1D],[Jacobian],[Residual],[ReactionModel],[ParticleType],[CI]")
 {
 	cadet::JsonParameterProvider jpp = create1DColumnWithTwoCompLinearBindingThreeParticleTypes();
 	cadet::test::reaction::testTimeDerivativeJacobianDynamicReactionsFD(jpp, false, true, false, 1e-6, 1e-14, 9e-4);
 }
 
-TEST_CASE("Column_1D as GRM multi particle types dynamic reactions time derivative Jacobian vs FD modified particle", "[Column_1D],[DG],[DG1D],[Jacobian],[Residual],[ReactionModel],[ParticleType],[CI]")
+TEST_CASE("Column_1D as GRM multi particle types dynamic reactions time derivative Jacobian vs FD modified particle", "[AxialColumn1D],[DG],[DG1D],[Jacobian],[Residual],[ReactionModel],[ParticleType],[CI]")
 {
 	cadet::JsonParameterProvider jpp = create1DColumnWithTwoCompLinearBindingThreeParticleTypes();
 	cadet::test::reaction::testTimeDerivativeJacobianDynamicReactionsFD(jpp, false, true, true, 1e-6, 1e-14, 9e-4);
 }
 
-TEST_CASE("Column_1D as GRM multi particle types dynamic reactions time derivative Jacobian vs FD bulk and particle", "[Column_1D],[DG],[DG1D],[Jacobian],[Residual],[ReactionModel],[ParticleType],[CI]")
+TEST_CASE("Column_1D as GRM multi particle types dynamic reactions time derivative Jacobian vs FD bulk and particle", "[AxialColumn1D],[DG],[DG1D],[Jacobian],[Residual],[ReactionModel],[ParticleType],[CI]")
 {
 	cadet::JsonParameterProvider jpp = create1DColumnWithTwoCompLinearBindingThreeParticleTypes();
 	cadet::test::reaction::testTimeDerivativeJacobianDynamicReactionsFD(jpp, true, true, false, 1e-6, 1e-14, 9e-4);
 }
 
-TEST_CASE("Column_1D as GRM multi particle types dynamic reactions time derivative Jacobian vs FD bulk and modified particle", "[Column_1D],[DG],[DG1D],[Jacobian],[Residual],[ReactionModel],[ParticleType],[CI]")
+TEST_CASE("Column_1D as GRM multi particle types dynamic reactions time derivative Jacobian vs FD bulk and modified particle", "[AxialColumn1D],[DG],[DG1D],[Jacobian],[Residual],[ReactionModel],[ParticleType],[CI]")
 {
 	cadet::JsonParameterProvider jpp = create1DColumnWithTwoCompLinearBindingThreeParticleTypes();
 	cadet::test::reaction::testTimeDerivativeJacobianDynamicReactionsFD(jpp, true, true, true, 1e-6, 1e-14, 9e-4);
 }
 
-TEST_CASE("Column_1D as LRMP inlet DOF Jacobian", "[Column_1D],[DG],[DG1D],[UnitOp],[Jacobian],[Inlet],[CI]")
+TEST_CASE("Column_1D as LRMP inlet DOF Jacobian", "[AxialColumn1D],[DG],[DG1D],[UnitOp],[Jacobian],[Inlet],[CI]")
 {
 	cadet::test::column::testInletDofJacobian("COLUMN_MODEL_1D_LRMP", "DG");
 }
 
-TEST_CASE("Column_1D as LRMP transport Jacobian", "[Column_1D],[DG],[DG1D],[UnitOp],[Jacobian],[CI]")
+TEST_CASE("Column_1D as LRMP transport Jacobian", "[AxialColumn1D],[DG],[DG1D],[UnitOp],[Jacobian],[CI]")
 {
 	cadet::JsonParameterProvider jpp = createColumnLinearBenchmark(false, true, "COLUMN_MODEL_1D_LRMP", "DG");
 	cadet::test::column::testJacobianAD(jpp, std::numeric_limits<float>::epsilon() * 100.0);
 }
 
-TEST_CASE("Column_1D as LRMP with two component linear binding Jacobian", "[Column_1D],[DG],[DG1D],[UnitOp],[Jacobian],[CI]")
+TEST_CASE("Column_1D as LRMP with two component linear binding Jacobian", "[AxialColumn1D],[DG],[DG1D],[UnitOp],[Jacobian],[CI]")
 {
 	cadet::JsonParameterProvider jpp = createColumnWithTwoCompLinearBinding("COLUMN_MODEL_1D_LRMP", "DG");
 	cadet::test::column::testJacobianAD(jpp, std::numeric_limits<float>::epsilon() * 100.0);
 }
 
-TEST_CASE("Column_1D as LRMP LWE one vs two identical particle types match", "[Column_1D],[DG],[DG1D],[Simulation],[ParticleType],[CI]")
+TEST_CASE("Column_1D as LRMP LWE one vs two identical particle types match", "[AxialColumn1D],[DG],[DG1D],[Simulation],[ParticleType],[CI]")
 {
 	cadet::test::particle::testOneVsTwoIdenticalParticleTypes("COLUMN_MODEL_1D_LRMP", "DG", 2.2e-8, 6e-5);
 }
 
-TEST_CASE("Column_1D as LRMP LWE separate identical particle types match", "[Column_1D],[DG],[DG1D],[Simulation],[ParticleType],[CI]")
+TEST_CASE("Column_1D as LRMP LWE separate identical particle types match", "[AxialColumn1D],[DG],[DG1D],[Simulation],[ParticleType],[CI]")
 {
 	cadet::test::particle::testSeparateIdenticalParticleTypes("COLUMN_MODEL_1D_LRMP", "DG", 1e-12, 1e-12);
 }
 
-TEST_CASE("Column_1D as LRMP linear binding single particle matches particle distribution", "[Column_1D],[DG],[DG1D],[Simulation],[ParticleType],[CI]")
+TEST_CASE("Column_1D as LRMP linear binding single particle matches particle distribution", "[AxialColumn1D],[DG],[DG1D],[Simulation],[ParticleType],[CI]")
 {
 	cadet::test::particle::testLinearMixedParticleTypes("COLUMN_MODEL_1D_LRMP", "DG", 5e-8, 5e-5);
 }
 
-TEST_CASE("Column_1D as LRMP multiple particle types Jacobian analytic vs AD", "[Column_1D],[DG],[DG1D],[Jacobian],[AD],[ParticleType],[CI]")
+TEST_CASE("Column_1D as LRMP multiple particle types Jacobian analytic vs AD", "[AxialColumn1D],[DG],[DG1D],[Jacobian],[AD],[ParticleType],[CI]")
 {
 	cadet::test::particle::testJacobianMixedParticleTypes("COLUMN_MODEL_1D_LRMP", "DG", 1e-11);
 }
 
-TEST_CASE("Column_1D as LRMP multiple particle types time derivative Jacobian vs FD", "[Column_1D],[DG],[DG1D],[UnitOp],[Residual],[Jacobian],[ParticleType],[CI]")
+TEST_CASE("Column_1D as LRMP multiple particle types time derivative Jacobian vs FD", "[AxialColumn1D],[DG],[DG1D],[UnitOp],[Residual],[Jacobian],[ParticleType],[CI]")
 {
 	cadet::test::particle::testTimeDerivativeJacobianMixedParticleTypesFD("COLUMN_MODEL_1D_LRMP", "DG", 1e-6, 0.0, 9e-4);
 }
 
-TEST_CASE("Column_1D as LRMP multiple spatially dependent particle types Jacobian analytic vs AD", "[Column_1D],[DG],[DG1D],[Jacobian],[AD],[ParticleType],[CI]")
+TEST_CASE("Column_1D as LRMP multiple spatially dependent particle types Jacobian analytic vs AD", "[AxialColumn1D],[DG],[DG1D],[Jacobian],[AD],[ParticleType],[CI]")
 {
 	cadet::test::particle::testJacobianSpatiallyMixedParticleTypes("COLUMN_MODEL_1D_LRMP", "DG", std::numeric_limits<float>::epsilon() * 100.0);
 }
 
-TEST_CASE("Column_1D as LRMP linear binding single particle matches spatially dependent particle distribution", "[Column_1D],[DG],[DG1D],[Simulation],[ParticleType],[CI]")
+TEST_CASE("Column_1D as LRMP linear binding single particle matches spatially dependent particle distribution", "[AxialColumn1D],[DG],[DG1D],[Simulation],[ParticleType],[CI]")
 {
 	cadet::test::particle::testLinearSpatiallyMixedParticleTypes("COLUMN_MODEL_1D_LRMP", "DG", 5e-8, 5e-5);
 }
 
-TEST_CASE("Column_1D as LRMP dynamic reactions Jacobian vs AD bulk", "[Column_1D],[DG],[DG1D],[Jacobian],[AD],[ReactionModel],[CI]")
+TEST_CASE("Column_1D as LRMP dynamic reactions Jacobian vs AD bulk", "[AxialColumn1D],[DG],[DG1D],[Jacobian],[AD],[ReactionModel],[CI]")
 {
 	cadet::test::reaction::testUnitJacobianDynamicReactionsAD("COLUMN_MODEL_1D_LRMP", "DG", true, false, false, std::numeric_limits<float>::epsilon() * 100.0);
 }
-TEST_CASE("Column_1D as LRMP dynamic reactions Jacobian vs AD particle", "[Column_1D],[DG],[DG1D],[Jacobian],[AD],[ReactionModel],[CI]")
+TEST_CASE("Column_1D as LRMP dynamic reactions Jacobian vs AD particle", "[AxialColumn1D],[DG],[DG1D],[Jacobian],[AD],[ReactionModel],[CI]")
 {
 	cadet::test::reaction::testUnitJacobianDynamicReactionsAD("COLUMN_MODEL_1D_LRMP", "DG", false, true, false, std::numeric_limits<float>::epsilon() * 100.0);
 }
 
-TEST_CASE("Column_1D as LRMP dynamic reactions Jacobian vs AD modified particle", "[Column_1D],[DG],[DG1D],[Jacobian],[AD],[ReactionModel],[CI]")
+TEST_CASE("Column_1D as LRMP dynamic reactions Jacobian vs AD modified particle", "[AxialColumn1D],[DG],[DG1D],[Jacobian],[AD],[ReactionModel],[CI]")
 {
 	cadet::test::reaction::testUnitJacobianDynamicReactionsAD("COLUMN_MODEL_1D_LRMP", "DG", false, true, true, std::numeric_limits<float>::epsilon() * 100.0);
 }
 
-TEST_CASE("Column_1D as LRMP dynamic reactions Jacobian vs AD bulk and particle", "[Column_1D],[DG],[DG1D],[Jacobian],[AD],[ReactionModel],[CI]")
+TEST_CASE("Column_1D as LRMP dynamic reactions Jacobian vs AD bulk and particle", "[AxialColumn1D],[DG],[DG1D],[Jacobian],[AD],[ReactionModel],[CI]")
 {
 	cadet::test::reaction::testUnitJacobianDynamicReactionsAD("COLUMN_MODEL_1D_LRMP", "DG", true, true, false, std::numeric_limits<float>::epsilon() * 100.0);
 }
 
-TEST_CASE("Column_1D as LRMP dynamic reactions Jacobian vs AD bulk and modified particle", "[Column_1D],[DG],[DG1D],[Jacobian],[AD],[ReactionModel],[CI]")
+TEST_CASE("Column_1D as LRMP dynamic reactions Jacobian vs AD bulk and modified particle", "[AxialColumn1D],[DG],[DG1D],[Jacobian],[AD],[ReactionModel],[CI]")
 {
 	cadet::test::reaction::testUnitJacobianDynamicReactionsAD("COLUMN_MODEL_1D_LRMP", "DG", true, true, true, std::numeric_limits<float>::epsilon() * 100.0);
 }
 
-TEST_CASE("Column_1D as LRMP dynamic reactions time derivative Jacobian vs FD bulk", "[Column_1D],[DG],[DG1D],[Jacobian],[Residual],[ReactionModel],[CI]")
+TEST_CASE("Column_1D as LRMP dynamic reactions time derivative Jacobian vs FD bulk", "[AxialColumn1D],[DG],[DG1D],[Jacobian],[Residual],[ReactionModel],[CI]")
 {
 	cadet::test::reaction::testTimeDerivativeJacobianDynamicReactionsFD("COLUMN_MODEL_1D_LRMP", "DG", true, false, false, 1e-6, 1e-14, 8e-4);
 }
 
-TEST_CASE("Column_1D as LRMP dynamic reactions time derivative Jacobian vs FD particle", "[Column_1D],[DG],[DG1D],[Jacobian],[Residual],[ReactionModel],[CI]")
+TEST_CASE("Column_1D as LRMP dynamic reactions time derivative Jacobian vs FD particle", "[AxialColumn1D],[DG],[DG1D],[Jacobian],[Residual],[ReactionModel],[CI]")
 {
 	cadet::test::reaction::testTimeDerivativeJacobianDynamicReactionsFD("COLUMN_MODEL_1D_LRMP", "DG", false, true, false, 1e-6, 1e-14, 8e-4);
 }
 
-TEST_CASE("Column_1D as LRMP dynamic reactions time derivative Jacobian vs FD modified particle", "[Column_1D],[DG],[DG1D],[Jacobian],[Residual],[ReactionModel],[CI]")
+TEST_CASE("Column_1D as LRMP dynamic reactions time derivative Jacobian vs FD modified particle", "[AxialColumn1D],[DG],[DG1D],[Jacobian],[Residual],[ReactionModel],[CI]")
 {
 	cadet::test::reaction::testTimeDerivativeJacobianDynamicReactionsFD("COLUMN_MODEL_1D_LRMP", "DG", false, true, true, 1e-6, 1e-14, 8e-4);
 }
 
-TEST_CASE("Column_1D as LRMP dynamic reactions time derivative Jacobian vs FD bulk and particle", "[Column_1D],[DG],[DG1D],[Jacobian],[Residual],[ReactionModel],[CI]")
+TEST_CASE("Column_1D as LRMP dynamic reactions time derivative Jacobian vs FD bulk and particle", "[AxialColumn1D],[DG],[DG1D],[Jacobian],[Residual],[ReactionModel],[CI]")
 {
 	cadet::test::reaction::testTimeDerivativeJacobianDynamicReactionsFD("COLUMN_MODEL_1D_LRMP", "DG", true, true, false, 1e-6, 1e-14, 8e-4);
 }
 
-TEST_CASE("Column_1D as LRMP dynamic reactions time derivative Jacobian vs FD bulk and modified particle", "[Column_1D],[DG],[DG1D],[Jacobian],[Residual],[ReactionModel],[CI]")
+TEST_CASE("Column_1D as LRMP dynamic reactions time derivative Jacobian vs FD bulk and modified particle", "[AxialColumn1D],[DG],[DG1D],[Jacobian],[Residual],[ReactionModel],[CI]")
 {
 	cadet::test::reaction::testTimeDerivativeJacobianDynamicReactionsFD("COLUMN_MODEL_1D_LRMP", "DG", true, true, true, 1e-6, 1e-14, 8e-4);
 }
@@ -797,67 +797,67 @@ inline cadet::JsonParameterProvider createLRMPColumnWithTwoCompLinearBindingThre
 	return jpp;
 }
 
-TEST_CASE("Column_1D as LRMP multi particle types dynamic reactions Jacobian vs AD bulk", "[Column_1D],[DG],[DG1D],[Jacobian],[AD],[ReactionModel],[ParticleType],[CI]")
+TEST_CASE("Column_1D as LRMP multi particle types dynamic reactions Jacobian vs AD bulk", "[AxialColumn1D],[DG],[DG1D],[Jacobian],[AD],[ReactionModel],[ParticleType],[CI]")
 {
 	cadet::JsonParameterProvider jpp = createLRMPColumnWithTwoCompLinearBindingThreeParticleTypes();
 	cadet::test::reaction::testUnitJacobianDynamicReactionsAD(jpp, true, false, false, 1e-8);
 }
 
-TEST_CASE("Column_1D as LRMP multi particle types dynamic reactions Jacobian vs AD particle", "[Column_1D],[DG],[DG1D],[Jacobian],[AD],[ReactionModel],[ParticleType],[CI]")
+TEST_CASE("Column_1D as LRMP multi particle types dynamic reactions Jacobian vs AD particle", "[AxialColumn1D],[DG],[DG1D],[Jacobian],[AD],[ReactionModel],[ParticleType],[CI]")
 {
 	cadet::JsonParameterProvider jpp = createLRMPColumnWithTwoCompLinearBindingThreeParticleTypes();
 	cadet::test::reaction::testUnitJacobianDynamicReactionsAD(jpp, false, true, false, 1e-8);
 }
 
-TEST_CASE("Column_1D as LRMP multi particle types dynamic reactions Jacobian vs AD modified particle", "[Column_1D],[DG],[DG1D],[Jacobian],[AD],[ReactionModel],[ParticleType],[CI]")
+TEST_CASE("Column_1D as LRMP multi particle types dynamic reactions Jacobian vs AD modified particle", "[AxialColumn1D],[DG],[DG1D],[Jacobian],[AD],[ReactionModel],[ParticleType],[CI]")
 {
 	cadet::JsonParameterProvider jpp = createLRMPColumnWithTwoCompLinearBindingThreeParticleTypes();
 	cadet::test::reaction::testUnitJacobianDynamicReactionsAD(jpp, false, true, true, 1e-8);
 }
 
-TEST_CASE("Column_1D as LRMP multi particle types dynamic reactions Jacobian vs AD bulk and particle", "[Column_1D],[DG],[DG1D],[Jacobian],[AD],[ReactionModel],[ParticleType],[CI]")
+TEST_CASE("Column_1D as LRMP multi particle types dynamic reactions Jacobian vs AD bulk and particle", "[AxialColumn1D],[DG],[DG1D],[Jacobian],[AD],[ReactionModel],[ParticleType],[CI]")
 {
 	cadet::JsonParameterProvider jpp = createLRMPColumnWithTwoCompLinearBindingThreeParticleTypes();
 	cadet::test::reaction::testUnitJacobianDynamicReactionsAD(jpp, true, true, false, 1e-8);
 }
 
-TEST_CASE("Column_1D as LRMP multi particle types dynamic reactions Jacobian vs AD bulk and modified particle", "[Column_1D],[DG],[DG1D],[Jacobian],[AD],[ReactionModel],[ParticleType],[CI]")
+TEST_CASE("Column_1D as LRMP multi particle types dynamic reactions Jacobian vs AD bulk and modified particle", "[AxialColumn1D],[DG],[DG1D],[Jacobian],[AD],[ReactionModel],[ParticleType],[CI]")
 {
 	cadet::JsonParameterProvider jpp = createLRMPColumnWithTwoCompLinearBindingThreeParticleTypes();
 	cadet::test::reaction::testUnitJacobianDynamicReactionsAD(jpp, true, true, true, 1e-8);
 }
 
-TEST_CASE("Column_1D as LRMP multi particle types dynamic reactions time derivative Jacobian vs FD bulk", "[Column_1D],[DG],[DG1D],[Jacobian],[Residual],[ReactionModel],[ParticleType],[CI]")
+TEST_CASE("Column_1D as LRMP multi particle types dynamic reactions time derivative Jacobian vs FD bulk", "[AxialColumn1D],[DG],[DG1D],[Jacobian],[Residual],[ReactionModel],[ParticleType],[CI]")
 {
 	cadet::JsonParameterProvider jpp = createLRMPColumnWithTwoCompLinearBindingThreeParticleTypes();
 	cadet::test::reaction::testTimeDerivativeJacobianDynamicReactionsFD(jpp, true, false, false, 1e-6, 1e-14, 8e-4);
 }
 
-TEST_CASE("Column_1D as LRMP multi particle types dynamic reactions time derivative Jacobian vs FD particle", "[Column_1D],[DG],[DG1D],[Jacobian],[Residual],[ReactionModel],[ParticleType],[CI]")
+TEST_CASE("Column_1D as LRMP multi particle types dynamic reactions time derivative Jacobian vs FD particle", "[AxialColumn1D],[DG],[DG1D],[Jacobian],[Residual],[ReactionModel],[ParticleType],[CI]")
 {
 	cadet::JsonParameterProvider jpp = createLRMPColumnWithTwoCompLinearBindingThreeParticleTypes();
 	cadet::test::reaction::testTimeDerivativeJacobianDynamicReactionsFD(jpp, false, true, false, 1e-6, 1e-14, 8e-4);
 }
 
-TEST_CASE("Column_1D as LRMP multi particle types dynamic reactions time derivative Jacobian vs FD modified particle", "[Column_1D],[DG],[DG1D],[Jacobian],[Residual],[ReactionModel],[ParticleType],[CI]")
+TEST_CASE("Column_1D as LRMP multi particle types dynamic reactions time derivative Jacobian vs FD modified particle", "[AxialColumn1D],[DG],[DG1D],[Jacobian],[Residual],[ReactionModel],[ParticleType],[CI]")
 {
 	cadet::JsonParameterProvider jpp = createLRMPColumnWithTwoCompLinearBindingThreeParticleTypes();
 	cadet::test::reaction::testTimeDerivativeJacobianDynamicReactionsFD(jpp, false, true, true, 1e-6, 1e-14, 8e-4);
 }
 
-TEST_CASE("Column_1D as LRMP multi particle types dynamic reactions time derivative Jacobian vs FD bulk and particle", "[Column_1D],[DG],[DG1D],[Jacobian],[Residual],[ReactionModel],[ParticleType],[CI]")
+TEST_CASE("Column_1D as LRMP multi particle types dynamic reactions time derivative Jacobian vs FD bulk and particle", "[AxialColumn1D],[DG],[DG1D],[Jacobian],[Residual],[ReactionModel],[ParticleType],[CI]")
 {
 	cadet::JsonParameterProvider jpp = createLRMPColumnWithTwoCompLinearBindingThreeParticleTypes();
 	cadet::test::reaction::testTimeDerivativeJacobianDynamicReactionsFD(jpp, true, true, false, 1e-6, 1e-14, 8e-4);
 }
 
-TEST_CASE("Column_1D as LRMP multi particle types dynamic reactions time derivative Jacobian vs FD bulk and modified particle", "[Column_1D],[DG],[DG1D],[Jacobian],[Residual],[ReactionModel],[ParticleType],[CI]")
+TEST_CASE("Column_1D as LRMP multi particle types dynamic reactions time derivative Jacobian vs FD bulk and modified particle", "[AxialColumn1D],[DG],[DG1D],[Jacobian],[Residual],[ReactionModel],[ParticleType],[CI]")
 {
 	cadet::JsonParameterProvider jpp = createLRMPColumnWithTwoCompLinearBindingThreeParticleTypes();
 	cadet::test::reaction::testTimeDerivativeJacobianDynamicReactionsFD(jpp, true, true, true, 1e-6, 1e-14, 8e-4);
 }
 
-TEST_CASE("Radial Column_1D as GRM LWE forward vs backward flow", "[Column_1D],[DG],[DG1D],[Simulation],[CI]")
+TEST_CASE("Radial Column_1D as GRM LWE forward vs backward flow", "[RadialColumn1D],[DG],[DG1D],[Simulation],[CI]")
 {
 	cadet::test::column::DGParams disc;
 
@@ -869,188 +869,188 @@ TEST_CASE("Radial Column_1D as GRM LWE forward vs backward flow", "[Column_1D],[
 	cadet::test::column::testForwardBackward("RADIAL_COLUMN_MODEL_1D_GRM", disc, 1e-9, 1e-4);
 }
 
-TEST_CASE("Radial Column_1D as GRM transport Jacobian", "[RadialColumn_1D],[DG],[UnitOp],[Jacobian],[CI]")
+TEST_CASE("Radial Column_1D as GRM transport Jacobian", "[RadialColumn1D],[DG],[UnitOp],[Jacobian],[CI]")
 {
 	cadet::JsonParameterProvider jpp = createColumnLinearBenchmark(false, true, "RADIAL_COLUMN_MODEL_1D_GRM", "DG");
 	cadet::test::column::testJacobianAD(jpp, std::numeric_limits<float>::epsilon() * 100.0);
 }
 
-TEST_CASE("Radial Column_1D as GRM Jacobian forward vs backward flow", "[Column_1D],[DG],[DG1D],[UnitOp],[Residual],[Jacobian],[AD],[CI]")
+TEST_CASE("Radial Column_1D as GRM Jacobian forward vs backward flow", "[RadialColumn1D],[DG],[DG1D],[UnitOp],[Residual],[Jacobian],[AD],[CI]")
 {
 	cadet::test::column::DGParams disc;
 	cadet::test::column::testJacobianForwardBackward("RADIAL_COLUMN_MODEL_1D_GRM", disc, std::numeric_limits<float>::epsilon() * 100.0);
 }
 
-TEST_CASE("Radial Column_1D as GRM time derivative Jacobian vs FD", "[RadialColumn_1D],[DG],[UnitOp],[Residual],[Jacobian],[CI]")
+TEST_CASE("Radial Column_1D as GRM time derivative Jacobian vs FD", "[RadialColumn1D],[DG],[UnitOp],[Residual],[Jacobian],[CI]")
 {
 	cadet::test::column::testTimeDerivativeJacobianFD("RADIAL_COLUMN_MODEL_1D_GRM", "DG");
 }
 
-TEST_CASE("Radial Column_1D as GRM inlet DOF Jacobian", "[RadialColumn_1D],[DG],[UnitOp],[Jacobian],[Inlet],[CI]")
+TEST_CASE("Radial Column_1D as GRM inlet DOF Jacobian", "[RadialColumn1D],[DG],[UnitOp],[Jacobian],[Inlet],[CI]")
 {
 	cadet::test::column::testInletDofJacobian("RADIAL_COLUMN_MODEL_1D_GRM", "DG");
 }
 
-TEST_CASE("Radial Column_1D as GRM with two component linear binding Jacobian", "[RadialColumn_1D],[DG],[UnitOp],[Jacobian],[CI]")
+TEST_CASE("Radial Column_1D as GRM with two component linear binding Jacobian", "[RadialColumn1D],[DG],[UnitOp],[Jacobian],[CI]")
 {
 	cadet::JsonParameterProvider jpp = createColumnWithTwoCompLinearBinding("RADIAL_COLUMN_MODEL_1D_GRM", "DG");
 	cadet::test::column::testJacobianAD(jpp, std::numeric_limits<float>::epsilon() * 100.0);
 }
 
-TEST_CASE("Radial Column_1D as LRMP transport Jacobian", "[RadialColumn_1D],[DG],[UnitOp],[Jacobian],[CI]")
+TEST_CASE("Radial Column_1D as LRMP transport Jacobian", "[RadialColumn1D],[DG],[UnitOp],[Jacobian],[CI]")
 {
 	cadet::JsonParameterProvider jpp = createColumnLinearBenchmark(false, true, "RADIAL_COLUMN_MODEL_1D_LRMP", "DG");
 	cadet::test::column::testJacobianAD(jpp, std::numeric_limits<float>::epsilon() * 100.0);
 }
 
-TEST_CASE("Radial Column_1D as LRMP time derivative Jacobian vs FD", "[RadialColumn_1D],[DG],[UnitOp],[Residual],[Jacobian],[CI]")
+TEST_CASE("Radial Column_1D as LRMP time derivative Jacobian vs FD", "[RadialColumn1D],[DG],[UnitOp],[Residual],[Jacobian],[CI]")
 {
 	cadet::test::column::testTimeDerivativeJacobianFD("RADIAL_COLUMN_MODEL_1D_LRMP", "DG");
 }
 
-TEST_CASE("Radial Column_1D as LRMP inlet DOF Jacobian", "[RadialColumn_1D],[DG],[UnitOp],[Jacobian],[Inlet],[CI]")
+TEST_CASE("Radial Column_1D as LRMP inlet DOF Jacobian", "[RadialColumn1D],[DG],[UnitOp],[Jacobian],[Inlet],[CI]")
 {
 	cadet::test::column::testInletDofJacobian("RADIAL_COLUMN_MODEL_1D_LRMP", "DG");
 }
 
-TEST_CASE("Radial Column_1D as LRMP with two component linear binding Jacobian", "[RadialColumn_1D],[DG],[UnitOp],[Jacobian],[CI]")
+TEST_CASE("Radial Column_1D as LRMP with two component linear binding Jacobian", "[RadialColumn1D],[DG],[UnitOp],[Jacobian],[CI]")
 {
 	cadet::JsonParameterProvider jpp = createColumnWithTwoCompLinearBinding("RADIAL_COLUMN_MODEL_1D_LRMP", "DG");
 	cadet::test::column::testJacobianAD(jpp, std::numeric_limits<float>::epsilon() * 100.0);
 }
 
-TEST_CASE("Radial Column_1D as GRM sensitivity Jacobians", "[RadialColumn_1D],[DG],[UnitOp],[Sensitivity],[CI]")
+TEST_CASE("Radial Column_1D as GRM sensitivity Jacobians", "[RadialColumn1D],[DG],[UnitOp],[Sensitivity],[CI]")
 {
 	cadet::JsonParameterProvider jpp = createColumnWithTwoCompLinearBinding("RADIAL_COLUMN_MODEL_1D_GRM", "DG");
 	cadet::test::column::testFwdSensJacobians(jpp, 1e-4, 6e-7);
 }
 
-TEST_CASE("Radial Column_1D as LRMP sensitivity Jacobians", "[RadialColumn_1D],[DG],[UnitOp],[Sensitivity],[CI]")
+TEST_CASE("Radial Column_1D as LRMP sensitivity Jacobians", "[RadialColumn1D],[DG],[UnitOp],[Sensitivity],[CI]")
 {
 	cadet::JsonParameterProvider jpp = createColumnWithTwoCompLinearBinding("RADIAL_COLUMN_MODEL_1D_LRMP", "DG");
 	cadet::test::column::testFwdSensJacobians(jpp, 1e-4, 6e-7);
 }
 
-TEST_CASE("Radial Column_1D as GRM consistent initialization with linear binding", "[RadialColumn_1D],[DG],[ConsistentInit],[CI]")
+TEST_CASE("Radial Column_1D as GRM consistent initialization with linear binding", "[RadialColumn1D],[DG],[ConsistentInit],[CI]")
 {
 	cadet::test::column::testConsistentInitializationLinearBinding("RADIAL_COLUMN_MODEL_1D_GRM", "DG", 1e-12, 1e-12, 0, 0);
 	cadet::test::column::testConsistentInitializationLinearBinding("RADIAL_COLUMN_MODEL_1D_GRM", "DG", 1e-12, 1e-12, 1, 0);
 	cadet::test::column::testConsistentInitializationLinearBinding("RADIAL_COLUMN_MODEL_1D_GRM", "DG", 1e-12, 1e-12, 0, 1);
 }
 
-TEST_CASE("Radial Column_1D as LRMP consistent initialization with linear binding", "[RadialColumn_1D],[DG],[ConsistentInit],[CI]")
+TEST_CASE("Radial Column_1D as LRMP consistent initialization with linear binding", "[RadialColumn1D],[DG],[ConsistentInit],[CI]")
 {
 	cadet::test::column::testConsistentInitializationLinearBinding("RADIAL_COLUMN_MODEL_1D_LRMP", "DG", 1e-12, 1e-12, 0, 0);
 	cadet::test::column::testConsistentInitializationLinearBinding("RADIAL_COLUMN_MODEL_1D_LRMP", "DG", 1e-12, 1e-12, 1, 0);
 	cadet::test::column::testConsistentInitializationLinearBinding("RADIAL_COLUMN_MODEL_1D_LRMP", "DG", 1e-12, 1e-12, 0, 1);
 }
 
-TEST_CASE("Radial Column_1D as GRM dynamic reactions Jacobian vs AD bulk", "[RadialColumn_1D],[DG],[Jacobian],[AD],[ReactionModel],[CI]")
+TEST_CASE("Radial Column_1D as GRM dynamic reactions Jacobian vs AD bulk", "[RadialColumn1D],[DG],[Jacobian],[AD],[ReactionModel],[CI]")
 {
 	cadet::test::reaction::testUnitJacobianDynamicReactionsAD("RADIAL_COLUMN_MODEL_1D_GRM", "DG", true, false, false, std::numeric_limits<float>::epsilon() * 100.0);
 }
 
-TEST_CASE("Radial Column_1D as GRM dynamic reactions Jacobian vs AD particle", "[RadialColumn_1D],[DG],[Jacobian],[AD],[ReactionModel],[CI]")
+TEST_CASE("Radial Column_1D as GRM dynamic reactions Jacobian vs AD particle", "[RadialColumn1D],[DG],[Jacobian],[AD],[ReactionModel],[CI]")
 {
 	cadet::test::reaction::testUnitJacobianDynamicReactionsAD("RADIAL_COLUMN_MODEL_1D_GRM", "DG", false, true, false, std::numeric_limits<float>::epsilon() * 100.0);
 }
 
-TEST_CASE("Radial Column_1D as GRM dynamic reactions Jacobian vs AD bulk and particle", "[RadialColumn_1D],[DG],[Jacobian],[AD],[ReactionModel],[CI]")
+TEST_CASE("Radial Column_1D as GRM dynamic reactions Jacobian vs AD bulk and particle", "[RadialColumn1D],[DG],[Jacobian],[AD],[ReactionModel],[CI]")
 {
 	cadet::test::reaction::testUnitJacobianDynamicReactionsAD("RADIAL_COLUMN_MODEL_1D_GRM", "DG", true, true, false, std::numeric_limits<float>::epsilon() * 100.0);
 }
 
-TEST_CASE("Radial Column_1D as LRMP dynamic reactions Jacobian vs AD bulk", "[RadialColumn_1D],[DG],[Jacobian],[AD],[ReactionModel],[CI]")
+TEST_CASE("Radial Column_1D as LRMP dynamic reactions Jacobian vs AD bulk", "[RadialColumn1D],[DG],[Jacobian],[AD],[ReactionModel],[CI]")
 {
 	cadet::test::reaction::testUnitJacobianDynamicReactionsAD("RADIAL_COLUMN_MODEL_1D_LRMP", "DG", true, false, false, std::numeric_limits<float>::epsilon() * 100.0);
 }
 
-TEST_CASE("Radial Column_1D as LRMP dynamic reactions Jacobian vs AD particle", "[RadialColumn_1D],[DG],[Jacobian],[AD],[ReactionModel],[CI]")
+TEST_CASE("Radial Column_1D as LRMP dynamic reactions Jacobian vs AD particle", "[RadialColumn1D],[DG],[Jacobian],[AD],[ReactionModel],[CI]")
 {
 	cadet::test::reaction::testUnitJacobianDynamicReactionsAD("RADIAL_COLUMN_MODEL_1D_LRMP", "DG", false, true, false, std::numeric_limits<float>::epsilon() * 100.0);
 }
 
-TEST_CASE("Radial Column_1D as LRMP dynamic reactions Jacobian vs AD bulk and particle", "[RadialColumn_1D],[DG],[Jacobian],[AD],[ReactionModel],[CI]")
+TEST_CASE("Radial Column_1D as LRMP dynamic reactions Jacobian vs AD bulk and particle", "[RadialColumn1D],[DG],[Jacobian],[AD],[ReactionModel],[CI]")
 {
 	cadet::test::reaction::testUnitJacobianDynamicReactionsAD("RADIAL_COLUMN_MODEL_1D_LRMP", "DG", true, true, false, std::numeric_limits<float>::epsilon() * 100.0);
 }
 
-TEST_CASE("Radial Column_1D as GRM dynamic binding with surf diff par dep Jacobian vs AD", "[RadialColumn_1D],[DG],[UnitOp],[Jacobian],[ParameterDependence]")
+TEST_CASE("Radial Column_1D as GRM dynamic binding with surf diff par dep Jacobian vs AD", "[RadialColumn1D],[DG],[UnitOp],[Jacobian],[ParameterDependence]")
 {
 	cadet::test::column::testJacobianADVariableParSurfDiff("RADIAL_COLUMN_MODEL_1D_GRM", "DG", true);
 }
 
-TEST_CASE("Radial Column_1D as GRM rapid-equilibrium binding with surf diff par dep Jacobian vs AD", "[RadialColumn_1D],[DG],[UnitOp],[Jacobian],[ParameterDependence]")
+TEST_CASE("Radial Column_1D as GRM rapid-equilibrium binding with surf diff par dep Jacobian vs AD", "[RadialColumn1D],[DG],[UnitOp],[Jacobian],[ParameterDependence]")
 {
 	cadet::test::column::testJacobianADVariableParSurfDiff("RADIAL_COLUMN_MODEL_1D_GRM", "DG", false);
 }
 
-TEST_CASE("Radial Column_1D as GRM LWE one vs two identical particle types match", "[RadialColumn_1D],[DG],[Simulation],[ParticleType],[CI]")
+TEST_CASE("Radial Column_1D as GRM LWE one vs two identical particle types match", "[RadialColumn1D],[DG],[Simulation],[ParticleType],[CI]")
 {
 	cadet::test::particle::testOneVsTwoIdenticalParticleTypes("RADIAL_COLUMN_MODEL_1D_GRM", "DG", 2e-8, 5e-5);
 }
 
-TEST_CASE("Radial Column_1D as GRM LWE separate identical particle types match", "[RadialColumn_1D],[DG],[Simulation],[ParticleType],[CI]")
+TEST_CASE("Radial Column_1D as GRM LWE separate identical particle types match", "[RadialColumn1D],[DG],[Simulation],[ParticleType],[CI]")
 {
 	cadet::test::particle::testSeparateIdenticalParticleTypes("RADIAL_COLUMN_MODEL_1D_GRM", "DG", 2e-8, 5e-5);
 }
 
-TEST_CASE("Radial Column_1D as GRM linear binding single particle matches particle distribution", "[RadialColumn_1D],[DG],[Simulation],[ParticleType],[CI]")
+TEST_CASE("Radial Column_1D as GRM linear binding single particle matches particle distribution", "[RadialColumn1D],[DG],[Simulation],[ParticleType],[CI]")
 {
 	cadet::test::particle::testLinearMixedParticleTypes("RADIAL_COLUMN_MODEL_1D_GRM", "DG", 5e-8, 5e-5);
 }
 
-TEST_CASE("Radial Column_1D as GRM multiple particle types Jacobian analytic vs AD", "[RadialColumn_1D],[DG],[Jacobian],[AD],[ParticleType],[CI]")
+TEST_CASE("Radial Column_1D as GRM multiple particle types Jacobian analytic vs AD", "[RadialColumn1D],[DG],[Jacobian],[AD],[ParticleType],[CI]")
 {
 	cadet::test::particle::testJacobianMixedParticleTypes("RADIAL_COLUMN_MODEL_1D_GRM", "DG", 5e-12);
 }
 
-TEST_CASE("Radial Column_1D as GRM multiple particle types time derivative Jacobian vs FD", "[RadialColumn_1D],[DG],[UnitOp],[Residual],[Jacobian],[ParticleType],[CI]")
+TEST_CASE("Radial Column_1D as GRM multiple particle types time derivative Jacobian vs FD", "[RadialColumn1D],[DG],[UnitOp],[Residual],[Jacobian],[ParticleType],[CI]")
 {
 	cadet::test::particle::testTimeDerivativeJacobianMixedParticleTypesFD("RADIAL_COLUMN_MODEL_1D_GRM", "DG", 1e-6, 0.0, 9e-4);
 }
 
-TEST_CASE("Radial Column_1D as GRM multiple spatially dependent particle types Jacobian analytic vs AD", "[RadialColumn_1D],[DG],[Jacobian],[AD],[ParticleType],[CI]")
+TEST_CASE("Radial Column_1D as GRM multiple spatially dependent particle types Jacobian analytic vs AD", "[RadialColumn1D],[DG],[Jacobian],[AD],[ParticleType],[CI]")
 {
 	cadet::test::particle::testJacobianSpatiallyMixedParticleTypes("RADIAL_COLUMN_MODEL_1D_GRM", "DG", 1e-11);
 }
 
-TEST_CASE("Radial Column_1D as GRM linear binding single particle matches spatially dependent particle distribution", "[RadialColumn_1D],[DG],[Simulation],[ParticleType],[CI]")
+TEST_CASE("Radial Column_1D as GRM linear binding single particle matches spatially dependent particle distribution", "[RadialColumn1D],[DG],[Simulation],[ParticleType],[CI]")
 {
 	cadet::test::particle::testLinearSpatiallyMixedParticleTypes("RADIAL_COLUMN_MODEL_1D_GRM", "DG", 5e-8, 5e-5);
 }
 
-TEST_CASE("Radial Column_1D as LRMP LWE one vs two identical particle types match", "[RadialColumn_1D],[DG],[Simulation],[ParticleType],[CI]")
+TEST_CASE("Radial Column_1D as LRMP LWE one vs two identical particle types match", "[RadialColumn1D],[DG],[Simulation],[ParticleType],[CI]")
 {
 	cadet::test::particle::testOneVsTwoIdenticalParticleTypes("RADIAL_COLUMN_MODEL_1D_LRMP", "DG", 2.2e-8, 6e-5);
 }
 
-TEST_CASE("Radial Column_1D as LRMP LWE separate identical particle types match", "[RadialColumn_1D],[DG],[Simulation],[ParticleType],[CI]")
+TEST_CASE("Radial Column_1D as LRMP LWE separate identical particle types match", "[RadialColumn1D],[DG],[Simulation],[ParticleType],[CI]")
 {
 	cadet::test::particle::testSeparateIdenticalParticleTypes("RADIAL_COLUMN_MODEL_1D_LRMP", "DG", 2e-8, 5e-5);
 }
 
-TEST_CASE("Radial Column_1D as LRMP linear binding single particle matches particle distribution", "[RadialColumn_1D],[DG],[Simulation],[ParticleType],[CI]")
+TEST_CASE("Radial Column_1D as LRMP linear binding single particle matches particle distribution", "[RadialColumn1D],[DG],[Simulation],[ParticleType],[CI]")
 {
 	cadet::test::particle::testLinearMixedParticleTypes("RADIAL_COLUMN_MODEL_1D_LRMP", "DG", 5e-8, 5e-5);
 }
 
-TEST_CASE("Radial Column_1D as LRMP multiple particle types Jacobian analytic vs AD", "[RadialColumn_1D],[DG],[Jacobian],[AD],[ParticleType],[CI]")
+TEST_CASE("Radial Column_1D as LRMP multiple particle types Jacobian analytic vs AD", "[RadialColumn1D],[DG],[Jacobian],[AD],[ParticleType],[CI]")
 {
 	cadet::test::particle::testJacobianMixedParticleTypes("RADIAL_COLUMN_MODEL_1D_LRMP", "DG", 5e-12);
 }
 
-TEST_CASE("Radial Column_1D as LRMP multiple particle types time derivative Jacobian vs FD", "[RadialColumn_1D],[DG],[UnitOp],[Residual],[Jacobian],[ParticleType],[CI]")
+TEST_CASE("Radial Column_1D as LRMP multiple particle types time derivative Jacobian vs FD", "[RadialColumn1D],[DG],[UnitOp],[Residual],[Jacobian],[ParticleType],[CI]")
 {
 	cadet::test::particle::testTimeDerivativeJacobianMixedParticleTypesFD("RADIAL_COLUMN_MODEL_1D_LRMP", "DG", 1e-6, 0.0, 9e-4);
 }
 
-TEST_CASE("Radial Column_1D as LRMP multiple spatially dependent particle types Jacobian analytic vs AD", "[RadialColumn_1D],[DG],[Jacobian],[AD],[ParticleType],[CI]")
+TEST_CASE("Radial Column_1D as LRMP multiple spatially dependent particle types Jacobian analytic vs AD", "[RadialColumn1D],[DG],[Jacobian],[AD],[ParticleType],[CI]")
 {
 	cadet::test::particle::testJacobianSpatiallyMixedParticleTypes("RADIAL_COLUMN_MODEL_1D_LRMP", "DG", 1e-11);
 }
 
-TEST_CASE("Radial Column_1D as LRMP linear binding single particle matches spatially dependent particle distribution", "[RadialColumn_1D],[DG],[Simulation],[ParticleType],[CI]")
+TEST_CASE("Radial Column_1D as LRMP linear binding single particle matches spatially dependent particle distribution", "[RadialColumn1D],[DG],[Simulation],[ParticleType],[CI]")
 {
 	cadet::test::particle::testLinearSpatiallyMixedParticleTypes("RADIAL_COLUMN_MODEL_1D_LRMP", "DG", 5e-8, 5e-5);
 }
@@ -1066,61 +1066,61 @@ inline cadet::JsonParameterProvider createRadial1DGRMColumnWithThreeParticleType
 	return jpp;
 }
 
-TEST_CASE("Radial Column_1D as GRM multi particle types dynamic reactions Jacobian vs AD bulk", "[RadialColumn_1D],[DG],[Jacobian],[AD],[ReactionModel],[ParticleType],[CI]")
+TEST_CASE("Radial Column_1D as GRM multi particle types dynamic reactions Jacobian vs AD bulk", "[RadialColumn1D],[DG],[Jacobian],[AD],[ReactionModel],[ParticleType],[CI]")
 {
 	cadet::JsonParameterProvider jpp = createRadial1DGRMColumnWithThreeParticleTypes();
 	cadet::test::reaction::testUnitJacobianDynamicReactionsAD(jpp, true, false, false);
 }
 
-TEST_CASE("Radial Column_1D as GRM multi particle types dynamic reactions Jacobian vs AD particle", "[RadialColumn_1D],[DG],[Jacobian],[AD],[ReactionModel],[ParticleType],[CI]")
+TEST_CASE("Radial Column_1D as GRM multi particle types dynamic reactions Jacobian vs AD particle", "[RadialColumn1D],[DG],[Jacobian],[AD],[ReactionModel],[ParticleType],[CI]")
 {
 	cadet::JsonParameterProvider jpp = createRadial1DGRMColumnWithThreeParticleTypes();
 	cadet::test::reaction::testUnitJacobianDynamicReactionsAD(jpp, false, true, false);
 }
 
-TEST_CASE("Radial Column_1D as GRM multi particle types dynamic reactions Jacobian vs AD modified particle", "[RadialColumn_1D],[DG],[Jacobian],[AD],[ReactionModel],[ParticleType],[CI]")
+TEST_CASE("Radial Column_1D as GRM multi particle types dynamic reactions Jacobian vs AD modified particle", "[RadialColumn1D],[DG],[Jacobian],[AD],[ReactionModel],[ParticleType],[CI]")
 {
 	cadet::JsonParameterProvider jpp = createRadial1DGRMColumnWithThreeParticleTypes();
 	cadet::test::reaction::testUnitJacobianDynamicReactionsAD(jpp, false, true, true);
 }
 
-TEST_CASE("Radial Column_1D as GRM multi particle types dynamic reactions Jacobian vs AD bulk and particle", "[RadialColumn_1D],[DG],[Jacobian],[AD],[ReactionModel],[ParticleType],[CI]")
+TEST_CASE("Radial Column_1D as GRM multi particle types dynamic reactions Jacobian vs AD bulk and particle", "[RadialColumn1D],[DG],[Jacobian],[AD],[ReactionModel],[ParticleType],[CI]")
 {
 	cadet::JsonParameterProvider jpp = createRadial1DGRMColumnWithThreeParticleTypes();
 	cadet::test::reaction::testUnitJacobianDynamicReactionsAD(jpp, true, true, false);
 }
 
-TEST_CASE("Radial Column_1D as GRM multi particle types dynamic reactions Jacobian vs AD bulk and modified particle", "[RadialColumn_1D],[DG],[Jacobian],[AD],[ReactionModel],[ParticleType],[CI]")
+TEST_CASE("Radial Column_1D as GRM multi particle types dynamic reactions Jacobian vs AD bulk and modified particle", "[RadialColumn1D],[DG],[Jacobian],[AD],[ReactionModel],[ParticleType],[CI]")
 {
 	cadet::JsonParameterProvider jpp = createRadial1DGRMColumnWithThreeParticleTypes();
 	cadet::test::reaction::testUnitJacobianDynamicReactionsAD(jpp, true, true, true);
 }
 
-TEST_CASE("Radial Column_1D as GRM multi particle types dynamic reactions time derivative Jacobian vs FD bulk", "[RadialColumn_1D],[DG],[Jacobian],[Residual],[ReactionModel],[ParticleType],[CI]")
+TEST_CASE("Radial Column_1D as GRM multi particle types dynamic reactions time derivative Jacobian vs FD bulk", "[RadialColumn1D],[DG],[Jacobian],[Residual],[ReactionModel],[ParticleType],[CI]")
 {
 	cadet::JsonParameterProvider jpp = createRadial1DGRMColumnWithThreeParticleTypes();
 	cadet::test::reaction::testTimeDerivativeJacobianDynamicReactionsFD(jpp, true, false, false, 1e-6, 1e-14, 9e-4);
 }
 
-TEST_CASE("Radial Column_1D as GRM multi particle types dynamic reactions time derivative Jacobian vs FD particle", "[RadialColumn_1D],[DG],[Jacobian],[Residual],[ReactionModel],[ParticleType],[CI]")
+TEST_CASE("Radial Column_1D as GRM multi particle types dynamic reactions time derivative Jacobian vs FD particle", "[RadialColumn1D],[DG],[Jacobian],[Residual],[ReactionModel],[ParticleType],[CI]")
 {
 	cadet::JsonParameterProvider jpp = createRadial1DGRMColumnWithThreeParticleTypes();
 	cadet::test::reaction::testTimeDerivativeJacobianDynamicReactionsFD(jpp, false, true, false, 1e-6, 1e-14, 9e-4);
 }
 
-TEST_CASE("Radial Column_1D as GRM multi particle types dynamic reactions time derivative Jacobian vs FD modified particle", "[RadialColumn_1D],[DG],[Jacobian],[Residual],[ReactionModel],[ParticleType],[CI]")
+TEST_CASE("Radial Column_1D as GRM multi particle types dynamic reactions time derivative Jacobian vs FD modified particle", "[RadialColumn1D],[DG],[Jacobian],[Residual],[ReactionModel],[ParticleType],[CI]")
 {
 	cadet::JsonParameterProvider jpp = createRadial1DGRMColumnWithThreeParticleTypes();
 	cadet::test::reaction::testTimeDerivativeJacobianDynamicReactionsFD(jpp, false, true, true, 1e-6, 1e-14, 9e-4);
 }
 
-TEST_CASE("Radial Column_1D as GRM multi particle types dynamic reactions time derivative Jacobian vs FD bulk and particle", "[RadialColumn_1D],[DG],[Jacobian],[Residual],[ReactionModel],[ParticleType],[CI]")
+TEST_CASE("Radial Column_1D as GRM multi particle types dynamic reactions time derivative Jacobian vs FD bulk and particle", "[RadialColumn1D],[DG],[Jacobian],[Residual],[ReactionModel],[ParticleType],[CI]")
 {
 	cadet::JsonParameterProvider jpp = createRadial1DGRMColumnWithThreeParticleTypes();
 	cadet::test::reaction::testTimeDerivativeJacobianDynamicReactionsFD(jpp, true, true, false, 1e-6, 1e-14, 9e-4);
 }
 
-TEST_CASE("Radial Column_1D as GRM multi particle types dynamic reactions time derivative Jacobian vs FD bulk and modified particle", "[RadialColumn_1D],[DG],[Jacobian],[Residual],[ReactionModel],[ParticleType],[CI]")
+TEST_CASE("Radial Column_1D as GRM multi particle types dynamic reactions time derivative Jacobian vs FD bulk and modified particle", "[RadialColumn1D],[DG],[Jacobian],[Residual],[ReactionModel],[ParticleType],[CI]")
 {
 	cadet::JsonParameterProvider jpp = createRadial1DGRMColumnWithThreeParticleTypes();
 	cadet::test::reaction::testTimeDerivativeJacobianDynamicReactionsFD(jpp, true, true, true, 1e-6, 1e-14, 9e-4);
@@ -1137,67 +1137,67 @@ inline cadet::JsonParameterProvider createRadial1DLRMPColumnWithThreeParticleTyp
 	return jpp;
 }
 
-TEST_CASE("Radial Column_1D as LRMP multi particle types dynamic reactions Jacobian vs AD bulk", "[RadialColumn_1D],[DG],[Jacobian],[AD],[ReactionModel],[ParticleType],[CI]")
+TEST_CASE("Radial Column_1D as LRMP multi particle types dynamic reactions Jacobian vs AD bulk", "[RadialColumn1D],[DG],[Jacobian],[AD],[ReactionModel],[ParticleType],[CI]")
 {
 	cadet::JsonParameterProvider jpp = createRadial1DLRMPColumnWithThreeParticleTypes();
 	cadet::test::reaction::testUnitJacobianDynamicReactionsAD(jpp, true, false, false);
 }
 
-TEST_CASE("Radial Column_1D as LRMP multi particle types dynamic reactions Jacobian vs AD particle", "[RadialColumn_1D],[DG],[Jacobian],[AD],[ReactionModel],[ParticleType],[CI]")
+TEST_CASE("Radial Column_1D as LRMP multi particle types dynamic reactions Jacobian vs AD particle", "[RadialColumn1D],[DG],[Jacobian],[AD],[ReactionModel],[ParticleType],[CI]")
 {
 	cadet::JsonParameterProvider jpp = createRadial1DLRMPColumnWithThreeParticleTypes();
 	cadet::test::reaction::testUnitJacobianDynamicReactionsAD(jpp, false, true, false);
 }
 
-TEST_CASE("Radial Column_1D as LRMP multi particle types dynamic reactions Jacobian vs AD modified particle", "[RadialColumn_1D],[DG],[Jacobian],[AD],[ReactionModel],[ParticleType],[CI]")
+TEST_CASE("Radial Column_1D as LRMP multi particle types dynamic reactions Jacobian vs AD modified particle", "[RadialColumn1D],[DG],[Jacobian],[AD],[ReactionModel],[ParticleType],[CI]")
 {
 	cadet::JsonParameterProvider jpp = createRadial1DLRMPColumnWithThreeParticleTypes();
 	cadet::test::reaction::testUnitJacobianDynamicReactionsAD(jpp, false, true, true);
 }
 
-TEST_CASE("Radial Column_1D as LRMP multi particle types dynamic reactions Jacobian vs AD bulk and particle", "[RadialColumn_1D],[DG],[Jacobian],[AD],[ReactionModel],[ParticleType],[CI]")
+TEST_CASE("Radial Column_1D as LRMP multi particle types dynamic reactions Jacobian vs AD bulk and particle", "[RadialColumn1D],[DG],[Jacobian],[AD],[ReactionModel],[ParticleType],[CI]")
 {
 	cadet::JsonParameterProvider jpp = createRadial1DLRMPColumnWithThreeParticleTypes();
 	cadet::test::reaction::testUnitJacobianDynamicReactionsAD(jpp, true, true, false);
 }
 
-TEST_CASE("Radial Column_1D as LRMP multi particle types dynamic reactions Jacobian vs AD bulk and modified particle", "[RadialColumn_1D],[DG],[Jacobian],[AD],[ReactionModel],[ParticleType],[CI]")
+TEST_CASE("Radial Column_1D as LRMP multi particle types dynamic reactions Jacobian vs AD bulk and modified particle", "[RadialColumn1D],[DG],[Jacobian],[AD],[ReactionModel],[ParticleType],[CI]")
 {
 	cadet::JsonParameterProvider jpp = createRadial1DLRMPColumnWithThreeParticleTypes();
 	cadet::test::reaction::testUnitJacobianDynamicReactionsAD(jpp, true, true, true);
 }
 
-TEST_CASE("Radial Column_1D as LRMP multi particle types dynamic reactions time derivative Jacobian vs FD bulk", "[RadialColumn_1D],[DG],[Jacobian],[Residual],[ReactionModel],[ParticleType],[CI]")
+TEST_CASE("Radial Column_1D as LRMP multi particle types dynamic reactions time derivative Jacobian vs FD bulk", "[RadialColumn1D],[DG],[Jacobian],[Residual],[ReactionModel],[ParticleType],[CI]")
 {
 	cadet::JsonParameterProvider jpp = createRadial1DLRMPColumnWithThreeParticleTypes();
 	cadet::test::reaction::testTimeDerivativeJacobianDynamicReactionsFD(jpp, true, false, false, 1e-6, 1e-14, 8e-4);
 }
 
-TEST_CASE("Radial Column_1D as LRMP multi particle types dynamic reactions time derivative Jacobian vs FD particle", "[RadialColumn_1D],[DG],[Jacobian],[Residual],[ReactionModel],[ParticleType],[CI]")
+TEST_CASE("Radial Column_1D as LRMP multi particle types dynamic reactions time derivative Jacobian vs FD particle", "[RadialColumn1D],[DG],[Jacobian],[Residual],[ReactionModel],[ParticleType],[CI]")
 {
 	cadet::JsonParameterProvider jpp = createRadial1DLRMPColumnWithThreeParticleTypes();
 	cadet::test::reaction::testTimeDerivativeJacobianDynamicReactionsFD(jpp, false, true, false, 1e-6, 1e-14, 8e-4);
 }
 
-TEST_CASE("Radial Column_1D as LRMP multi particle types dynamic reactions time derivative Jacobian vs FD modified particle", "[RadialColumn_1D],[DG],[Jacobian],[Residual],[ReactionModel],[ParticleType],[CI]")
+TEST_CASE("Radial Column_1D as LRMP multi particle types dynamic reactions time derivative Jacobian vs FD modified particle", "[RadialColumn1D],[DG],[Jacobian],[Residual],[ReactionModel],[ParticleType],[CI]")
 {
 	cadet::JsonParameterProvider jpp = createRadial1DLRMPColumnWithThreeParticleTypes();
 	cadet::test::reaction::testTimeDerivativeJacobianDynamicReactionsFD(jpp, false, true, true, 1e-6, 1e-14, 8e-4);
 }
 
-TEST_CASE("Radial Column_1D as LRMP multi particle types dynamic reactions time derivative Jacobian vs FD bulk and particle", "[RadialColumn_1D],[DG],[Jacobian],[Residual],[ReactionModel],[ParticleType],[CI]")
+TEST_CASE("Radial Column_1D as LRMP multi particle types dynamic reactions time derivative Jacobian vs FD bulk and particle", "[RadialColumn1D],[DG],[Jacobian],[Residual],[ReactionModel],[ParticleType],[CI]")
 {
 	cadet::JsonParameterProvider jpp = createRadial1DLRMPColumnWithThreeParticleTypes();
 	cadet::test::reaction::testTimeDerivativeJacobianDynamicReactionsFD(jpp, true, true, false, 1e-6, 1e-14, 8e-4);
 }
 
-TEST_CASE("Radial Column_1D as LRMP multi particle types dynamic reactions time derivative Jacobian vs FD bulk and modified particle", "[RadialColumn_1D],[DG],[Jacobian],[Residual],[ReactionModel],[ParticleType],[CI]")
+TEST_CASE("Radial Column_1D as LRMP multi particle types dynamic reactions time derivative Jacobian vs FD bulk and modified particle", "[RadialColumn1D],[DG],[Jacobian],[Residual],[ReactionModel],[ParticleType],[CI]")
 {
 	cadet::JsonParameterProvider jpp = createRadial1DLRMPColumnWithThreeParticleTypes();
 	cadet::test::reaction::testTimeDerivativeJacobianDynamicReactionsFD(jpp, true, true, true, 1e-6, 1e-14, 8e-4);
 }
 
-TEST_CASE("Radial Column_1D pure convection dispersion numerical benchmark", "[RadialColumn_1D],[DG],[DG1D],[Simulation],[Reference],[CI]")
+TEST_CASE("Radial Column_1D pure convection dispersion numerical benchmark", "[RadialColumn1D],[DG],[DG1D],[Simulation],[Reference],[CI]")
 {
 	std::string modelFilePath = std::string("/data/config_radCOL1D_transport_1comp_DGP3_benchmark1_DG_P3Z16.json");
 	std::string refFilePath = std::string("/data/ref_radCOL1D_transport_1comp_DGP3_benchmark1_DG_P3Z16.h5");

--- a/test/ColumnModel2D.cpp
+++ b/test/ColumnModel2D.cpp
@@ -51,9 +51,9 @@ void test2DColumnJacobian(const std::string relModelFilePath, const int maxAxEle
 	else
 		REQUIRE((radPolyDeg + 1) * maxRadElem <= nRad);
 
-	std::vector<cadet::active> flowRate;
+	std::vector<double> flowRate;
 	for (int i = 1; i <= nRad; i++)
-		flowRate.push_back(static_cast<cadet::active>(connections[i * 7 - 1]));
+		flowRate.push_back(connections[i * 7 - 1]);
 
 	if (axPolyDeg > 0)
 		jpp.set("AX_POLYDEG", axPolyDeg);
@@ -72,7 +72,7 @@ void test2DColumnJacobian(const std::string relModelFilePath, const int maxAxEle
 			jpp.set("RAD_NELEM", rElem);
 			jpp.popScope();
 
-			cadet::test::column::testJacobianAD(jpp, 1e10, std::numeric_limits<float>::epsilon() * 100.0, &flowRate[0]);
+			cadet::test::column::testJacobianAD(jpp, 1e10, std::numeric_limits<float>::epsilon() * 100.0, flowRate);
 		}
 	}
 }

--- a/test/ColumnTests.cpp
+++ b/test/ColumnTests.cpp
@@ -689,7 +689,7 @@ namespace column
 		}
 	}
 
-	void testEqualResults(cadet::JsonParameterProvider jpp1, cadet::JsonParameterProvider jpp2, double absTol, double relTol)
+	void testEqualResults(cadet::JsonParameterProvider jpp1, cadet::JsonParameterProvider jpp2, double absTol, double relTol, int unitID)
 	{
 		cadet::Driver drv1;
 		drv1.configure(jpp1);
@@ -699,8 +699,8 @@ namespace column
 		drv2.configure(jpp2);
 		drv2.run();
 
-		cadet::InternalStorageUnitOpRecorder const* const test1Data = drv1.solution()->unitOperation(0);
-		cadet::InternalStorageUnitOpRecorder const* const test2Data = drv2.solution()->unitOperation(0);
+		cadet::InternalStorageUnitOpRecorder const* const test1Data = drv1.solution()->unitOperation(unitID);
+		cadet::InternalStorageUnitOpRecorder const* const test2Data = drv2.solution()->unitOperation(unitID);
 
 		double const* test1Inlet = test1Data->inlet();
 		double const* test1Outlet = test1Data->outlet();

--- a/test/ColumnTests.cpp
+++ b/test/ColumnTests.cpp
@@ -601,8 +601,10 @@ namespace column
 
 		if (jpp.exists("VELOCITY"))
 			jpp.set("VELOCITY", -jpp.getDouble("VELOCITY"));
-		else
+		else if(jpp.exists("VELOCITY_COEFF"))
 			jpp.set("VELOCITY_COEFF", -jpp.getDouble("VELOCITY_COEFF"));
+		else
+			jpp.set("FORWARD_FLOW", static_cast<int>(!jpp.getBool("FORWARD_FLOW")));
 
 		for (int l = 0; l < level; ++l)
 			jpp.popScope();
@@ -740,6 +742,15 @@ namespace column
 			cadet::JsonParameterProvider jpp = createLWE(uoType, "DG");
 			disc.setDisc(jpp);
 
+			if (static_cast<std::string>(uoType).substr(0, 7) == "FRUSTUM")
+			{
+				jpp.pushScope("model");
+				jpp.pushScope("unit_000");
+				jpp.set("COL_RADIUS_SMALL_END", jpp.getDouble("COL_RADIUS_LARGE_END"));
+				jpp.popScope();
+				jpp.popScope();
+			}
+
 			testForwardBackward(jpp, absTol, relTol);
 		}
 	}
@@ -845,7 +856,7 @@ namespace column
 	}
 	////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-	void testJacobianAD(cadet::JsonParameterProvider& jpp, const double absTolFDpattern, const double absTolAD, const active* flowRate)
+	void testJacobianAD(cadet::JsonParameterProvider& jpp, const double absTolFDpattern, const double absTolAD, const std::vector<double> flowRate)
 	{
 		cadet::ad::setDirections(cadet::ad::getMaxDirections()); // AD directions needed in createAndConfigureUnit but requiredADdirs not known before configureModelDiscretization (which is called in configureUnit)
 
@@ -871,18 +882,27 @@ namespace column
 
 		// Fill state vector with some values
 		util::populate(y.data(), [](unsigned int idx) { return std::abs(std::sin(idx * 0.13)) + 1e-4; }, unitAna->numDofs());
-//			util::populate(y.data(), [](unsigned int idx) { return 1.0; }, unitAna->numDofs());
+		// util::populate(y.data(), [](unsigned int idx) { return 1.0; }, unitAna->numDofs());
 
 		// Setup matrices
-		const AdJacobianParams noAdParams{nullptr, nullptr, 0u};
-		const AdJacobianParams adParams{adRes, adY, 0u};
+		const AdJacobianParams noAdParams{ nullptr, nullptr, 0u };
+		const AdJacobianParams adParams{ adRes, adY, 0u };
 		unitAD->prepareADvectors(adParams);
 
-		if (flowRate) //  for 2D units, velocity needs to be determined from flow rates
+		cadet::ad::setDirections(cadet::ad::getMaxDirections());
+
+		// set velocity from flow rates if provided as fresh active after setDirections to ensure all AD slots are zero-initialized
+		if (!flowRate.empty())
 		{
-			unitAna->setFlowRates(flowRate, flowRate);
-			unitAD->setFlowRates(flowRate, flowRate);
+			cadet::active* safeFlowRate = new cadet::active[flowRate.size()];
+
+			for (int i = 0; i < flowRate.size(); ++i)
+				safeFlowRate[i] = flowRate[i];
+
+			unitAna->setFlowRates(&safeFlowRate[0], &safeFlowRate[0]);
+			unitAD->setFlowRates(&safeFlowRate[0], &safeFlowRate[0]);
 		}
+
 		const ConstSimulationState simState{y.data(), nullptr};
 		unitAna->notifyDiscontinuousSectionTransition(0.0, 0u, simState, noAdParams);
 		unitAD->notifyDiscontinuousSectionTransition(0.0, 0u, simState, adParams);

--- a/test/ColumnTests.hpp
+++ b/test/ColumnTests.hpp
@@ -594,8 +594,9 @@ namespace column
 	 * @param [in] jpp2 Configured column model
 	 * @param [in] absTol Absolute error tolerance
 	 * @param [in] relTol Relative error tolerance
+	 * @param [in] unitID Unit operation ID
 	 */
-	void testEqualResults(cadet::JsonParameterProvider jpp1, cadet::JsonParameterProvider jpp2, double absTol, double relTol);
+	void testEqualResults(cadet::JsonParameterProvider jpp1, cadet::JsonParameterProvider jpp2, double absTol, double relTol, int unitID);
 
 	/**
 	 * @brief Checks the full Jacobian against AD and FD pattern switching
@@ -605,7 +606,7 @@ namespace column
 	 * @param [in] absTolAD absolute tolerance when comparing the AD Jacobians. Deviation from default only advised when values are numerically challenging, i.e. are at least 1E+10
 	 * @param [in] flowRate flow rate, needs to be specified for 2D units, where velocity is derived from flow rates.
 	 */
-	void testJacobianAD(JsonParameterProvider& jpp, const double absTolFDpattern = 0.0, const double absTolAD = std::numeric_limits<float>::epsilon() * 100.0, const cadet::active* flowRate = nullptr);
+	void testJacobianAD(JsonParameterProvider& jpp, const double absTolFDpattern = 0.0, const double absTolAD = std::numeric_limits<float>::epsilon() * 100.0, const std::vector<double> flowRate = {});
 
 	/**
 	 * @brief Checks the full Jacobian against AD and FD pattern switching in case of variable surface diffusion coefficient

--- a/test/JsonTestModels.cpp
+++ b/test/JsonTestModels.cpp
@@ -77,13 +77,21 @@ json createColumnWithSMAJson(const std::string& uoType, const std::string& spati
 		config["NCHANNEL"] = 1;
 
 	// Geometry
-	if (uoType.substr(0, 6) == "RADIAL" || uoType.substr(0, 7) == "FRUSTUM")
+	if (uoType.substr(0, 6) == "RADIAL" || (uoType.substr(0, 7) == "FRUSTUM" && bulkMethod == "FV"))
 	{
 		config["COL_RADIUS_INNER"] = 0.001;
 		config["COL_RADIUS_OUTER"] = 0.004;
 		if (uoType.substr(0, 7) == "FRUSTUM")
 			config["COL_LENGTH"] = 0.01;
 		config["VELOCITY_COEFF"] = 5.75e-4;
+	}
+	else if (uoType.substr(0, 7) == "FRUSTUM" && bulkMethod == "DG")
+	{
+		config["GEOMETRY"] = "AXIAL_FLOW_FRUSTUM";
+		config["COL_LENGTH"] = 0.014;
+		config["COL_RADIUS_LARGE_END"] = 0.007023769168568; // we get v = 5.75e-4 at large radius with Q = 6.683738370512285e-8 and eps^b = 0.75
+		config["COL_RADIUS_SMALL_END"] = 0.004;
+		config["FORWARD_FLOW"] = { 1 };
 	}
 	else
 	{
@@ -1127,13 +1135,21 @@ json createLinearBenchmarkColumnJson(bool dynamicBinding, bool nonBinding, const
 		grm["NCHANNEL"] = 3;
 
 	// Geometry
-	if (uoType.substr(0, 6) == "RADIAL" || uoType.substr(0, 7) == "FRUSTUM")
+	if (uoType.substr(0, 6) == "RADIAL" || (uoType.substr(0, 7) == "FRUSTUM" && bulkMethod == "FV"))
 	{
 		grm["COL_RADIUS_INNER"] = 0.001;
 		grm["COL_RADIUS_OUTER"] = 0.004;
 		if (uoType.substr(0, 7) == "FRUSTUM")
 			grm["COL_LENGTH"] = 0.01;
 		grm["VELOCITY_COEFF"] = 5.75e-4;
+	}
+	else if (uoType.substr(0, 7) == "FRUSTUM" && bulkMethod == "DG")
+	{
+		grm["GEOMETRY"] = "AXIAL_FLOW_FRUSTUM";
+		grm["COL_LENGTH"] = 0.05;
+		grm["COL_RADIUS_LARGE_END"] = 0.05;
+		grm["COL_RADIUS_SMALL_END"] = 0.01;
+		grm["FORWARD_FLOW"] = { 1 };
 	}
 	else
 	{


### PR DESCRIPTION
This PR adds a DG discretization for the frustum geometry.
CI tests are: Jacobian AD test, bwd vs fwd flow test (with inlet radius = outlet radius), and EOC tests implemented in https://github.com/cadet/CADET-Verification/tree/feature/frustumDG
EOC rates are excellent:
                    0.0,
                    1.3658614887644018,
                    3.5057385316492713,
                    5.4915312483818095,
                    5.361584012890104,
                    4.867405052499091,
                    4.67274387461102
[convergence_COL1D_frustumTransport_1comp_benchmark1.json](https://github.com/user-attachments/files/30469850/convergence_COL1D_frustumTransport_1comp_benchmark1.json)

