### PR TITLE
CI: ignore gcov suspicious hit parse errors during coverage generation

### DIFF
--- a/.github/workflows/ci_coverage.yml
+++ b/.github/workflows/ci_coverage.yml
@@ -187,6 +187,7 @@ jobs:
             --root "${{ github.workspace }}" \
             --filter "${{ github.workspace }}/(src|include|build/src)" \
             --exclude-directories '.*ThirdParty.*' \
+            --gcov-ignore-parse-errors=suspicious_hits.warn_once_per_file \
             --cobertura -o coverage.xml \
             --gcov-executable gcov-14 \
             --txt=-


### PR DESCRIPTION
Recent versions of gcovr treat "suspicious hit" values reported by gcov as fatal parse errors, causing the coverage workflow to fail even though this is a known gcov issue that commonly affects heavily templated C++ code.

Configure gcovr to downgrade these parse errors to warnings (once per file) using:

  --gcov-ignore-parse-errors=suspicious_hits.warn_once_per_file

This preserves coverage report generation while still surfacing the issue in the workflow logs, avoiding failures caused by GCC/gcov bug 68080.