### PR TITLE
Chore: rename coordinates in `ColumnPosition` struct

### DIFF
--- a/src/libcadet/SimulationTypes.hpp
+++ b/src/libcadet/SimulationTypes.hpp
@@ -28,9 +28,9 @@ namespace cadet
  */
 struct ColumnPosition
 {
-	double axial; //!< Axial bulk coordinate z
-	double radial; //!< Radial bulk coordinate rho
-	double particle; //!< Radial particle coordinate r
+	double primary; //!< primary bulk coordinate
+	double secondary; //!< secondary bulk coordinate
+	double particle; //!< Radial particle coordinate
 };
 
 /**

--- a/src/libcadet/model/ExternalFunctionSupport.hpp
+++ b/src/libcadet/model/ExternalFunctionSupport.hpp
@@ -168,8 +168,7 @@ namespace model
 		/**
 		 * @brief Evaluates the external functions for the different parameters
 		 * @param [in] t Current time
-		 * @param [in] z Axial coordinate in the column
-		 * @param [in] r Radial coordinate in the bead
+		 * @param [in] colPos with particle and primary/secondary bulk coordinates
 		 * @param [in] secIdx Index of the current section
 		 * @param [in] nParams Number of externally dependent parameters (also size of buffer)
 		 * @param [out] buffer Buffer that holds function evaluations
@@ -180,7 +179,7 @@ namespace model
 			{
 				IExternalFunction* const fun = _extFun[i];
 				if (fun)
-					buffer[i] = fun->externalProfile(t, colPos.axial, colPos.radial, colPos.particle, secIdx);
+					buffer[i] = fun->externalProfile(t, colPos.primary, colPos.secondary, colPos.particle, secIdx);
 				else
 					buffer[i] = 0.0;
 			}
@@ -201,7 +200,7 @@ namespace model
 			{
 				IExternalFunction* const fun = _extFun[i];
 				if (fun)
-					buffer[i] = fun->timeDerivative(t, colPos.axial, colPos.radial, colPos.particle, secIdx);
+					buffer[i] = fun->timeDerivative(t, colPos.primary, colPos.secondary, colPos.particle, secIdx);
 				else
 					buffer[i] = 0.0;
 			}


### PR DESCRIPTION
This commit updates the ColumnPosition names to the geometrically generalized unit operations, the column position is determined by a primary flow directional coordinate and a secondary coordinate.