### PR TITLE
Add dispersion param dep to frustum DG implementation

### DIFF
--- a/src/libcadet/model/GeneralRateModel.cpp
+++ b/src/libcadet/model/GeneralRateModel.cpp
@@ -2010,7 +2010,7 @@ int GeneralRateModel<ConvDispOperator>::residualFlux(double t, unsigned int secI
 			const ParamType curVelocity = static_cast<ParamType>(_convDispOp.currentVelocity(relPos));
 			for (unsigned int comp = 0; comp < _disc.nComp; ++comp)
 			{
-				const ParamType modifier = static_cast<ParamType>(_filmDiffDep->getValue(*this, ColumnPosition{relPos, 0.0, 0.0}, comp, ParTypeIndep, BoundStateIndep, curVelocity));
+				const ParamType modifier = static_cast<ParamType>(_filmDiffDep->getValue(ColumnPosition{relPos, 0.0, 0.0}, comp, ParTypeIndep, BoundStateIndep, curVelocity));
 				const ParamType filmDiffMod = static_cast<ParamType>(filmDiff[comp]) * modifier;
 				ParamType kf_FV_local;
 				if (cadet_likely(_colParBoundaryOrder == 2))
@@ -2044,7 +2044,7 @@ int GeneralRateModel<ConvDispOperator>::residualFlux(double t, unsigned int secI
 			const ParamType curVelocity = static_cast<ParamType>(_convDispOp.currentVelocity(relPos));
 			for (unsigned int comp = 0; comp < _disc.nComp; ++comp)
 			{
-				const ParamType modifier = static_cast<ParamType>(_filmDiffDep->getValue(*this, ColumnPosition{relPos, 0.0, 0.0}, comp, ParTypeIndep, BoundStateIndep, curVelocity));
+				const ParamType modifier = static_cast<ParamType>(_filmDiffDep->getValue(ColumnPosition{relPos, 0.0, 0.0}, comp, ParTypeIndep, BoundStateIndep, curVelocity));
 				const ParamType filmDiffMod = static_cast<ParamType>(filmDiff[comp]) * modifier;
 				ParamType kf_FV_local;
 				if (cadet_likely(_colParBoundaryOrder == 2))
@@ -2078,7 +2078,7 @@ int GeneralRateModel<ConvDispOperator>::residualFlux(double t, unsigned int secI
 
 				for (unsigned int comp = 0; comp < _disc.nComp; ++comp)
 				{
-					const ParamType modifier = static_cast<ParamType>(_filmDiffDep->getValue(*this, ColumnPosition{relPos, 0.0, 0.0}, comp, ParTypeIndep, BoundStateIndep, curVelocity));
+					const ParamType modifier = static_cast<ParamType>(_filmDiffDep->getValue(ColumnPosition{relPos, 0.0, 0.0}, comp, ParTypeIndep, BoundStateIndep, curVelocity));
 					const ParamType filmDiffMod = static_cast<ParamType>(filmDiff[comp]) * modifier;
 					kf_FV[comp] = (1.0 - static_cast<ParamType>(_parPorosity[type])) / (1.0 + epsP * static_cast<ParamType>(_poreAccessFactor[type * _disc.nComp + comp]) * static_cast<ParamType>(parDiff[comp]) / (absOuterShellHalfRadius * filmDiffMod));
 
@@ -2191,7 +2191,7 @@ void GeneralRateModel<ConvDispOperator>::assembleOffdiagJac(double t, unsigned i
 			const double curVelocity = static_cast<double>(_convDispOp.currentVelocity(relPos));
 			for (unsigned int comp = 0; comp < _disc.nComp; ++comp)
 			{
-				const double modifier = static_cast<double>(_filmDiffDep->getValue(*this, ColumnPosition{relPos, 0.0, 0.0}, comp, ParTypeIndep, BoundStateIndep, curVelocity));
+				const double modifier = static_cast<double>(_filmDiffDep->getValue(ColumnPosition{relPos, 0.0, 0.0}, comp, ParTypeIndep, BoundStateIndep, curVelocity));
 				const double filmDiffMod = static_cast<double>(filmDiff[comp]) * modifier;
 				double kf_FV_local;
 				if (cadet_likely(_colParBoundaryOrder == 2))
@@ -2228,7 +2228,7 @@ void GeneralRateModel<ConvDispOperator>::assembleOffdiagJac(double t, unsigned i
 			const double curVelocity = static_cast<double>(_convDispOp.currentVelocity(relPos));
 			for (unsigned int comp = 0; comp < _disc.nComp; ++comp)
 			{
-				const double modifier = static_cast<double>(_filmDiffDep->getValue(*this, ColumnPosition{relPos, 0.0, 0.0}, comp, ParTypeIndep, BoundStateIndep, curVelocity));
+				const double modifier = static_cast<double>(_filmDiffDep->getValue(ColumnPosition{relPos, 0.0, 0.0}, comp, ParTypeIndep, BoundStateIndep, curVelocity));
 				const double filmDiffMod = static_cast<double>(filmDiff[comp]) * modifier;
 				double kf_FV_local;
 				if (cadet_likely(_colParBoundaryOrder == 2))
@@ -2264,7 +2264,7 @@ void GeneralRateModel<ConvDispOperator>::assembleOffdiagJac(double t, unsigned i
 
 				for (unsigned int comp = 0; comp < _disc.nComp; ++comp)
 				{
-					const double modifier = static_cast<double>(_filmDiffDep->getValue(*this, ColumnPosition{relPos, 0.0, 0.0}, comp, ParTypeIndep, BoundStateIndep, curVelocity));
+					const double modifier = static_cast<double>(_filmDiffDep->getValue(ColumnPosition{relPos, 0.0, 0.0}, comp, ParTypeIndep, BoundStateIndep, curVelocity));
 					const double filmDiffMod = static_cast<double>(filmDiff[comp]) * modifier;
 					kf_FV[comp] = (1.0 - static_cast<double>(_parPorosity[type])) / (1.0 + epsP * static_cast<double>(_poreAccessFactor[type * _disc.nComp + comp]) * static_cast<double>(parDiff[comp]) / (absOuterShellHalfRadius * filmDiffMod));
 
@@ -2362,7 +2362,7 @@ void GeneralRateModel<ConvDispOperator>::assembleOffdiagJacFluxParticle(double t
 			const double curVelocity = static_cast<double>(_convDispOp.currentVelocity(relPos));
 			for (unsigned int comp = 0; comp < _disc.nComp; ++comp)
 			{
-				const double modifier = static_cast<double>(_filmDiffDep->getValue(*this, ColumnPosition{relPos, 0.0, 0.0}, comp, ParTypeIndep, BoundStateIndep, curVelocity));
+				const double modifier = static_cast<double>(_filmDiffDep->getValue(ColumnPosition{relPos, 0.0, 0.0}, comp, ParTypeIndep, BoundStateIndep, curVelocity));
 				const double filmDiffMod = static_cast<double>(filmDiff[comp]) * modifier;
 				double kf_FV_local;
 				if (cadet_likely(_colParBoundaryOrder == 2))
@@ -2398,7 +2398,7 @@ void GeneralRateModel<ConvDispOperator>::assembleOffdiagJacFluxParticle(double t
 
 				for (unsigned int comp = 0; comp < _disc.nComp; ++comp)
 				{
-					const double modifier = static_cast<double>(_filmDiffDep->getValue(*this, ColumnPosition{relPos, 0.0, 0.0}, comp, ParTypeIndep, BoundStateIndep, curVelocity));
+					const double modifier = static_cast<double>(_filmDiffDep->getValue(ColumnPosition{relPos, 0.0, 0.0}, comp, ParTypeIndep, BoundStateIndep, curVelocity));
 					const double filmDiffMod = static_cast<double>(filmDiff[comp]) * modifier;
 					kf_FV[comp] = (1.0 - static_cast<double>(_parPorosity[type])) / (1.0 + epsP * static_cast<double>(_poreAccessFactor[type * _disc.nComp + comp]) * static_cast<double>(parDiff[comp]) / (absOuterShellHalfRadius * filmDiffMod));
 					const unsigned int eq = typeOffset + pblk * idxr.strideColCell() + comp * idxr.strideColComp();

--- a/src/libcadet/model/LumpedRateModelWithPores.cpp
+++ b/src/libcadet/model/LumpedRateModelWithPores.cpp
@@ -1121,7 +1121,7 @@ int LumpedRateModelWithPores<ConvDispOperator>::residualFlux(double t, unsigned 
 
 			const double relPos = _convDispOp.relativeCoordinate(colCell);
 			const active curVelocity = _convDispOp.currentVelocity(relPos);
-			const active modifier = _filmDiffDep->getValue(*this, ColumnPosition{relPos, 0.0, 0.0}, comp, ParTypeIndep, BoundStateIndep, curVelocity);
+			const active modifier = _filmDiffDep->getValue(ColumnPosition{relPos, 0.0, 0.0}, comp, ParTypeIndep, BoundStateIndep, curVelocity);
 
 			resCol[i] += jacCF_val * static_cast<ParamType>(filmDiff[comp]) * static_cast<ParamType>(modifier) * static_cast<ParamType>(_parTypeVolFrac[type + _disc.nParType * colCell]) * yFluxType[i];
 		}
@@ -1144,7 +1144,7 @@ int LumpedRateModelWithPores<ConvDispOperator>::residualFlux(double t, unsigned 
 
 			for (unsigned int comp = 0; comp < _disc.nComp; ++comp)
 			{
-				const active modifier = _filmDiffDep->getValue(*this, ColumnPosition{relPos, 0.0, 0.0}, comp, ParTypeIndep, BoundStateIndep, curVelocity);
+				const active modifier = _filmDiffDep->getValue(ColumnPosition{relPos, 0.0, 0.0}, comp, ParTypeIndep, BoundStateIndep, curVelocity);
 
 				const unsigned int eq = pblk * idxr.strideColCell() + comp * idxr.strideColComp();
 				resParType[pblk * idxr.strideParBlock(type) + comp] += jacPF_val / static_cast<ParamType>(poreAccFactor[comp]) * static_cast<ParamType>(filmDiff[comp]) * static_cast<ParamType>(modifier) * yFluxType[eq];
@@ -1210,7 +1210,7 @@ void LumpedRateModelWithPores<ConvDispOperator>::assembleOffdiagJac(double t, un
 
 			const double relPos = _convDispOp.relativeCoordinate(colCell);
 			const double curVelocity = static_cast<double>(_convDispOp.currentVelocity(relPos));
-			const double modifier = _filmDiffDep->getValue(*this, ColumnPosition{relPos, 0.0, 0.0}, comp, ParTypeIndep, BoundStateIndep, curVelocity);
+			const double modifier = _filmDiffDep->getValue(ColumnPosition{relPos, 0.0, 0.0}, comp, ParTypeIndep, BoundStateIndep, curVelocity);
 
 			// Main diagonal corresponds to j_{f,i} (flux) state variable
 			_jacCF.addElement(eq, eq + typeOffset, jacCF_val * static_cast<double>(filmDiff[comp]) * modifier * static_cast<double>(_parTypeVolFrac[type + _disc.nParType * colCell]));
@@ -1233,7 +1233,7 @@ void LumpedRateModelWithPores<ConvDispOperator>::assembleOffdiagJac(double t, un
 				const unsigned int eq = typeOffset + pblk * idxr.strideColCell() + comp * idxr.strideColComp();
 				const unsigned int col = pblk * idxr.strideParBlock(type) + comp;
 
-				const double modifier = _filmDiffDep->getValue(*this, ColumnPosition{relPos, 0.0, 0.0}, comp, ParTypeIndep, BoundStateIndep, curVelocity);
+				const double modifier = _filmDiffDep->getValue(ColumnPosition{relPos, 0.0, 0.0}, comp, ParTypeIndep, BoundStateIndep, curVelocity);
 				_jacPF[type].addElement(col, eq, jacPF_val / static_cast<double>(poreAccFactor[comp]) * static_cast<double>(filmDiff[comp]) * modifier);
 			}
 		}

--- a/src/libcadet/model/ParameterDependence.hpp
+++ b/src/libcadet/model/ParameterDependence.hpp
@@ -461,7 +461,7 @@ public:
 	 * @param [in] bnd Index of the bound state the parameter belongs to (or @c -1 if independent of bound states)
 	 * @return Actual parameter value
 	 */
-	virtual double getValue(const IModel& model, const ColumnPosition& colPos, int comp, int parType, int bnd) const = 0;
+	virtual double getValue(const ColumnPosition& colPos, int comp, int parType, int bnd) const = 0;
 
 	/**
 	 * @brief Evaluates the parameter
@@ -474,21 +474,7 @@ public:
 	 * @param [in] bnd Index of the bound state the parameter belongs to (or @c -1 if independent of bound states)
 	 * @return Actual parameter value
 	 */
-	virtual active getValueActive(const IModel& model, const ColumnPosition& colPos, int comp, int parType, int bnd) const = 0;
-
-	/**
-	 * @brief Evaluates the parameter
-	 * @details This function is called simultaneously from multiple threads.
-	 * 
-	 * @param [in] model Model that owns this parameter dependence
-	 * @param [in] colPos Position in normalized coordinates (column inlet = 0, column outlet = 1; outer shell = 1, inner center = 0)
-	 * @param [in] comp Index of the component the parameter belongs to (or @c -1 if independent of components)
-	 * @param [in] parType Index of the particle type the parameter belongs to (or @c -1 if independent of particle types)
-	 * @param [in] bnd Index of the bound state the parameter belongs to (or @c -1 if independent of bound states)
-	 * @param [in] val Additional parameter-dependent value
-	 * @return Actual parameter value
-	 */
-	virtual double getValue(const IModel& model, const ColumnPosition& colPos, int comp, int parType, int bnd, double val) const = 0;
+	virtual active getValueActive(const ColumnPosition& colPos, int comp, int parType, int bnd) const = 0;
 
 	/**
 	 * @brief Evaluates the parameter
@@ -502,7 +488,21 @@ public:
 	 * @param [in] val Additional parameter-dependent value
 	 * @return Actual parameter value
 	 */
-	virtual active getValue(const IModel& model, const ColumnPosition& colPos, int comp, int parType, int bnd, const active& val) const = 0;
+	virtual double getValue(const ColumnPosition& colPos, int comp, int parType, int bnd, double val) const = 0;
+
+	/**
+	 * @brief Evaluates the parameter
+	 * @details This function is called simultaneously from multiple threads.
+	 * 
+	 * @param [in] model Model that owns this parameter dependence
+	 * @param [in] colPos Position in normalized coordinates (column inlet = 0, column outlet = 1; outer shell = 1, inner center = 0)
+	 * @param [in] comp Index of the component the parameter belongs to (or @c -1 if independent of components)
+	 * @param [in] parType Index of the particle type the parameter belongs to (or @c -1 if independent of particle types)
+	 * @param [in] bnd Index of the bound state the parameter belongs to (or @c -1 if independent of bound states)
+	 * @param [in] val Additional parameter-dependent value
+	 * @return Actual parameter value
+	 */
+	virtual active getValue(const ColumnPosition& colPos, int comp, int parType, int bnd, const active& val) const = 0;
 
 protected:
 };

--- a/src/libcadet/model/paramdep/DummyParameterDependence.cpp
+++ b/src/libcadet/model/paramdep/DummyParameterDependence.cpp
@@ -165,13 +165,13 @@ protected:
 	}
 
 	template <typename ParamType>
-	ParamType getValueImpl(const IModel& model, const ColumnPosition& colPos, int comp, int parType, int bnd) const
+	ParamType getValueImpl(const ColumnPosition& colPos, int comp, int parType, int bnd) const
 	{
 		return 0.0;
 	}
 
 	template <typename ParamType>
-	ParamType getValueImpl(const IModel& model, const ColumnPosition& colPos, int comp, int parType, int bnd, const ParamType& val) const
+	ParamType getValueImpl(const ColumnPosition& colPos, int comp, int parType, int bnd, const ParamType& val) const
 	{
 		return 0.0;
 	}
@@ -202,13 +202,13 @@ protected:
 	}
 
 	template <typename ParamType>
-	ParamType getValueImpl(const IModel& model, const ColumnPosition& colPos, int comp, int parType, int bnd) const
+	ParamType getValueImpl(const ColumnPosition& colPos, int comp, int parType, int bnd) const
 	{
 		return 1.0;
 	}
 
 	template <typename ParamType>
-	ParamType getValueImpl(const IModel& model, const ColumnPosition& colPos, int comp, int parType, int bnd, const ParamType& val) const
+	ParamType getValueImpl(const ColumnPosition& colPos, int comp, int parType, int bnd, const ParamType& val) const
 	{
 		return 1.0;
 	}

--- a/src/libcadet/model/paramdep/IdentityParameterDependence.cpp
+++ b/src/libcadet/model/paramdep/IdentityParameterDependence.cpp
@@ -107,13 +107,13 @@ protected:
 	}
 
 	template <typename ParamType>
-	ParamType getValueImpl(const IModel& model, const ColumnPosition& colPos, int comp, int parType, int bnd) const
+	ParamType getValueImpl(const ColumnPosition& colPos, int comp, int parType, int bnd) const
 	{
 		return 0.0;
 	}
 
 	template <typename ParamType>
-	ParamType getValueImpl(const IModel& model, const ColumnPosition& colPos, int comp, int parType, int bnd, const ParamType& val) const
+	ParamType getValueImpl(const ColumnPosition& colPos, int comp, int parType, int bnd, const ParamType& val) const
 	{
 		return val;
 	}

--- a/src/libcadet/model/paramdep/ParameterDependenceBase.hpp
+++ b/src/libcadet/model/paramdep/ParameterDependenceBase.hpp
@@ -65,9 +65,9 @@ protected:
 	std::unordered_map<ParameterId, active*> _parameters; //!< Map used to translate ParameterIds to actual variables
 
 	/**
-	 * @brief Configures the reaction model
-	 * @details This function implements the (re-)configuration of a reaction model. It is called when
-	 *          the reaction model is configured or reconfigured. On call the _parameters map will always
+	 * @brief Configures the parameter dependence model
+	 * @details This function implements the (re-)configuration of a parameter dependence model. It is called when
+	 *          the parameter dependence model is configured or reconfigured. On call the _parameters map will always
 	 *          be empty.
 	 * @param [in] paramProvider Parameter provider
 	 * @param [in] unitOpIdx Unit operation index
@@ -216,9 +216,9 @@ protected:
 	std::unordered_map<ParameterId, active*> _parameters; //!< Map used to translate ParameterIds to actual variables
 
 	/**
-	 * @brief Configures the reaction model
-	 * @details This function implements the (re-)configuration of a reaction model. It is called when
-	 *          the reaction model is configured or reconfigured. On call the _parameters map will always
+	 * @brief Configures the parameter dependence model
+	 * @details This function implements the (re-)configuration of a parameter dependence model. It is called when
+	 *          the parameter dependence model is configured or reconfigured. On call the _parameters map will always
 	 *          be empty.
 	 * @param [in] paramProvider Parameter provider
 	 * @param [in] unitOpIdx Unit operation index
@@ -242,24 +242,24 @@ protected:
  *          The implementation is inserted inline in the class declaration.
  */
 #define CADET_PARAMETERPARAMETERDEPENDENCE_BOILERPLATE                                                                                  \
-	virtual double getValue(const IModel& model, const ColumnPosition& colPos, int comp, int parType, int bnd, double val) const        \
+	virtual double getValue(const ColumnPosition& colPos, int comp, int parType, int bnd, double val) const                             \
 	{                                                                                                                                   \
-		return getValueImpl<double>(model, colPos, comp, parType, bnd, val);                                                            \
+		return getValueImpl<double>(colPos, comp, parType, bnd, val);                                                                   \
 	}                                                                                                                                   \
                                                                                                                                         \
-	virtual active getValue(const IModel& model, const ColumnPosition& colPos, int comp, int parType, int bnd, const active& val) const \
+	virtual active getValue(const ColumnPosition& colPos, int comp, int parType, int bnd, const active& val) const                      \
 	{                                                                                                                                   \
-		return getValueImpl<active>(model, colPos, comp, parType, bnd, val);                                                            \
+		return getValueImpl<active>(colPos, comp, parType, bnd, val);                                                                   \
 	}                                                                                                                                   \
                                                                                                                                         \
-	virtual double getValue(const IModel& model, const ColumnPosition& colPos, int comp, int parType, int bnd) const                    \
+	virtual double getValue(const ColumnPosition& colPos, int comp, int parType, int bnd) const                                         \
 	{                                                                                                                                   \
-		return getValueImpl<double>(model, colPos, comp, parType, bnd);                                                                 \
+		return getValueImpl<double>(colPos, comp, parType, bnd);                                                                        \
 	}                                                                                                                                   \
                                                                                                                                         \
-	virtual active getValueActive(const IModel& model, const ColumnPosition& colPos, int comp, int parType, int bnd) const              \
+	virtual active getValueActive(const ColumnPosition& colPos, int comp, int parType, int bnd) const                                   \
 	{                                                                                                                                   \
-		return getValueImpl<active>(model, colPos, comp, parType, bnd);                                                                 \
+		return getValueImpl<active>(colPos, comp, parType, bnd);                                                                        \
 	}
 
 

--- a/src/libcadet/model/paramdep/PowerLawParameterDependence.cpp
+++ b/src/libcadet/model/paramdep/PowerLawParameterDependence.cpp
@@ -71,13 +71,13 @@ protected:
 	}
 
 	template <typename ParamType>
-	ParamType getValueImpl(const IModel& model, const ColumnPosition& colPos, int comp, int parType, int bnd) const
+	ParamType getValueImpl(const ColumnPosition& colPos, int comp, int parType, int bnd) const
 	{
 		return 0.0;
 	}
 
 	template <typename ParamType>
-	ParamType getValueImpl(const IModel& model, const ColumnPosition& colPos, int comp, int parType, int bnd, ParamType val) const
+	ParamType getValueImpl(const ColumnPosition& colPos, int comp, int parType, int bnd, ParamType val) const
 	{
 		using std::pow;
 		using std::abs;

--- a/src/libcadet/model/parts/AxialConvectionDispersionKernelFV.hpp
+++ b/src/libcadet/model/parts/AxialConvectionDispersionKernelFV.hpp
@@ -59,7 +59,6 @@ struct AxialFlowParameters
 	unsigned int offsetToInlet; //!< Offset to the first component of the inlet DOFs in the local state vector
 	unsigned int offsetToBulk; //!< Offset to the first component of the first bulk cell in the local state vector
 	IParameterParameterDependence* parDep;
-	const IModel& model;
 	bool gridEquidistant;
 	std::vector<active> const* cellFaces; //!< Positions of the cell faces for non-equidistant grids
 };
@@ -146,7 +145,7 @@ namespace impl
 						static_cast<double>((*p.cellFaces)[col + 1]) / static_cast<double>(colLength) :
 						static_cast<double>(col + 1) / p.nCol;                                                                                // relative coordinate of the cell face for parameter dependence
 
-					const ParamType d_ax_right = d_ax * p.parDep->getValue(p.model, ColumnPosition{ relCoord, 0.0, 0.0 }, comp, ParTypeIndep, BoundStateIndep, static_cast<ParamType>(p.u));
+					const ParamType d_ax_right = d_ax * p.parDep->getValue(ColumnPosition{ relCoord, 0.0, 0.0 }, comp, ParTypeIndep, BoundStateIndep, static_cast<ParamType>(p.u));
 					
 					const ParamType coeff = d_ax_right / (hCol * deltaZ);
 
@@ -169,7 +168,7 @@ namespace impl
 						static_cast<double>((*p.cellFaces)[col]) / static_cast<double>(colLength) :
 						static_cast<double>(col) / p.nCol;
 
-					const ParamType d_ax_left = d_ax * p.parDep->getValue(p.model, ColumnPosition{ relCoord, 0.0, 0.0 }, comp, ParTypeIndep, BoundStateIndep, static_cast<ParamType>(p.u));
+					const ParamType d_ax_left = d_ax * p.parDep->getValue(ColumnPosition{ relCoord, 0.0, 0.0 }, comp, ParTypeIndep, BoundStateIndep, static_cast<ParamType>(p.u));
 
 					const ParamType coeff = d_ax_left / (hCol * deltaZ);
 					if (wantRes)
@@ -325,7 +324,7 @@ namespace impl
 					const double relCoord = nonEqGrid ?
 						static_cast<double>((*p.cellFaces)[col + 1]) / static_cast<double>(colLength) :
 						static_cast<double>(col + 1) / p.nCol;
-					const ParamType d_ax_right = d_ax * p.parDep->getValue(p.model, ColumnPosition{ relCoord, 0.0, 0.0 }, comp, ParTypeIndep, BoundStateIndep, static_cast<ParamType>(p.u));
+					const ParamType d_ax_right = d_ax * p.parDep->getValue(ColumnPosition{ relCoord, 0.0, 0.0 }, comp, ParTypeIndep, BoundStateIndep, static_cast<ParamType>(p.u));
 					
 					const ParamType coeff = d_ax_right / (hCol * deltaZ);
 					if (wantRes)
@@ -347,7 +346,7 @@ namespace impl
 						static_cast<double>((*p.cellFaces)[col]) / static_cast<double>(colLength) :
 						static_cast<double>(col) / p.nCol;
 
-					const ParamType d_ax_left = d_ax * p.parDep->getValue(p.model, ColumnPosition{ relCoord, 0.0, 0.0 }, comp, ParTypeIndep, BoundStateIndep, static_cast<ParamType>(p.u));
+					const ParamType d_ax_left = d_ax * p.parDep->getValue(ColumnPosition{ relCoord, 0.0, 0.0 }, comp, ParTypeIndep, BoundStateIndep, static_cast<ParamType>(p.u));
 
 					const ParamType coeff = d_ax_left / (hCol * deltaZ);
 					if (wantRes)

--- a/src/libcadet/model/parts/ConvectionDispersionOperatorDG.cpp
+++ b/src/libcadet/model/parts/ConvectionDispersionOperatorDG.cpp
@@ -27,6 +27,7 @@
 #include <Eigen/Sparse>
 #include <algorithm>
 #include <cmath>
+#include <cstring>
 
 namespace cadet
 {
@@ -1159,21 +1160,6 @@ void RadialConvectionDispersionOperatorBaseDG::TransposedADWeightedStiffnessMatr
 			quadWeights);
 
 		_S_g[elem] = _polyDerM.transpose() * M_AD;
-
-		//Eigen::MatrixXd S_g_ref =
-		//	dgtoolbox::radialDispersionMatrix(
-		//		_polyDeg,
-		//		_nodes,
-		//		rho_left,
-		//		deltaRho,
-		//		_dispersionAtNodes[elem],
-		//		nQuadPoints);
-
-		//if(!_S_g[elem].isApprox(S_g_ref, 1e-15))
-		//{
-		//	std::cout << "Computed S_g:\n" << _S_g[elem] << "\n";
-		//	std::cout << "Reference radial dispersion matrix:\n" << dgtoolbox::radialDispersionMatrix(_polyDeg, _nodes, rho_left, deltaRho, _dispersionAtNodes[elem], nQuadPoints) << "\n";
-		//}
 	}
 }
 
@@ -1866,10 +1852,6 @@ bool FrustumConvectionDispersionOperatorBaseDG::configureModelDiscretization(IPa
 	_strideNode = strideNode;
 	_strideElem = _nNodes * strideNode;
 
-	// Read quadrature parameters
-	_axDispQuadDeg = paramProvider.exists("DISPERSION_SPATIAL_DEPENDENCE_POLYDEG") ? paramProvider.getInt("DISPERSION_SPATIAL_DEPENDENCE_POLYDEG") : 0;
-	_filmDiffQuadDeg = paramProvider.exists("FILM_DIFFUSION_SPATIAL_DEPENDENCE_POLYDEG") ? paramProvider.getInt("FILM_DIFFUSION_SPATIAL_DEPENDENCE_POLYDEG") : 0;
-
 	// Read frustum geometry parameters
 	_radiusXStart = paramProvider.getDouble("COL_RADIUS_LARGE_END");
 	_radiusXEnd = paramProvider.getDouble("COL_RADIUS_SMALL_END");
@@ -1927,6 +1909,16 @@ bool FrustumConvectionDispersionOperatorBaseDG::configureModelDiscretization(IPa
 	}
 	else
 		_dispersionDep = helper.createParameterParameterDependence("CONSTANT_ONE");
+
+	_variableDispersion = std::strcmp(_dispersionDep->name(), "CONSTANT_ONE") != 0;
+	if (_variableDispersion)
+	{
+		if (!paramProvider.exists("DISPERSION_SPATIAL_DEPENDENCE_POLYDEG"))
+			throw InvalidParameterException("Missing DISPERSION_SPATIAL_DEPENDENCE_POLYDEG parameter for variable dispersion, see COL_DISPERSION_DEP");
+
+		_axDispQuadDeg = paramProvider.getInt("DISPERSION_SPATIAL_DEPENDENCE_POLYDEG");
+	}
+	else _axDispQuadDeg = 0;
 
 	// Allocate per-cell Jacobian blocks
 	_DGjacFrustumDispBlocks.resize(_nComp);
@@ -1998,7 +1990,7 @@ bool FrustumConvectionDispersionOperatorBaseDG::configure(UnitOpIdx unitOpIdx, I
 
 	// Geometry dependent operators
 	computeGeometryFrustum();
-	computeOperatorsFrustum();
+	computeOperatorsFrustum(0);
 
 	return true;
 }
@@ -2009,7 +2001,9 @@ bool FrustumConvectionDispersionOperatorBaseDG::notifyDiscontinuousSectionTransi
 	_newStaticJac = true;
 
 	// note: flow direction is set by setFlowRates() before notifyDiscontinuousSectionTransition() is called
-	_curFwdFlow = _forwardFlow.size() > 1 ? _forwardFlow[secIdx] : _forwardFlow[0];
+	const bool newFlowFwdDir = _forwardFlow.size() > 1 ? _forwardFlow[secIdx] : _forwardFlow[0];
+	const bool flowDirChange = _curFwdFlow == newFlowFwdDir;
+	_curFwdFlow = newFlowFwdDir;
 
 	// Recompute direction dependent Jacobian blocks.
 	for (unsigned int elem = 0; elem < _nElem; elem++)
@@ -2020,7 +2014,10 @@ bool FrustumConvectionDispersionOperatorBaseDG::notifyDiscontinuousSectionTransi
 	else
 		jacInlet = _DGjacFrustumConvBlocks[_nElem - 1].col(_DGjacFrustumConvBlocks[_nElem - 1].cols() - 1);
 
-	return true;
+	// some model parameters are baked into the DG operators but may be updated at section transitions
+	computeOperatorsFrustum(secIdx);
+
+	return flowDirChange;
 }
 
 void FrustumConvectionDispersionOperatorBaseDG::setFlowRates(const active& in, const active& out, const active& colPorosity) CADET_NOEXCEPT
@@ -2111,7 +2108,7 @@ void FrustumConvectionDispersionOperatorBaseDG::computeGeometryFrustum()
 	}
 }
 
-void FrustumConvectionDispersionOperatorBaseDG::computeOperatorsFrustum()
+void FrustumConvectionDispersionOperatorBaseDG::computeOperatorsFrustum(const unsigned int secIdx)
 {
 	const double pi = 3.14159265358979323846;
 	const double H = static_cast<double>(_bedLength);
@@ -2129,30 +2126,71 @@ void FrustumConvectionDispersionOperatorBaseDG::computeOperatorsFrustum()
 		comps.resize(_nElem);
 	_invMM_A_times_DT_timesM00.resize(_nElem);
 
+	// number of nodes for exact gauss quadrature of the integral with dispersion weight
+	const int frustumGeomFactorDegree = 2; // we have r(x)^2 = (r0 + x/H * (rH - r0))^2, which is a polynomial of degree 2 in x
+	const int nQuadNodes = std::ceil((_axDispQuadDeg + frustumGeomFactorDegree + 2 * _polyDeg + 1) / 2);
+	// geometric weight factors as ( \sum_n (1 - \xi)^\alpha_n + \sum_m (1 + \xi)^\beta_m + gamma) = A(x^e(\xi)) = A((\xi + 1) \DeltaX_i / 2 + x_i)
+	// with A = \pi r(x)^2 and r(x) = r_0 + \frac{x}{H} \left( r_{L^\mathrm{b}} - r_0 \right)
+	const std::vector<double> alpha = { };
+	std::vector<double> beta = { 0.0, 0.0 };
+
 	for (unsigned int elem = 0; elem < _nElem; ++elem)
 	{
 		const double x_L = elem * dx;
+		const double beta1 = (r0 * rDiff * dx / H + rDiff * rDiff / H / H * x_L * dx);
+		const double beta2 = (rDiff * rDiff / H / H * dx * dx / 2.0 / 2.0);
+		beta[0] = beta1; beta[1] = beta2;
+		const double gamma = (r0 * r0 + 2.0 * r0 * x_L / H * rDiff + x_L * x_L / H / H * rDiff * rDiff);
 
-		Eigen::MatrixXd M_A = (r0 * r0 + 2.0 * r0 * x_L / H * rDiff + x_L * x_L / H / H * rDiff * rDiff) * _M00;
-		M_A += (r0 * rDiff * dx / H + rDiff * rDiff / H / H * x_L * dx) * M01;
-		M_A += (rDiff * rDiff / H / H * dx * dx / 2.0 / 2.0) * M02;
+		Eigen::MatrixXd M_A = gamma * _M00;
+		M_A += beta1 * M01;
+		M_A += beta2 * M02;
 		M_A *= pi;
 		_invMM_A[elem] = M_A.inverse();
 
 		for (int comp = 0; comp < _nComp; comp++)
 		{
-			// \tilde{M}^(AD)_{i,j} = \int_{-1}^1 \ell_i(\xi) \frac{\partial \ell_j(\xi)}{\partial \xi} w(\xi) d\xi
-			// with w(\xi) = A(x^e_i(\xi) D^{ax}(x^e_i(\xi)
-			// with x^e_i(\xi) = (\xi + 1) * dx_i / 2 + x_i, and A(x) = \pi * r(x)^2, D^{ax} being the spatially dependent dispersion parameter,
-			// and r(x) = _radiusXEnd + x / _bedLength * (_radiusXStart - _radiusXEnd)
-			// matrix computed with gauss quadrature
-			// const int nGaussQuadNodes = _nNodes + 2 + _axDispQuadDeg; // accurate up to degree 2N - 1, ie exact if _axDispQuadDeg is the polynomial degree of the spatially dependent dispersion parameter
-			// ... wip
-			// for now, we assume constant dispersion, ie \tilde{M}^(AD) can be computed exactly as D^{ax} * M_A
-			Eigen::MatrixXd gaussMM_AD = static_cast<double>(_colDispersion[comp]) * M_A;
+			const double baseDispersion = static_cast<double>(currentDispersion(secIdx)[comp]);
 
-			// Matrix product (M^A)^-1 * D^T * \tilde{S}^(AD) = (M^A)^-1 * D^T * \tilde{M}^(AD)
-			_invMM_A_times_ST_AD[comp][elem] = _invMM_A[elem] * _polyDerM.transpose() * gaussMM_AD;
+			if (!_variableDispersion)
+			{
+				// we can compute the integral exaclty
+				Eigen::MatrixXd gaussMM_AD = baseDispersion * M_A;
+				// Matrix product (M^A)^-1 * D^T * \tilde{S}^(AD) = (M^A)^-1 * D^T * \tilde{M}^(AD)
+				_invMM_A_times_ST_AD[comp][elem] = _invMM_A[elem] * _polyDerM.transpose() * gaussMM_AD;
+			}
+			else
+			{
+				// Evaluate dispersion at each quadrature node
+				Eigen::VectorXd dispAtQNodes(nQuadNodes);
+				Eigen::VectorXd quadNodes = Eigen::VectorXd::Zero(nQuadNodes);
+				Eigen::VectorXd quadWeights = Eigen::VectorXd::Zero(nQuadNodes);
+				dgtoolbox::lgNodesWeights(nQuadNodes - 1, quadNodes, quadWeights, false);
+
+				for (unsigned int node = 0; node < nQuadNodes; ++node)
+				{
+					const double physicalPos = x_L + 0.5 * dx * (1.0 + quadNodes[node]);
+					// Normalize position to [0, 1] for parameter dependence evaluation
+					const double relPos = physicalPos / H;
+
+					// Evaluate D(rho) = baseDispersion * dependence_factor(rho)
+					dispAtQNodes[node] = _dispersionDep->getValue(ColumnPosition{ relPos, 0.0, 0.0 },
+						comp, ParTypeIndep, BoundStateIndep, baseDispersion);
+				}
+
+				// \tilde{M}^(AD)_{i,j} = \int_{-1}^1 \ell_i(\xi) \frac{\partial \ell_j(\xi)}{\partial \xi} w(\xi) d\xi
+				Eigen::MatrixXd gaussMM_AD = dgtoolbox::weightedQuadMassMatrix(
+					_nodes,
+					dispAtQNodes,
+					alpha,
+					beta,
+					gamma,
+					quadNodes,
+					quadWeights);
+
+				// Matrix product (M^A)^-1 * D^T * \tilde{S}^(AD) = (M^A)^-1 * D^T * \tilde{M}^(AD)
+				_invMM_A_times_ST_AD[comp][elem] = _invMM_A[elem] * _polyDerM.transpose() * gaussMM_AD;
+			}
 		}
 		// Matrix product (M^A)^-1 D^T * M00
 		_invMM_A_times_DT_timesM00[elem] = _invMM_A[elem] * _polyDerM.transpose() * _M00;

--- a/src/libcadet/model/parts/ConvectionDispersionOperatorDG.cpp
+++ b/src/libcadet/model/parts/ConvectionDispersionOperatorDG.cpp
@@ -810,7 +810,7 @@ bool RadialConvectionDispersionOperatorBaseDG::configureModelDiscretization(IPar
 	// M^{(0,0)} = integral of l_i * l_j (standard Lagrange mass matrix)
 	// M^{(0,1)} = integral of l_i * l_j * (1+xi) (weighted Lagrange mass matrix)
 	_M00 = dgtoolbox::mMatrix(_polyDeg, _nodes, 0.0, 0.0);
-	_M01 = dgtoolbox::weightedMMatrix(_polyDeg, _nodes);
+	_M01 = dgtoolbox::mMatrix(_polyDeg, _nodes, 0.0, 1.0);
 
 	if (paramProvider.exists("COL_DISPERSION_DEP"))
 	{
@@ -1107,23 +1107,73 @@ void RadialConvectionDispersionOperatorBaseDG::updateDispersionValues(const IMod
  * @brief Recomputes S_g matrices for variable dispersion using quadrature
  * @detail For variable D(rho): S_g[i,j] = ∫ dL_i/dξ * L_j * ρ(ξ) * D(ρ(ξ)) dξ
  */
-void RadialConvectionDispersionOperatorBaseDG::recomputeDispersionMatrices()
+void RadialConvectionDispersionOperatorBaseDG::TransposedADWeightedStiffnessMatrix(const IModel& model, unsigned int secIdx, unsigned int comp)
 {
-	if (!_variableDispersion)
-		return;
-
 	const double deltaRho = static_cast<double>(_deltaRho);
 
 	// Number of quadrature points: use 3p/2 for overintegration, p+2 otherwise
 	const int nQuadPoints = _overintegrate ? static_cast<int>((3 * _polyDeg + 1) / 2 + 1) : static_cast<int>(_polyDeg + 2);
 
+	// Get Gauss-Legendre quadrature points and weights.
+	Eigen::VectorXd quadNodes = Eigen::VectorXd::Zero(nQuadPoints);
+	Eigen::VectorXd quadWeights = Eigen::VectorXd::Zero(nQuadPoints);
+	dgtoolbox::lgNodesWeights(nQuadPoints - 1, quadNodes, quadWeights, false);
+
+	const std::vector<double> alpha = { };
+	const std::vector<double> beta = { 0.5 * deltaRho };
+
 	for (unsigned int elem = 0; elem < _nElem; ++elem)
 	{
 		const double rho_left = _rhoCellBounds[elem];
 
-		// Use the radialDispersionMatrix function from DGToolbox
-		_S_g[elem] = dgtoolbox::radialDispersionMatrix(_polyDeg, _nodes, rho_left, deltaRho,
-		                                                _dispersionAtNodes[elem], nQuadPoints);
+		Eigen::VectorXd dispersionAtQNodes(nQuadPoints);
+		const double baseDispersion = static_cast<double>(currentDispersion(secIdx)[comp]);
+
+		if (!_variableDispersion)
+		{
+			dispersionAtQNodes.setConstant(baseDispersion);
+		}
+		else
+		{
+			// Evaluate dispersion at each node
+			for (unsigned int node = 0; node < nQuadPoints; ++node)
+			{
+				const double rho = rho_left + 0.5 * deltaRho * (1.0 + quadNodes[node]);
+				// Normalize position to [0, 1] for parameter dependence evaluation
+				const double relPos = (rho - static_cast<double>(_innerRadius)) /
+					(static_cast<double>(_outerRadius) - static_cast<double>(_innerRadius));
+
+				// Evaluate D(rho) = baseDispersion * dependence_factor(rho)
+				dispersionAtQNodes[node] = _dispersionDep->getValue(model, ColumnPosition{ relPos, 0.0, 0.0 },
+					comp, ParTypeIndep, BoundStateIndep, baseDispersion);
+			}
+		}
+
+		Eigen::MatrixXd M_AD = dgtoolbox::weightedQuadMassMatrix(
+			_nodes,
+			dispersionAtQNodes,
+			alpha,
+			beta,
+			rho_left,
+			quadNodes,
+			quadWeights);
+
+		_S_g[elem] = _polyDerM.transpose() * M_AD;
+
+		//Eigen::MatrixXd S_g_ref =
+		//	dgtoolbox::radialDispersionMatrix(
+		//		_polyDeg,
+		//		_nodes,
+		//		rho_left,
+		//		deltaRho,
+		//		_dispersionAtNodes[elem],
+		//		nQuadPoints);
+
+		//if(!_S_g[elem].isApprox(S_g_ref, 1e-15))
+		//{
+		//	std::cout << "Computed S_g:\n" << _S_g[elem] << "\n";
+		//	std::cout << "Reference radial dispersion matrix:\n" << dgtoolbox::radialDispersionMatrix(_polyDeg, _nodes, rho_left, deltaRho, _dispersionAtNodes[elem], nQuadPoints) << "\n";
+		//}
 	}
 }
 
@@ -1436,7 +1486,7 @@ int RadialConvectionDispersionOperatorBaseDG::residualImpl(const IModel& model, 
 		mutableThis->updateDispersionValues(model, secIdx, comp);
 
 		if (_variableDispersion && _newStaticJac)
-			mutableThis->recomputeDispersionMatrices();
+			mutableThis->TransposedADWeightedStiffnessMatrix(model, secIdx, comp);
 
 		// Auxiliary state g for this component
 		StateType* g = reinterpret_cast<StateType*>(_auxState);

--- a/src/libcadet/model/parts/ConvectionDispersionOperatorDG.cpp
+++ b/src/libcadet/model/parts/ConvectionDispersionOperatorDG.cpp
@@ -1086,7 +1086,7 @@ void RadialConvectionDispersionOperatorBaseDG::updateDispersionValues(const IMod
 			                      (static_cast<double>(_outerRadius) - static_cast<double>(_innerRadius));
 
 			// Evaluate D(rho) = baseDispersion * dependence_factor(rho)
-			const double depValue = _dispersionDep->getValue(model, ColumnPosition{relPos, 0.0, 0.0},
+			const double depValue = _dispersionDep->getValue(ColumnPosition{relPos, 0.0, 0.0},
 			                                                  comp, ParTypeIndep, BoundStateIndep, baseDispersion);
 			_dispersionAtNodes[elem][node] = depValue;
 		}
@@ -1098,7 +1098,7 @@ void RadialConvectionDispersionOperatorBaseDG::updateDispersionValues(const IMod
 		const double rho = _rhoCellBounds[iface];
 		const double relPos = (rho - static_cast<double>(_innerRadius)) /
 		                      (static_cast<double>(_outerRadius) - static_cast<double>(_innerRadius));
-		_dispersionAtInterfaces[iface] = _dispersionDep->getValue(model, ColumnPosition{relPos, 0.0, 0.0},
+		_dispersionAtInterfaces[iface] = _dispersionDep->getValue(ColumnPosition{relPos, 0.0, 0.0},
 		                                                           comp, ParTypeIndep, BoundStateIndep, baseDispersion);
 	}
 }
@@ -1144,7 +1144,7 @@ void RadialConvectionDispersionOperatorBaseDG::TransposedADWeightedStiffnessMatr
 					(static_cast<double>(_outerRadius) - static_cast<double>(_innerRadius));
 
 				// Evaluate D(rho) = baseDispersion * dependence_factor(rho)
-				dispersionAtQNodes[node] = _dispersionDep->getValue(model, ColumnPosition{ relPos, 0.0, 0.0 },
+				dispersionAtQNodes[node] = _dispersionDep->getValue(ColumnPosition{ relPos, 0.0, 0.0 },
 					comp, ParTypeIndep, BoundStateIndep, baseDispersion);
 			}
 		}

--- a/src/libcadet/model/parts/ConvectionDispersionOperatorDG.hpp
+++ b/src/libcadet/model/parts/ConvectionDispersionOperatorDG.hpp
@@ -1778,7 +1778,6 @@ namespace cadet
 				unsigned int _nElem;
 				unsigned int _nNodes;
 				unsigned int _nPoints;
-				unsigned int _filmDiffQuadDeg;
 				unsigned int _axDispQuadDeg;
 
 				unsigned int _strideNode;
@@ -1825,13 +1824,14 @@ namespace cadet
 
 				bool _dispersionCompIndep;
 				IParameterParameterDependence* _dispersionDep;
+				bool _variableDispersion;
 
 				/* ===================================================================
 				 *  Geometry helpers
 				 * =================================================================== */
 
 				void computeGeometryFrustum();
-				void computeOperatorsFrustum();
+				void computeOperatorsFrustum(const unsigned int secIdx);
 
 				/* ===================================================================
 				 *  Jacobian block helpers

--- a/src/libcadet/model/parts/ConvectionDispersionOperatorDG.hpp
+++ b/src/libcadet/model/parts/ConvectionDispersionOperatorDG.hpp
@@ -1374,7 +1374,7 @@ namespace cadet
 				 * @brief Recomputes S_g matrices for variable dispersion
 				 * @detail Uses quadrature integration with dispersion values at DG nodes
 				 */
-				void recomputeDispersionMatrices();
+				void TransposedADWeightedStiffnessMatrix(const IModel& model, unsigned int secIdx, unsigned int comp);
 
 				/**
 				 * @brief Computes radial node coordinates in physical space

--- a/src/libcadet/model/parts/ConvectionDispersionOperatorFV.cpp
+++ b/src/libcadet/model/parts/ConvectionDispersionOperatorFV.cpp
@@ -537,7 +537,6 @@ int AxialConvectionDispersionOperatorBaseFV::residualImpl(const IModel& model, d
 			0u,
 			_nComp,
 			_dispersionDep,
-			model,
 			_gridEquidistant,
 			cellFacesPtr
 		};
@@ -559,7 +558,6 @@ int AxialConvectionDispersionOperatorBaseFV::residualImpl(const IModel& model, d
 			0u,
 			_nComp,
 			_dispersionDep,
-			model,
 			_gridEquidistant,
 			cellFacesPtr
 		};
@@ -1299,7 +1297,6 @@ int RadialConvectionDispersionOperatorBaseFV::residualImpl(const IModel& model, 
 			0u,
 			_nComp,
 			_dispersionDep,
-			model,
 			_gridEquidistant,
 			cellFacesPtr
 		};
@@ -1322,7 +1319,6 @@ int RadialConvectionDispersionOperatorBaseFV::residualImpl(const IModel& model, 
 			0u,
 			_nComp,
 			_dispersionDep,
-			model,
 			_gridEquidistant,
 			cellFacesPtr
 		};
@@ -2101,7 +2097,6 @@ int FrustumConvectionDispersionOperatorBaseFV::residualImpl(const IModel& model,
 			0u,
 			_nComp,
 			_dispersionDep,
-			model,
 			_gridEquidistant,
 			cellFacesPtr
 		};
@@ -2127,7 +2122,6 @@ int FrustumConvectionDispersionOperatorBaseFV::residualImpl(const IModel& model,
 			0u,
 			_nComp,
 			_dispersionDep,
-			model,
 			_gridEquidistant,
 			cellFacesPtr
 		};

--- a/src/libcadet/model/parts/DGToolbox.cpp
+++ b/src/libcadet/model/parts/DGToolbox.cpp
@@ -695,7 +695,7 @@ Eigen::MatrixXd weightedQuadMassMatrix(
 	const Eigen::VectorXd& paramAtQNodes,
 	const std::vector<double>& alpha,
 	const std::vector<double>& beta,
-	const double c,
+	const double gamma,
 	const Eigen::VectorXd& QNodes,
 	const Eigen::VectorXd& QWeights)
 {
@@ -722,7 +722,7 @@ Eigen::MatrixXd weightedQuadMassMatrix(
 	{
 		const double xi = QNodes[k];
 
-		double geometricWeight = c;
+		double geometricWeight = gamma;
 
 		// alpha[p-1] * (1 - xi)^p
 		double minusPower = 1.0 - xi;

--- a/src/libcadet/model/parts/DGToolbox.cpp
+++ b/src/libcadet/model/parts/DGToolbox.cpp
@@ -454,18 +454,6 @@ Eigen::MatrixXd mMatrix(const unsigned int polyDeg, const Eigen::VectorXd nodes,
 	return invMMatrix(polyDeg, nodes, alpha, beta).inverse();
 }
 /**
- * @brief calculates the weighted mass matrix M^{(0,1)} for radial DG integrals
- * @detail For integrals of the form \int_E \ell_i(\xi) \ell_j(\xi) (1 + \xi) d\xi
- *         Used to construct radial weighted mass matrix: M_rho = (delta_rho/2) * M^{(0,1)} + rho_i * M^{(0,0)}
- * @param [in] polyDeg polynomial degree
- * @param [in] nodes polynomial interpolation nodes
- */
-Eigen::MatrixXd weightedMMatrix(const unsigned int polyDeg, const Eigen::VectorXd nodes)
-{
-	// M^{(0,1)} uses alpha=0, beta=1 to get (1+xi) weighting
-	return mMatrix(polyDeg, nodes, 0.0, 1.0);
-}
-/**
  * @brief calculates the derivative of the Vandermonde matrix of the normalized Legendre polynomials
  * @param [in] polyDeg polynomial degree
  * @param [in] a Jacobi polynomial parameter
@@ -701,60 +689,85 @@ VectorXd evalLagrangeBasisDerivative(const int j, const VectorXd baseNodes, cons
 
 	return evalDerEll;
 }
-/**
- * @brief computes radial dispersion matrix S_g for a single cell with variable D(rho)
- * @detail For radial DG: S_g[i,j] = ∫ dL_i/dξ * L_j * ρ(ξ) * D(ρ(ξ)) dξ
- *         where ρ(ξ) = rho_left + (delta_rho/2) * (1 + ξ)
- *         Uses Gauss-Legendre quadrature for numerical integration.
- * @param [in] polyDeg polynomial degree
- * @param [in] LGLnodes LGL interpolation nodes
- * @param [in] rho_left left boundary of cell in physical space
- * @param [in] delta_rho cell width in physical space
- * @param [in] dispAtNodes dispersion coefficient D evaluated at physical node positions
- * @param [in] nQuadPoints number of Gauss quadrature points (default: 3/2 rule for dealiasing)
- */
-MatrixXd radialDispersionMatrix(const unsigned int polyDeg, const VectorXd LGLnodes,
-                                 const double rho_left, const double delta_rho,
-                                 const VectorXd dispAtNodes, const int nQuadPoints)
+
+Eigen::MatrixXd weightedQuadMassMatrix(
+	const Eigen::VectorXd& LegNodes,
+	const Eigen::VectorXd& paramAtQNodes,
+	const std::vector<double>& alpha,
+	const std::vector<double>& beta,
+	const double c,
+	const Eigen::VectorXd& QNodes,
+	const Eigen::VectorXd& QWeights)
 {
-	const unsigned int nNodes = polyDeg + 1;
-	const int nQuad = (nQuadPoints < 0) ? static_cast<int>((3 * polyDeg + 1) / 2 + 1) : nQuadPoints;
+	const unsigned int nNodes = LegNodes.size();
+	const int nQuad = QNodes.size();
 
-	// Get Gauss-Legendre quadrature points and weights
-	VectorXd quadNodes = VectorXd::Zero(nQuad);
-	VectorXd quadWeights = VectorXd::Zero(nQuad);
-	lgNodesWeights(nQuad - 1, quadNodes, quadWeights, false);
-
-	// Evaluate Lagrange basis and derivatives at quadrature points
-	MatrixXd basisAtQuad(nNodes, nQuad);
-	MatrixXd basisDerAtQuad(nNodes, nQuad);
-	for (unsigned int j = 0; j < nNodes; j++) {
-		basisAtQuad.row(j) = evalLagrangeBasis(j, LGLnodes, quadNodes);
-		basisDerAtQuad.row(j) = evalLagrangeBasisDerivative(j, LGLnodes, quadNodes);
+	// Sanity check: paramAtQuad must correspond to the quadrature points.
+	if (paramAtQNodes.size() != nQuad)
+	{
+		throw std::invalid_argument(
+			"weightedMassMatrix: paramAtQuad.size() must equal nQuadPoints.");
 	}
 
-	// Interpolate dispersion coefficient to quadrature points
-	VectorXd dispAtQuad = VectorXd::Zero(nQuad);
-	for (int k = 0; k < nQuad; k++) {
-		for (unsigned int j = 0; j < nNodes; j++) {
-			dispAtQuad[k] += dispAtNodes[j] * basisAtQuad(j, k);
+	Eigen::MatrixXd basisAtQuad(nNodes, nQuad);
+
+	for (unsigned int i = 0; i < nNodes; ++i)
+		basisAtQuad.row(i) = evalLagrangeBasis(i, LegNodes, QNodes);
+
+	// Compute the geometric weight g(xi) * parameter at every
+	// quadrature point.
+	Eigen::VectorXd weightAtQuad = Eigen::VectorXd::Zero(nQuad);
+
+	for (int k = 0; k < nQuad; ++k)
+	{
+		const double xi = QNodes[k];
+
+		double geometricWeight = c;
+
+		// alpha[p-1] * (1 - xi)^p
+		double minusPower = 1.0 - xi;
+		for (std::size_t p = 0; p < alpha.size(); ++p)
+		{
+			geometricWeight += alpha[p] * minusPower;
+			minusPower *= (1.0 - xi);
 		}
+
+		// beta[p-1] * (1 + xi)^p
+		double plusPower = 1.0 + xi;
+		for (std::size_t p = 0; p < beta.size(); ++p)
+		{
+			geometricWeight += beta[p] * plusPower;
+			plusPower *= (1.0 + xi);
+		}
+
+		weightAtQuad[k] =
+			QWeights[k] *
+			paramAtQNodes[k] *
+			geometricWeight;
 	}
 
-	// Compute S_g matrix: S_g[i,j] = sum_k w_k * dL_i(quad_k) * L_j(quad_k) * rho(quad_k) * D(rho(quad_k))
-	MatrixXd S_g = MatrixXd::Zero(nNodes, nNodes);
-	for (unsigned int i = 0; i < nNodes; i++) {
-		for (unsigned int j = 0; j < nNodes; j++) {
-			for (int k = 0; k < nQuad; k++) {
-				// Map reference coordinate to physical radius: rho = rho_left + (delta_rho/2) * (1 + xi)
-				double rho_k = rho_left + 0.5 * delta_rho * (1.0 + quadNodes[k]);
-				double weight_factor = quadWeights[k] * rho_k * dispAtQuad[k];
-				S_g(i, j) += weight_factor * basisDerAtQuad(i, k) * basisAtQuad(j, k);
+	// Assemble weighted mass matrix:
+	//
+	// M_AD[i,j] = sum_k w_k * param_k * g(xi_k)
+	//                   * L_i(xi_k) * L_j(xi_k)
+	//
+	Eigen::MatrixXd M_AD = Eigen::MatrixXd::Zero(nNodes, nNodes);
+
+	for (unsigned int i = 0; i < nNodes; ++i)
+	{
+		for (unsigned int j = 0; j < nNodes; ++j)
+		{
+			for (int k = 0; k < nQuad; ++k)
+			{
+				M_AD(i, j) +=
+					weightAtQuad[k] *
+					basisAtQuad(i, k) *
+					basisAtQuad(j, k);
 			}
 		}
 	}
 
-	return S_g;
+	return M_AD;
 }
 
 } // namespace dgtoolbox

--- a/src/libcadet/model/parts/DGToolbox.hpp
+++ b/src/libcadet/model/parts/DGToolbox.hpp
@@ -143,14 +143,6 @@ Eigen::MatrixXd invMMatrix(const unsigned int polyDeg, const Eigen::VectorXd nod
  */
 Eigen::MatrixXd mMatrix(const unsigned int polyDeg, const Eigen::VectorXd nodes, const double alpha, const double beta);
 /**
- * @brief calculates the weighted mass matrix M^{(0,1)} for radial DG integrals
- * @detail For integrals of the form \int_E \ell_i(\xi) \ell_j(\xi) (1 + \xi) d\xi
- *         Used to construct radial weighted mass matrix: M_rho = (delta_rho/2) * M^{(0,1)} + rho_i * M^{(0,0)}
- * @param [in] polyDeg polynomial degree
- * @param [in] nodes polynomial interpolation nodes
- */
-Eigen::MatrixXd weightedMMatrix(const unsigned int polyDeg, const Eigen::VectorXd nodes);
-/**
  * @brief calculates a specific second order nodal stiffness matrix
  * @detail for integrals including terms of the form (1 - \xi)^\alpha (1 + \xi)^\beta. Computation via transformation to the respective Jacobi polynomial
  * @param [in] polyDeg polynomial degree
@@ -208,19 +200,38 @@ Eigen::MatrixXd subcellIntegrationMatrix(const Eigen::VectorXd& LGLnodes, const 
  */
 Eigen::VectorXd evalLagrangeBasisDerivative(const int j, const Eigen::VectorXd baseNodes, const Eigen::VectorXd evalNodes);
 /**
- * @brief computes radial dispersion matrix S_g for a single cell with variable D(rho)
- * @detail For radial DG: S_g[i,j] = ∫ dL_i/dξ * L_j * ρ(ξ) * D(ρ(ξ)) dξ
- *         where ρ(ξ) = rho_left + (delta_rho/2) * (1 + ξ)
- * @param [in] polyDeg polynomial degree
- * @param [in] LGLnodes LGL interpolation nodes
- * @param [in] rho_left left boundary of cell in physical space
- * @param [in] delta_rho cell width in physical space
- * @param [in] dispAtNodes dispersion coefficient D evaluated at physical node positions
- * @param [in] nQuadPoints number of Gauss quadrature points (default: 3/2 rule for dealiasing)
+ * @brief Computes a parameter-weighted quadrature mass matrix on Legendre polynomials.
+ *
+ * @details
+ * Computes
+ *
+ *     M_AD[i,j] = ∫ L_i(ξ) L_j(ξ) param(ξ) g(ξ) dξ
+ *
+ * where L_i are the Legendre polynomials and the parameter values param(ξ) are
+ * given at the quadrature points in paramAtQuad, and the geometric weight is
+ *
+ *     g(ξ) = sum_{p=1}^{n} alpha[p-1] * (1 - ξ)^p
+ *          + sum_{p=1}^{m} beta[p-1]  * (1 + ξ)^p
+ *          + c.
+ *
+ * @param [in] polyDeg			LegNodes interpolation nodes for Legendre basis.
+ * @param [in] paramAtQNodes	Parameter values evaluated at quadrature points.
+ * @param [in] alpha			Coefficients of powers of (1 - ξ).
+ * @param [in] beta				Coefficients of powers of (1 + ξ).
+ * @param [in] c				Constant coefficient of the geometric weight.
+ * @param [in] QNodes			Quadrature nodes.
+ * @param [in] QWeights			Quadrature weights.
+ *
+ * @return Parameter- and geometry-weighted Gauss quadrature mass matrix.
  */
-Eigen::MatrixXd radialDispersionMatrix(const unsigned int polyDeg, const Eigen::VectorXd LGLnodes,
-                                        const double rho_left, const double delta_rho,
-                                        const Eigen::VectorXd dispAtNodes, const int nQuadPoints = -1);
+Eigen::MatrixXd weightedQuadMassMatrix(
+	const Eigen::VectorXd& LegNodes,
+	const Eigen::VectorXd& paramAtQNodes,
+	const std::vector<double>& alpha,
+	const std::vector<double>& beta,
+	const double c,
+	const Eigen::VectorXd& QNodes,
+	const Eigen::VectorXd& QWeights);
 /**
  * @brief evaluates the jth Lagrange basis functions at given nodes
  * @param [in, out] coords DG coordinate array

--- a/src/libcadet/model/parts/DGToolbox.hpp
+++ b/src/libcadet/model/parts/DGToolbox.hpp
@@ -218,7 +218,7 @@ Eigen::VectorXd evalLagrangeBasisDerivative(const int j, const Eigen::VectorXd b
  * @param [in] paramAtQNodes	Parameter values evaluated at quadrature points.
  * @param [in] alpha			Coefficients of powers of (1 - ξ).
  * @param [in] beta				Coefficients of powers of (1 + ξ).
- * @param [in] c				Constant coefficient of the geometric weight.
+ * @param [in] gamma			Constant coefficient of the geometric weight.
  * @param [in] QNodes			Quadrature nodes.
  * @param [in] QWeights			Quadrature weights.
  *
@@ -229,7 +229,7 @@ Eigen::MatrixXd weightedQuadMassMatrix(
 	const Eigen::VectorXd& paramAtQNodes,
 	const std::vector<double>& alpha,
 	const std::vector<double>& beta,
-	const double c,
+	const double gamma,
 	const Eigen::VectorXd& QNodes,
 	const Eigen::VectorXd& QWeights);
 /**

--- a/src/libcadet/model/parts/FrustumConvectionDispersionKernelFV.hpp
+++ b/src/libcadet/model/parts/FrustumConvectionDispersionKernelFV.hpp
@@ -64,7 +64,6 @@ struct FrustumFlowParameters
 	unsigned int offsetToInlet; //!< Offset to the first component of the inlet DOFs in the local state vector
 	unsigned int offsetToBulk; //!< Offset to the first component of the first bulk cell in the local state vector
 	IParameterParameterDependence* parDep;
-	const IModel& model;
 	bool gridEquidistant; //!< Determines whether the grid is equidistant
 	std::vector<active> const* gridFaces; //!< Positions of the cell faces for non-equidistant grids
 };
@@ -135,7 +134,7 @@ namespace impl
 				if (cadet_likely(col < p.nCol - 1))
 				{
 					const double relCoord = static_cast<double>(p.cellFaces[col + 1]) / static_cast<double>(colLength);
-					const ParamType dispRight = disp * p.parDep->getValue(p.model, ColumnPosition{relCoord, 0.0, 0.0}, comp, ParTypeIndep, BoundStateIndep,
+					const ParamType dispRight = disp * p.parDep->getValue(ColumnPosition{relCoord, 0.0, 0.0}, comp, ParTypeIndep, BoundStateIndep,
 						static_cast<ParamType>(p.u) / static_cast<ParamType>(p.cellFaceRadiusSq[col + 1]));
 					const ParamType coeff = dispRight * preFac * static_cast<ParamType>(p.cellFaceRadiusSq[col + 1]) / (static_cast<ParamType>(p.cellCenters[col + 1]) - static_cast<ParamType>(p.cellCenters[col]));
 					if (wantRes)
@@ -151,7 +150,7 @@ namespace impl
 				if (cadet_likely(col > 0))
 				{
 					const double relCoord = static_cast<double>(p.cellFaces[col]) / static_cast<double>(colLength);
-					const ParamType dispLeft = disp * p.parDep->getValue(p.model, ColumnPosition{relCoord, 0.0, 0.0}, comp, ParTypeIndep, BoundStateIndep,
+					const ParamType dispLeft = disp * p.parDep->getValue(ColumnPosition{relCoord, 0.0, 0.0}, comp, ParTypeIndep, BoundStateIndep,
 						static_cast<ParamType>(p.u) / static_cast<ParamType>(p.cellFaceRadiusSq[col]));
 					const ParamType coeff = dispLeft * preFac * static_cast<ParamType>(p.cellFaceRadiusSq[col]) / (static_cast<ParamType>(p.cellCenters[col]) - static_cast<ParamType>(p.cellCenters[col - 1]));
 					if (wantRes)
@@ -274,7 +273,7 @@ namespace impl
 				if (cadet_likely(col < p.nCol - 1))
 				{
 					const double relCoord = static_cast<double>(p.cellFaces[col + 1]) / static_cast<double>(colLength);
-					const ParamType dispRight = disp * p.parDep->getValue(p.model, ColumnPosition{relCoord, 0.0, 0.0}, comp, ParTypeIndep, BoundStateIndep,
+					const ParamType dispRight = disp * p.parDep->getValue(ColumnPosition{relCoord, 0.0, 0.0}, comp, ParTypeIndep, BoundStateIndep,
 						static_cast<ParamType>(p.u) / static_cast<ParamType>(p.cellFaceRadiusSq[col + 1]));
 					const ParamType coeff = dispRight * preFac * static_cast<ParamType>(p.cellFaceRadiusSq[col + 1]) / (static_cast<ParamType>(p.cellCenters[col + 1]) - static_cast<ParamType>(p.cellCenters[col]));
 					if (wantRes)
@@ -290,7 +289,7 @@ namespace impl
 				if (cadet_likely(col > 0))
 				{
 					const double relCoord = static_cast<double>(p.cellFaces[col]) / static_cast<double>(colLength);
-					const ParamType dispLeft = disp * p.parDep->getValue(p.model, ColumnPosition{relCoord, 0.0, 0.0}, comp, ParTypeIndep, BoundStateIndep,
+					const ParamType dispLeft = disp * p.parDep->getValue(ColumnPosition{relCoord, 0.0, 0.0}, comp, ParTypeIndep, BoundStateIndep,
 						static_cast<ParamType>(p.u) / static_cast<ParamType>(p.cellFaceRadiusSq[col]));
                     const ParamType coeff = dispLeft * preFac * static_cast<ParamType>(p.cellFaceRadiusSq[col]) / (static_cast<ParamType>(p.cellCenters[col]) - static_cast<ParamType>(p.cellCenters[col - 1]));
 					if (wantRes)

--- a/src/libcadet/model/parts/MultiChannelConvectionDispersionOperator.cpp
+++ b/src/libcadet/model/parts/MultiChannelConvectionDispersionOperator.cpp
@@ -1104,7 +1104,6 @@ int MultiChannelConvectionDispersionOperator::residualImpl(const IModel& model, 
 				_nComp * i,                        // Offset to the first component of the inlet DOFs in the local state vector
 				_nComp * (_nChannel + i),          // Offset to the first component of the first bulk cell in the local state vector
 				_dispersionDep,
-				model,
 				_gridEquidistant,
 				cellFacesPtr
 			};
@@ -1129,7 +1128,6 @@ int MultiChannelConvectionDispersionOperator::residualImpl(const IModel& model, 
 				_nComp * i,                        // Offset to the first component of the inlet DOFs in the local state vector
 				_nComp * (_nChannel + i),          // Offset to the first component of the first bulk cell in the local state vector
 				_dispersionDep,
-				model,
 				_gridEquidistant,
 				cellFacesPtr
 			};

--- a/src/libcadet/model/parts/RadialConvectionDispersionKernelFV.hpp
+++ b/src/libcadet/model/parts/RadialConvectionDispersionKernelFV.hpp
@@ -61,7 +61,6 @@ struct RadialFlowParameters
 	unsigned int offsetToInlet; //!< Offset to the first component of the inlet DOFs in the local state vector
 	unsigned int offsetToBulk; //!< Offset to the first component of the first bulk cell in the local state vector
 	IParameterParameterDependence* parDep;
-	const IModel& model;
 	bool gridEquidistant; //!< Determines whether the grid is equidistant
 	std::vector<active> const* cellFaces; //!< Positions of the cell faces for non-equidistant grids (points to _cellBounds)
 };
@@ -139,7 +138,7 @@ namespace impl
 				if (cadet_likely(col < p.nCol - 1))
 				{
 					const double relCoord = (static_cast<double>(p.cellBounds[col+1]) - static_cast<double>(p.cellBounds[0])) / (static_cast<double>(p.cellBounds[p.nCol - 1]) - static_cast<double>(p.cellBounds[0]));
-					const ParamType d_rad_right = d_rad * p.parDep->getValue(p.model, ColumnPosition{relCoord, 0.0, 0.0}, comp, ParTypeIndep, BoundStateIndep, static_cast<ParamType>(p.u) / static_cast<ParamType>(p.cellBounds[col+1]));
+					const ParamType d_rad_right = d_rad * p.parDep->getValue(ColumnPosition{relCoord, 0.0, 0.0}, comp, ParTypeIndep, BoundStateIndep, static_cast<ParamType>(p.u) / static_cast<ParamType>(p.cellBounds[col+1]));
 					if(wantRes)
 						resBulkComp[col * p.strideCell] -= d_rad_right * static_cast<ParamType>(p.cellBounds[col+1]) / denom * (stencil[1] - stencil[0]) / (static_cast<ParamType>(p.cellCenters[col+1]) - static_cast<ParamType>(p.cellCenters[col]));
 					// Jacobian entries
@@ -155,7 +154,7 @@ namespace impl
 				if (cadet_likely(col > 0))
 				{
 					const double relCoord = (static_cast<double>(p.cellBounds[col]) - static_cast<double>(p.cellBounds[0])) / (static_cast<double>(p.cellBounds[p.nCol - 1]) - static_cast<double>(p.cellBounds[0]));
-					const ParamType d_rad_left = d_rad * p.parDep->getValue(p.model, ColumnPosition{ relCoord, 0.0, 0.0 }, comp, ParTypeIndep, BoundStateIndep, static_cast<ParamType>(p.u) / static_cast<ParamType>(p.cellBounds[col]));
+					const ParamType d_rad_left = d_rad * p.parDep->getValue(ColumnPosition{ relCoord, 0.0, 0.0 }, comp, ParTypeIndep, BoundStateIndep, static_cast<ParamType>(p.u) / static_cast<ParamType>(p.cellBounds[col]));
 					if(wantRes)
 						resBulkComp[col * p.strideCell] -= d_rad_left * static_cast<ParamType>(p.cellBounds[col]) / denom * (stencil[-1] - stencil[0]) / (static_cast<ParamType>(p.cellCenters[col]) - static_cast<ParamType>(p.cellCenters[col-1]));
 					// Jacobian entries
@@ -302,7 +301,7 @@ namespace impl
 				if (cadet_likely(col < p.nCol - 1))
 				{
 					const double relCoord = (static_cast<double>(p.cellBounds[col + 1]) - static_cast<double>(p.cellBounds[0])) / (static_cast<double>(p.cellBounds[p.nCol - 1]) - static_cast<double>(p.cellBounds[0]));
-					const ParamType d_rad_right = d_rad * p.parDep->getValue(p.model, ColumnPosition{ relCoord, 0.0, 0.0 }, comp, ParTypeIndep, BoundStateIndep, static_cast<ParamType>(p.u) / static_cast<ParamType>(p.cellBounds[col + 1]));
+					const ParamType d_rad_right = d_rad * p.parDep->getValue(ColumnPosition{ relCoord, 0.0, 0.0 }, comp, ParTypeIndep, BoundStateIndep, static_cast<ParamType>(p.u) / static_cast<ParamType>(p.cellBounds[col + 1]));
 					if (wantRes)
 						resBulkComp[col * p.strideCell] -= d_rad_right * static_cast<ParamType>(p.cellBounds[col + 1]) / denom * (stencil[-1] - stencil[0]) / (static_cast<ParamType>(p.cellCenters[col + 1]) - static_cast<ParamType>(p.cellCenters[col]));
 					// Jacobian entries
@@ -318,7 +317,7 @@ namespace impl
 				if (cadet_likely(col > 0))
 				{
 					const double relCoord = (static_cast<double>(p.cellBounds[col]) - static_cast<double>(p.cellBounds[0])) / (static_cast<double>(p.cellBounds[p.nCol - 1]) - static_cast<double>(p.cellBounds[0]));
-					const ParamType d_rad_left = d_rad * p.parDep->getValue(p.model, ColumnPosition{ relCoord, 0.0, 0.0 }, comp, ParTypeIndep, BoundStateIndep, static_cast<ParamType>(p.u) / static_cast<ParamType>(p.cellBounds[col]));
+					const ParamType d_rad_left = d_rad * p.parDep->getValue(ColumnPosition{ relCoord, 0.0, 0.0 }, comp, ParTypeIndep, BoundStateIndep, static_cast<ParamType>(p.u) / static_cast<ParamType>(p.cellBounds[col]));
 					if (wantRes)
 						resBulkComp[col * p.strideCell] -= d_rad_left * static_cast<ParamType>(p.cellBounds[col]) / denom * (stencil[1] - stencil[0]) / (static_cast<ParamType>(p.cellCenters[col - 1]) - static_cast<ParamType>(p.cellCenters[col]));
 					// Jacobian entries

--- a/src/libcadet/model/parts/TwoDimensionalConvectionDispersionOperatorFV.cpp
+++ b/src/libcadet/model/parts/TwoDimensionalConvectionDispersionOperatorFV.cpp
@@ -1121,7 +1121,6 @@ int TwoDimensionalConvectionDispersionOperatorFV::residualImpl(const IModel& mod
 				_nComp * i,                        // Offset to the first component of the inlet DOFs in the local state vector
 				_nComp * (_nRad + i),              // Offset to the first component of the first bulk cell in the local state vector
 				_dispersionDep,
-				model,
 				_gridEquidistant,
 				cellFacesPtr
 			};
@@ -1146,7 +1145,6 @@ int TwoDimensionalConvectionDispersionOperatorFV::residualImpl(const IModel& mod
 				_nComp * i,                        // Offset to the first component of the inlet DOFs in the local state vector
 				_nComp * (_nRad + i),              // Offset to the first component of the first bulk cell in the local state vector
 				_dispersionDep,
-				model,
 				_gridEquidistant,
 				cellFacesPtr
 			};

--- a/test/ConvectionDispersionOperatorFV.cpp
+++ b/test/ConvectionDispersionOperatorFV.cpp
@@ -414,7 +414,6 @@ struct AxialFlow
 			0u,
 			static_cast<unsigned int>(nComp),
 			parDep.get(),
-			DummyModel(),
 			true,
 			nullptr
 		};
@@ -482,7 +481,6 @@ struct RadialFlow
 			0u,
 			static_cast<unsigned int>(nComp),
 			parDep.get(),
-			DummyModel(),
 			true,
 			nullptr
 		};


### PR DESCRIPTION
This PR adds velocity dependent axial dispersion to the frustum DG discretization.
As preparation, we remove the `IModel` dependence of the parameter dependence interface, since this is not used so far (and I don't see us using further parameters from the unit operation model in the future), and it hinders using the convection dispersion operator as the object owning the dependence.
Also, we reuse some of the functionality from the dg toolbox and generalize the weighted stiffness function implementation so that it can be reused for both frustum and radial flow.