### PR TITLE
Fix mass action law derivative calculation edge case

### DIFF
--- a/src/libcadet/model/reaction/MassActionLawReaction.cpp
+++ b/src/libcadet/model/reaction/MassActionLawReaction.cpp
@@ -180,6 +180,8 @@ namespace
 
 				if (y[c] > 0.0)
 					fluxGrad[c] *= exponentValue * std::pow(y[c], exponentValue - 1.0);
+				else if (exponentValue == 1.0)
+					fluxGrad[c]*= 1.0;
 				else
 					fluxGrad[c]*= 0.0;
 
@@ -381,6 +383,8 @@ protected:
 					if (static_cast<double>(y[c]) > 0.0)
 						fwd *= pow(static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(y[c]),
 							static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(_expFwd.native(c, r)));
+					else if (static_cast<double>(_expFwd.native(c, r)) == 1.0)
+						fwd *= static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(y[c]);
 					else
 					{
 						fwd *= 0.0;
@@ -398,6 +402,8 @@ protected:
 					if (static_cast<double>(y[c]) > 0.0)
 						bwd *= pow(static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(y[c]),
 							static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(_expBwd.native(c, r)));
+					else if (static_cast<double>(_expBwd.native(c, r)) == 1.0)
+						bwd *= static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(y[c]);
 					else
 					{
 						bwd *= 0.0;
@@ -481,6 +487,8 @@ protected:
 				{
 					if (static_cast<double>(y[c]) > 0.0)
 						fwd *= pow(static_cast<ResidualType>(y[c]), static_cast<ResidualType>(_expFwd.native(c, r)));
+					else if (static_cast<double>(_expFwd.native(c, r)) == 1)
+						fwd *= static_cast<ResidualType>(y[c]);
 					else
 					{
 						fwd *= 0.0;
@@ -496,8 +504,9 @@ protected:
 				if (_expBwd.native(c, r) != 0.0)
 				{
 					if (static_cast<double>(y[c]) > 0.0)
-						bwd *= pow(static_cast<ResidualType>(y[c]),
-							static_cast<ResidualType>(_expBwd.native(c, r)));
+						bwd *= pow(static_cast<ResidualType>(y[c]), static_cast<ResidualType>(_expBwd.native(c, r)));
+					else if (static_cast<double>(_expBwd.native(c, r)) == 1)
+						bwd *= static_cast<ResidualType>(y[c]);
 					else
 					{
 						bwd *= 0.0;

--- a/src/libcadet/model/reaction/MassActionLawReactionCrossPhase.cpp
+++ b/src/libcadet/model/reaction/MassActionLawReactionCrossPhase.cpp
@@ -185,6 +185,8 @@ namespace cadet
 
 						if (static_cast<double>(y[c]) > 0.0)
 							fluxGrad[c] *= exponentValue * pow(y[c], exponentValue - 1.0);
+						else if (exponentValue == 1.0)
+							fluxGrad[c] *= 1.0;
 						else
 							fluxGrad[c] *= 0.0;
 
@@ -240,8 +242,10 @@ namespace cadet
 							fluxGrad[j] *= v;
 						if (static_cast<double>(yLiquid[c]) > 0.0)
 							fluxGrad[c] *= exponentValue * pow(yLiquid[c], exponentValue - 1.0);
+						else if (exponentValue == 1.0)
+							fluxGrad[c] *= 1.0;
 						else
-							fluxGrad[c]*= 0.0;
+							fluxGrad[c] *= 0.0;
 
 						for (unsigned int j = c + 1; j < nComp + nTotalBoundStates; ++j)
 							fluxGrad[j] *= v;
@@ -263,8 +267,10 @@ namespace cadet
 
 						if (static_cast<double>(ySolid[c]) > 0.0)
 							fluxGrad[nComp + c] *= exponentValue * pow(ySolid[c], exponentValue - 1.0);
+						else if (exponentValue == 1.0)
+							fluxGrad[nComp + c] *= 1.0;
 						else
-							fluxGrad[nComp + c]*= 0.0;
+							fluxGrad[nComp + c] *= 0.0;
 
 						for (unsigned int j = c + 1; j < nTotalBoundStates; ++j)
 							fluxGrad[nComp + j] *= v;
@@ -530,6 +536,8 @@ namespace cadet
 							if (static_cast<double>(yLiquid[c]) > 0.0)
 								fwd *= pow(static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(yLiquid[c]),
 									static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(_expLiquidFwd.native(c, r)));
+							else if (static_cast<double>(_expLiquidFwd.native(c, r)) == 1.0)
+								fwd *= static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(yLiquid[c]);
 							else
 							{
 								fwd *= 0.0;
@@ -544,6 +552,8 @@ namespace cadet
 							if (static_cast<double>(ySolid[c]) > 0.0)
 								fwd *= pow(static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(ySolid[c]),
 									static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(_expLiquidFwdSolid.native(c, r)));
+							else if (static_cast<double>(_expLiquidFwdSolid.native(c, r)) == 1.0)
+								fwd *= static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(ySolid[c]);
 							else
 							{
 								fwd *= 0.0;
@@ -560,6 +570,8 @@ namespace cadet
 							if (static_cast<double>(yLiquid[c]) > 0.0)
 								bwd *= pow(static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(yLiquid[c]),
 									static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(_expLiquidBwd.native(c, r)));
+							else if (static_cast<double>(_expLiquidBwd.native(c, r)) == 1.0)
+								bwd *= static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(yLiquid[c]);
 							else
 							{
 								bwd *= 0.0;
@@ -574,6 +586,8 @@ namespace cadet
 							if (static_cast<double>(ySolid[c]) > 0.0)
 								bwd *= pow(static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(ySolid[c]),
 									static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(_expLiquidBwdSolid.native(c, r)));
+							else if (static_cast<double>(_expLiquidBwdSolid.native(c, r)) == 1.0)
+								bwd *= static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(ySolid[c]);
 							else
 							{
 								bwd *= 0.0;
@@ -602,6 +616,8 @@ namespace cadet
 							if (static_cast<double>(yLiquid[c]) > 0.0)
 								fwd *= pow(static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(yLiquid[c]),
 									static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(_expSolidFwdLiquid.native(c, r)));
+							else if (static_cast<double>(_expSolidFwdLiquid.native(c, r)) == 1.0)
+								fwd *= static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(yLiquid[c]);
 							else
 							{
 								fwd *= 0.0;
@@ -616,6 +632,8 @@ namespace cadet
 							if (static_cast<double>(ySolid[c]) > 0.0)
 								fwd *= pow(static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(ySolid[c]),
 									static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(_expSolidFwd.native(c, r)));
+							else if (static_cast<double>(_expSolidFwd.native(c, r)) == 1.0)
+								fwd *= static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(ySolid[c]);
 							else
 							{
 								fwd *= 0.0;
@@ -632,6 +650,8 @@ namespace cadet
 							if (static_cast<double>(yLiquid[c]) > 0.0)
 								bwd *= pow(static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(yLiquid[c]),
 									static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(_expSolidBwdLiquid.native(c, r)));
+							else if (static_cast<double>(_expSolidBwdLiquid.native(c, r)) == 1.0)
+								bwd *= static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(yLiquid[c]);
 							else
 							{
 								bwd *= 0.0;
@@ -646,6 +666,8 @@ namespace cadet
 							if (static_cast<double>(ySolid[c]) > 0.0)
 								bwd *= pow(static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(ySolid[c]),
 									static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(_expSolidBwd.native(c, r)));
+							else if (static_cast<double>(_expSolidBwd.native(c, r)) == 1.0)
+								bwd *= static_cast<typename DoubleActiveDemoter<flux_t, active>::type>(ySolid[c]);
 							else
 							{
 								bwd *= 0.0;


### PR DESCRIPTION
This PR fixes the calculation of the derivative of the mass action law for the case where
$$
\frac{d}{dx} x = 1 
$$ 

for all $x \in \mathbb{R}$. 

Currently, the derivative was also set to zero for x = 0. This PR fixes that.  Additionally, the residual calculation is adjusted to obtain the direct Jacobian from the AD calculation.