### PR TITLE
Refactor conserved moieties calculation

### DIFF
--- a/src/libcadet/model/ColumnModel1D-InitialConditions.cpp
+++ b/src/libcadet/model/ColumnModel1D-InitialConditions.cpp
@@ -326,7 +326,7 @@ void ColumnModel1D<ConvDispOperator>::consistentInitialState(const SimulationTim
 	const auto& cm = _reaction.conservedMoieties("liquid");
 	if (cm.isEnabled() && cm.numEquilibriumReactions() > 0)
 	{
-		const auto& L = cm.getConservedMoietiesMatrix();
+		const auto& L = cm.conservedMoietyMatrix();
 		const unsigned int nMoieties = cm.numMoieties();
 		const unsigned int nEq = cm.numEquilibriumReactions();
 		const unsigned int probSize = _disc.nComp;
@@ -351,7 +351,7 @@ void ColumnModel1D<ConvDispOperator>::consistentInitialState(const SimulationTim
 			BufferedArray<double> conservedBuffer = tlmAlloc.array<double>(nMoieties);
 			double* const conserved = static_cast<double*>(conservedBuffer);
 
-			cm.multiplyToVector(conserved, cLocal, probSize);
+			cm.applyToVector(conserved, cLocal, probSize);
 
 			BufferedArray<double> baNonlinMem = tlmAlloc.array<double>(_nonlinearSolver->workspaceSize(probSize));
 			double* const nonlinMem = static_cast<double*>(baNonlinMem);
@@ -384,7 +384,7 @@ void ColumnModel1D<ConvDispOperator>::consistentInitialState(const SimulationTim
 			resFunc = [&](double const* const x, double* const r)
 			{
 				// Upper part: Conserved moieties
-				cm.multiplyToVector(r, x, probSize);
+				cm.applyToVector(r, x, probSize);
 				for (unsigned int m = 0; m < nMoieties; ++m)
 					r[m] -= conserved[m];
 
@@ -781,7 +781,7 @@ void ColumnModel1D<ConvDispOperator>::consistentInitialTimeDerivative(const Simu
 	const auto& cm = _reaction.conservedMoieties("liquid");
 	if (cm.isEnabled() && cm.numEquilibriumReactions() > 0)
 	{
-		const auto& L = cm.getConservedMoietiesMatrix();
+		const auto& L = cm.conservedMoietyMatrix();
 		const unsigned int nMoieties = cm.numMoieties();
 		const unsigned int nEq = cm.numEquilibriumReactions();
 

--- a/src/libcadet/model/ColumnModel1D-LinearSolver.cpp
+++ b/src/libcadet/model/ColumnModel1D-LinearSolver.cpp
@@ -147,7 +147,7 @@ int ColumnModel1D<ConvDispOperator>::linearSolve(double t, double alpha, double 
 	const auto& cm = _reaction.conservedMoieties("liquid");
 	if (cm.isEnabled() && cm.numEquilibriumReactions() > 0)
 	{
- 		const auto& L = cm.getConservedMoietiesMatrix();
+		const auto& L = cm.conservedMoietyMatrix();
         for (unsigned int moiety = 0; moiety < cm.numMoieties(); ++moiety)
         {
             double inletValue = 0.0;
@@ -228,7 +228,7 @@ void ColumnModel1D<ConvDispOperator>::assembleDiscretizedGlobalJacobian(double a
 	const auto& cm = _reaction.conservedMoieties("liquid");
 	if (cm.isEnabled() && cm.numEquilibriumReactions() > 0)
 	{
-		const auto& L = cm.getConservedMoietiesMatrix();
+		const auto& L = cm.conservedMoietyMatrix();
 		const unsigned int nMoieties = cm.numMoieties();
 		// todo refactor this
 		for (unsigned int point = 0; point < _disc.nPoints; ++point)

--- a/src/libcadet/model/ColumnModel1D.cpp
+++ b/src/libcadet/model/ColumnModel1D.cpp
@@ -496,7 +496,7 @@ bool ColumnModel1D<ConvDispOperator>::configure(IParameterProvider& paramProvide
 		hasBulkReaction = true;
 
 	setJacobianPattern(_globalJac, 0, hasBulkReaction);
-	reserveConservedMoietyJacobian();
+	resizeConservedMoietyJacobianBuffer();
 	_globalJacDisc = _globalJac;
 	// the solver repetitively solves the linear system with a static pattern of the jacobian (set above). 
 	// The goal of analyzePattern() is to reorder the nonzero elements of the matrix, such that the factorization step creates less fill-in
@@ -611,7 +611,7 @@ void ColumnModel1D<ConvDispOperator>::notifyDiscontinuousSectionTransition(doubl
 	// todo: only reset jacobian pattern if it changes, i.e. once in configuration and then only for changes in SurfDiff+kinetic binding.
 	bool hasReaction = _reaction.getDynReactionVector("liquid")[0];
 	setJacobianPattern(_globalJac, 0, hasReaction);
-	reserveConservedMoietyJacobian();
+	resizeConservedMoietyJacobianBuffer();
 	_globalJacDisc = _globalJac;
 
 	for (int parType = 0; parType < _disc.nParType; parType++)
@@ -764,7 +764,8 @@ void ColumnModel1D<ConvDispOperator>::extractJacobianFromAD(active const* const 
 		{
 			const int pointOffset = idxr.offsetC() + point * idxr.strideColNode();
 
-			cm.multiplyToMatrix(_globalJac, _disc.nComp, pointOffset, idxr.offsetCp(), _globalJac.cols(), _cMJacobianEntries);
+			cm.applyToMatrix(_globalJac, _disc.nComp, pointOffset, idxr.offsetCp(), _globalJac.cols(),
+				_cMJacobianEntries.data(), _cMJacobianEntries.size());
 		}
 	}
 
@@ -1095,7 +1096,7 @@ int ColumnModel1D<ConvDispOperator>::residualImpl(double t, unsigned int secIdx,
 				ResidualType* const resC = res + pointOffset;
 
 				std::copy_n(resC, _disc.nComp, static_cast<ResidualType*>(oldRes));
-				cm.multiplyToVector(resC, static_cast<ResidualType*>(oldRes), _disc.nComp);
+				cm.applyToVector(resC, static_cast<ResidualType*>(oldRes), _disc.nComp);
 
 				ResidualType* const eqRes = resC + nMoieties;
 				std::fill_n(eqRes, nEq, 0.0);
@@ -1124,7 +1125,8 @@ int ColumnModel1D<ConvDispOperator>::residualImpl(double t, unsigned int secIdx,
 			{
 				const int pointOffset = idxr.offsetC() + point * idxr.strideColNode();
 
-				cm.multiplyToMatrix(_globalJac, _disc.nComp, pointOffset, _cMJacobianEntries);
+				cm.applyToMatrix(_globalJac, _disc.nComp, pointOffset, 0, _globalJac.cols(),
+					_cMJacobianEntries.data(), _cMJacobianEntries.size());
 
 				// Replace the remaining component rows by equilibrium equations
 				for (unsigned int r = 0; r < nEq; ++r)
@@ -1332,7 +1334,7 @@ void ColumnModel1D<ConvDispOperator>::multiplyWithJacobian(const SimulationTime&
 	if (cm.isEnabled() && cm.numEquilibriumReactions() > 0)
 	{
 
-		const auto& L = cm.getConservedMoietiesMatrix();
+		const auto& L = cm.conservedMoietyMatrix();
 		for (unsigned int moiety = 0; moiety < cm.numMoieties(); ++moiety)
 		{
 			double inletDirection = 0.0;
@@ -1409,9 +1411,6 @@ void ColumnModel1D<ConvDispOperator>::multiplyWithDerivativeJacobian(const Simul
 	const auto& cm = _reaction.conservedMoieties("liquid");
 	if (cm.isEnabled() && cm.numEquilibriumReactions() > 0)
 	{
-		const unsigned int nMoieties = cm.numMoieties();
-		const unsigned int nEq = cm.numEquilibriumReactions();
-
 		for (unsigned int point = 0; point < _disc.nPoints; ++point)
 		{
 			const int pointOffset = idxr.offsetC() + point * idxr.strideColNode();
@@ -1419,10 +1418,7 @@ void ColumnModel1D<ConvDispOperator>::multiplyWithDerivativeJacobian(const Simul
 			double const* const localSDot = sDot + pointOffset;
 			double* const localRet = ret + pointOffset;
 
-			cm.multiplyToVector(localRet, localSDot, _disc.nComp);
-
-			// Equilibrium reaction rows
-			std::fill_n(localRet + nMoieties, nEq, 0.0);
+			cm.applyToDerivativeVector(localRet, localSDot, _disc.nComp);
 		}
 	}
 	// Handle inlet DOFs (all algebraic)
@@ -1889,7 +1885,7 @@ int ColumnModel1D<ConvDispOperator>::Exporter::writeOutlet(double* buffer) const
 }
 
 template <typename ConvDispOperator>
-void ColumnModel1D<ConvDispOperator>::reserveConservedMoietyJacobian()
+void ColumnModel1D<ConvDispOperator>::resizeConservedMoietyJacobianBuffer()
 {
 	const auto& cm = _reaction.conservedMoieties("liquid");
 	if (!cm.isEnabled() || (cm.numEquilibriumReactions() == 0))
@@ -1910,7 +1906,7 @@ void ColumnModel1D<ConvDispOperator>::reserveConservedMoietyJacobian()
 		maxEntries = std::max(maxEntries, numEntries);
 	}
 
-	_cMJacobianEntries.reserve(maxEntries);
+	_cMJacobianEntries.resize(maxEntries);
 }
 
 namespace

--- a/src/libcadet/model/ColumnModel1D.hpp
+++ b/src/libcadet/model/ColumnModel1D.hpp
@@ -294,7 +294,7 @@ protected:
 
 	parts::cell::CellParameters makeCellResidualParams(unsigned int parType, int const* qsReaction) const;
 
-	void reserveConservedMoietyJacobian();
+	void resizeConservedMoietyJacobianBuffer();
 
 #ifdef CADET_CHECK_ANALYTIC_JACOBIAN
 	void checkAnalyticJacobianAgainstAd(active const* const adRes, unsigned int adDirOffset) const;
@@ -341,7 +341,7 @@ protected:
 	ConvDispOperator _convDispOp; //!< Convection dispersion operator base for interstitial volume transport
 	ReactionSystem _reaction; //!< Reaction system for bulk phase
 
-	std::vector<ConservedMoieties::EigenSparseMatrixEntry> _cMJacobianEntries;
+	std::vector<Eigen::Triplet<double>> _cMJacobianEntries;
 
 	cadet::linalg::EigenSolverBase* _linearSolver; //!< Linear solver
 
@@ -553,39 +553,7 @@ protected:
 
 		const auto& cm = _reaction.conservedMoieties("liquid");
 		if (cm.isEnabled() && cm.numEquilibriumReactions() > 0)
-		{
-			const unsigned int nMoieties = cm.numMoieties();
-			const std::size_t originalTripletCount = tripletList.size();
-
-			const int firstBulkRow = idxr.offsetC();
-			const int lastBulkRow = idxr.offsetCp();
-
-			std::size_t numBulkTriplets = 0;
-			for (std::size_t i = 0; i < originalTripletCount; ++i)
-			{
-				const int sourceRow = tripletList[i].row();
-				if ((sourceRow >= firstBulkRow) && (sourceRow < lastBulkRow))
-					++numBulkTriplets;
-			}
-
-			tripletList.reserve(originalTripletCount + static_cast<std::size_t>(nMoieties) * numBulkTriplets);
-
-			for (std::size_t i = 0; i < originalTripletCount; ++i)
-			{
-				const int sourceRow = tripletList[i].row();
-				const int sourceColumn = tripletList[i].col();
-
-				if ((sourceRow < firstBulkRow) || (sourceRow >= lastBulkRow))
-					continue;
-
-				const unsigned int point = static_cast<unsigned int>(sourceRow - firstBulkRow) / idxr.strideColNode();
-
-				const int pointOffset = idxr.offsetC() + point * idxr.strideColNode();
-
-				for (unsigned int moiety = 0; moiety < nMoieties; ++moiety)
-					tripletList.emplace_back(pointOffset + moiety, sourceColumn, 0.0);
-			}
-		}
+				cm.addPatternToBlocks(tripletList, _disc.nComp, idxr.offsetC(), _disc.nPoints, idxr.strideColNode(), 0, globalJ.cols());
 
 		globalJ.setFromTriplets(tripletList.begin(), tripletList.end());
 	}

--- a/src/libcadet/model/StirredTankModel.cpp
+++ b/src/libcadet/model/StirredTankModel.cpp
@@ -679,7 +679,7 @@ void CSTRModel::consistentInitialState(const SimulationTime& simTime, double* co
 		}
 		LinearBufferAllocator tlmAlloc = threadLocalMem.get();
 
-		const auto& L = cm.getConservedMoietiesMatrix();
+		const auto& L = cm.conservedMoietyMatrix();
 
 		const unsigned int nMoieties = cm.numMoieties();
 		const unsigned int nEq = cm.numEquilibriumReactions();
@@ -1707,7 +1707,7 @@ int CSTRModel::residualImpl(double t, unsigned int secIdx, StateType const* cons
 	const auto& cm = _reactionSystemBulk.conservedMoieties("liquid");
 	if (cm.isEnabled() && cm.numEquilibriumReactions() > 0)
 	{ 
-		const Eigen::MatrixXd& L = cm.getConservedMoietiesMatrix();
+		const Eigen::MatrixXd& L = cm.conservedMoietyMatrix();
 
 		const unsigned int nMoieties = cm.numMoieties() ;
 		const unsigned int nEq = cm.numEquilibriumReactions();
@@ -2132,7 +2132,7 @@ void CSTRModel::multiplyWithDerivativeJacobian(const SimulationTime& simTime, co
 	if (cm.isEnabled() && cm.numEquilibriumReactions() > 0)
 	{
 		const unsigned int nPure = numPureDofs();
-		const Eigen::MatrixXd& L = cm.getConservedMoietiesMatrix();
+		const Eigen::MatrixXd& L = cm.conservedMoietyMatrix();
 		const unsigned int nMoieties = cm.numMoieties();
 		const unsigned int nEq = cm.numEquilibriumReactions();
 
@@ -2244,7 +2244,7 @@ void CSTRModel::addTimeDerivativeJacobian(double t, double alpha, const ConstSim
 
 	if (cm.isEnabled() &&  (cm.numEquilibriumReactions() > 0))
     {
-        const auto& L = cm.getConservedMoietiesMatrix();
+        const auto& L = cm.conservedMoietyMatrix();
         const unsigned int nMoieties = cm.numMoieties();
 
         //mat += alpha * L * dRes / dyDot

--- a/src/libcadet/model/reaction/ConservedMoieties.hpp
+++ b/src/libcadet/model/reaction/ConservedMoieties.hpp
@@ -12,19 +12,16 @@
 
 #pragma once
 
-#include "model/ReactionModel.hpp"
 #include "cadet/Exceptions.hpp"
-#include "ConfigurationHelper.hpp"
-#include "SensParamUtil.hpp"
-
-#include "LoggingUtils.hpp"
-#include "Logging.hpp"
+#include "cadet/cadetCompilerInfo.hpp"
+#include "common/CompilerSpecific.hpp"
 
 #include <Eigen/Core>
 #include <Eigen/SparseCore>
 #include <Eigen/SVD>
 
-#include <utility>
+#include <algorithm>
+#include <cstddef>
 #include <vector>
 
 namespace cadet
@@ -34,267 +31,224 @@ namespace model
 {
 
 
-
 class ConservedMoieties
-    {
-        
-        private:
-        bool _enabled = false;
+{
+public:
+	const Eigen::MatrixXd& conservedMoietyMatrix() const CADET_NOEXCEPT { return _L; }
 
-        unsigned int _nStates = 0;
-        unsigned int _nReactionTotal = 0;
-        unsigned int _nReactionEquilibirum = 0;
-        
-        std::vector<unsigned int> _reactionColumnOffset;
-        std::vector<bool> _eqReactionMask;
+	bool isEnabled() const CADET_NOEXCEPT { return _enabled; }
+	unsigned int rank() const CADET_NOEXCEPT { return numEquilibriumReactions(); }
+	unsigned int numMoieties() const CADET_NOEXCEPT { return static_cast<unsigned int>(_L.rows()); }
+	unsigned int numEquilibriumReactions() const CADET_NOEXCEPT
+	{
+		return static_cast<unsigned int>(_L.cols() - _L.rows());
+	}
 
-        Eigen::MatrixXd _S; // N dim: nStates x nReaction
-        Eigen::MatrixXd _eqS; // N_eq dim: nStates x nEqreaction
-        
-        Eigen::MatrixXd _L; // L dim: nMoities x nStates
-        unsigned int _rank = 0;
+	void clear()
+	{
+		_enabled = false;
+		_L.resize(0, 0);
+	}
 
-        double _TOL = 1e-15;
+	bool configure(unsigned int numStates, const std::vector<bool>& equilibriumReactionFlags, const Eigen::MatrixXd& stoichiometry, double rankTolerance)
+	{
+		cadet_assert(numStates == static_cast<unsigned int>(stoichiometry.rows()));
+		cadet_assert(equilibriumReactionFlags.size() == static_cast<std::size_t>(stoichiometry.cols()));
 
-        public:
-        const Eigen::MatrixXd& getConservedMoietiesMatrix() const { return _L; }
-        const Eigen::MatrixXd& conservedMoietyMatrix() const { return _L; }
-        const Eigen::MatrixXd& stoichiometryMatrix() const { return _S; }
-        const Eigen::MatrixXd& equilibriumStoichiometryMatrix() const { return _eqS; }
+		_enabled = false;
+		computeLeftNullspace(equilibriumReactionFlags, stoichiometry, rankTolerance);
+		_enabled = true;
+		return true;
+	}
 
+	/**
+	 * @brief Multiplies the conserved-moiety matrix with a state-sized vector
+	 * @param [out] targetVec Result vector with numMoieties() entries
+	 * @param [in] sourceVec Source vector with @p size entries, which must not alias @p targetVec
+	 * @param [in] size Number of source entries, equal to the number of states
+	 */
+	template <typename TargetType, typename SourceType>
+	void applyToVector(TargetType* const targetVec, SourceType const* const sourceVec, unsigned int size) const
+	{
+		cadet_assert(size == static_cast<unsigned int>(_L.cols()));
 
-        bool isEnabled() const {return _enabled; }
-        unsigned int rank() const {return _rank; }
-        unsigned int numMoieties() const  {return static_cast<unsigned int>(_L.rows()); }
-        unsigned int numEquilibriumReactions() const {return static_cast<unsigned int>(_eqS.cols()); }
+		for (unsigned int moiety = 0; moiety < numMoieties(); ++moiety)
+		{
+			targetVec[moiety] = TargetType{0.0};
+			for (unsigned int state = 0; state < size; ++state)
+				targetVec[moiety] += static_cast<double>(_L(moiety, state)) * sourceVec[state];
+		}
+	}
 
-        const std::vector<bool>& equilibriumReactionFlags() const { return _eqReactionMask;}
+	std::size_t matrixBufferSize(Eigen::SparseMatrix<double, Eigen::RowMajor> const& matrix, unsigned int numStates,
+		unsigned int rowOffset, Eigen::Index firstColumn, Eigen::Index lastColumn) const
+	{
+		cadet_assert(numStates == static_cast<unsigned int>(_L.cols()));
+		cadet_assert(rowOffset + numStates <= static_cast<unsigned int>(matrix.rows()));
+		cadet_assert((firstColumn >= 0) && (firstColumn <= lastColumn));
+		cadet_assert(lastColumn <= matrix.cols());
 
-        void clear()
-        {
-            _enabled = false;
-            _nStates = 0;
-            _nReactionTotal = 0;
-            _nReactionEquilibirum = 0;
-            _reactionColumnOffset.clear();
-            _eqReactionMask.clear();
-            _S.resize(0, 0);
-            _eqS.resize(0, 0);
-            _L.resize(0, 0);
-            _rank = 0;
-        }
+		std::size_t numEntries = 0;
+		for (unsigned int state = 0; state < numStates; ++state)
+		{
+			for (Eigen::SparseMatrix<double, Eigen::RowMajor>::InnerIterator it(matrix, rowOffset + state); it; ++it)
+			{
+				if ((it.col() >= firstColumn) && (it.col() < lastColumn))
+					++numEntries;
+			}
+		}
+		return numEntries;
+	}
 
-        bool configure(unsigned int states, std::vector<unsigned int>&& reactionColumnOffset,
-            std::vector<bool>&& eqReactionFlags, Eigen::MatrixXd&& stoichiometry, double rankTol)
-        {
-            _enabled = false;
-            _nStates = states;
-            _nReactionTotal = static_cast<unsigned int>(eqReactionFlags.size());
-            _reactionColumnOffset = std::move(reactionColumnOffset);
-            _eqReactionMask = std::move(eqReactionFlags);
-            _S = std::move(stoichiometry);
-            _TOL = rankTol;
+	/**
+	 * @brief Replaces a sparse row block in place using caller-provided buffer memory
+	 * @details The affected source entries are preserved in @p buffer before their rows are
+	 *          cleared. The buffer array must contain at least matrixBufferSize() entries. The
+	 *          matrix pattern must contain the union of all source row patterns in every
+	 *          conserved-moiety row.
+	 */
+	void applyToMatrix(Eigen::SparseMatrix<double, Eigen::RowMajor>& matrix, unsigned int numStates, unsigned int rowOffset, Eigen::Index firstColumn, Eigen::Index lastColumn, Eigen::Triplet<double>* const buffer, std::size_t bufferSize) const
+	{
+		cadet_assert(numStates == static_cast<unsigned int>(_L.cols()));
+		cadet_assert(rowOffset + numStates <= static_cast<unsigned int>(matrix.rows()));
+		cadet_assert((firstColumn >= 0) && (firstColumn <= lastColumn));
+		cadet_assert(lastColumn <= matrix.cols());
 
-            extractEquilibriumStoichiometry();
-            computeLeftNullspace();
+		std::size_t numEntries = 0;
+		for (unsigned int state = 0; state < numStates; ++state)
+		{
+			for (Eigen::SparseMatrix<double, Eigen::RowMajor>::InnerIterator it(matrix, rowOffset + state); it; ++it)
+			{
+				if ((it.col() < firstColumn) || (it.col() >= lastColumn))
+					continue;
 
-            _enabled = true;
-            return true;
-        }
+				cadet_assert(numEntries < bufferSize);
+				buffer[numEntries++] = Eigen::Triplet<double>(state, it.col(), it.value());
+				it.valueRef() = 0.0;
+			}
+		}
+		cadet_assert(numEntries <= bufferSize);
 
-        void extractEquilibriumStoichiometry()
-        {
-            unsigned int nEq = 0;
-            for (bool isEq : _eqReactionMask)
-            {
-                if (isEq) ++nEq;
-            }
+		for (std::size_t entryIndex = 0; entryIndex < numEntries; ++entryIndex)
+		{
+			const Eigen::Triplet<double>& entry = buffer[entryIndex];
+			for (unsigned int moiety = 0; moiety < numMoieties(); ++moiety)
+			{
+				const double factor = _L(moiety, entry.row());
+				if (factor != 0.0)
+					matrix.coeffRef(rowOffset + moiety, entry.col()) += factor * entry.value();
+			}
+		}
+	}
 
-            _nReactionEquilibirum = nEq;
-            _eqS.resize(_S.rows(), nEq);
-            unsigned int col = 0;
-            for (unsigned int r = 0; r < _eqReactionMask.size(); ++r)
-            {
-                if (!_eqReactionMask[r])
-                    continue;
-                _eqS.col(col++) = _S.col(r);
-            }
+	/**
+	 * @brief Multiplies the conserved-moiety transformation to a time-derivative result
+	 * @details Conserved-moiety rows are transformed and equilibrium-reaction rows are
+	 *          set to zero because equilibrium equations are algebraic.
+	 */
+	template <typename TargetType, typename SourceType>
+	void applyToDerivativeVector(TargetType* const targetVec, SourceType const* const sourceVec, unsigned int size) const
+	{
+		cadet_assert(numMoieties() + numEquilibriumReactions() == size);
+		applyToVector(targetVec, sourceVec, size);
+		std::fill_n(targetVec + numMoieties(), numEquilibriumReactions(), TargetType{0.0});
+	}
 
-        }
+	/**
+	 * @brief Adds the row-pattern for one or more conserved-moiety row blocks
+	 * @details Every conserved-moiety row receives the union of the patterns of all source rows
+	 *          in its block and within the selected column range. All blocks are processed in one
+	 *          pass over @p entries. Only entries present when the method is called are used as
+	 *          source entries, so generated entries are never transformed recursively.
+	 */
+	void addPatternToBlocks(std::vector<Eigen::Triplet<double>>& entries, unsigned int numStates, unsigned int firstRowOffset, unsigned int numBlocks, unsigned int rowStride, Eigen::Index firstColumn, Eigen::Index lastColumn) const
+	{
+		cadet_assert(numStates == static_cast<unsigned int>(_L.cols()));
+		cadet_assert(rowStride >= numStates);
+		cadet_assert(firstColumn <= lastColumn);
+		if ((numBlocks == 0) || (numStates == 0))
+			return;
 
-        void computeLeftNullspace()
-        {
-            if (_eqS.cols() == 0)
-            { 
-                _rank = 0;
-                _L = Eigen::MatrixXd::Identity(_eqS.rows(), _eqS.rows());
-                return;
-            }
+		const std::size_t originalSize = entries.size();
+		std::size_t sourceEntries = 0;
+		for (std::size_t i = 0; i < originalSize; ++i)
+		{
+			const Eigen::Index column = entries[i].col();
+			if ((column < firstColumn) || (column >= lastColumn))
+				continue;
 
-            Eigen::MatrixXd A = _eqS.transpose();
-            Eigen::JacobiSVD<Eigen::MatrixXd> svd(A, Eigen::ComputeFullV);
-            
-            const auto& singularValues = svd.singularValues();
+			const Eigen::Index relativeRow = entries[i].row() - static_cast<Eigen::Index>(firstRowOffset);
+			if (relativeRow < 0)
+				continue;
 
-            _rank = 0;
-            for (int i = 0; i < singularValues.size(); ++i)
-            {
-                if (singularValues(i) > _TOL)
-                    ++_rank;
-            }
+			const unsigned int block = static_cast<unsigned int>(relativeRow) / rowStride;
+			const unsigned int localRow = static_cast<unsigned int>(relativeRow) % rowStride;
+			if ((block < numBlocks) && (localRow < numStates))
+				++sourceEntries;
+		}
 
-            if (_nReactionEquilibirum != _rank)
-	            throw InvalidParameterException("Conserved Moieties: Redundant equilibrium reactions are not supported");
+		entries.reserve(entries.size() + static_cast<std::size_t>(numMoieties()) * sourceEntries);
+		for (std::size_t i = 0; i < originalSize; ++i)
+		{
+			const Eigen::Index sourceColumn = entries[i].col();
+			if ((sourceColumn < firstColumn) || (sourceColumn >= lastColumn))
+				continue;
 
-            const unsigned int nullity = static_cast<unsigned int>(A.cols()) - _rank;
-            
-            if (nullity == 0)
-            {
-                _L = Eigen::MatrixXd::Zero(0, _eqS.rows());
-                return;
-            }
-            
-            const Eigen::MatrixXd V = svd.matrixV();
-            
-            // Columns rank ... end span null(A)
-            const Eigen::MatrixXd nullspace = V.rightCols(nullity);
-            // L such that L * N = 0
-            _L = nullspace.transpose();
-        }
+			const Eigen::Index relativeRow = entries[i].row() - static_cast<Eigen::Index>(firstRowOffset);
+			if (relativeRow < 0)
+				continue;
 
-        /**
-         * @brief Multiplies the conserved-moiety matrix with a state-sized vector
-         * @param [out] targetVec Result vector with numMoieties() entries
-         * @param [in] sourceVec Source vector with @p size entries, which must not alias @p targetVec
-         * @param [in] size Number of source entries, equal to the number of states
-         */
-        template <typename TargetType, typename SourceType>
-        void multiplyToVector(TargetType* const targetVec, SourceType const* const sourceVec, unsigned int size) const
-        {
-            cadet_assert(size == static_cast<unsigned int>(_L.cols()));
+			const unsigned int block = static_cast<unsigned int>(relativeRow) / rowStride;
+			const unsigned int localRow = static_cast<unsigned int>(relativeRow) % rowStride;
+			if ((block >= numBlocks) || (localRow >= numStates))
+				continue;
 
-            for (unsigned int moiety = 0; moiety < numMoieties(); ++moiety)
-            {
-                targetVec[moiety] = TargetType{0.0};
-                for (unsigned int state = 0; state < size; ++state)
-                    targetVec[moiety] += static_cast<double>(_L(moiety, state)) * sourceVec[state];
-            }
-        }
+			const Eigen::Index targetRowOffset = firstRowOffset + block * rowStride;
+			for (unsigned int moiety = 0; moiety < numMoieties(); ++moiety)
+				entries.emplace_back(targetRowOffset + moiety, sourceColumn, 0.0);
+		}
+	}
 
-        /**
-         * @brief Replaces a sparse row block by its conserved-moiety transformation
-         * @details All @p numStates rows in the target block are cleared. The first numMoieties()
-         *          rows are then set to L times the corresponding source rows. The source and
-         *          target matrices must not alias. The target pattern must contain the union
-         *          of all source row patterns.
-         */
-        void multiplyToMatrix(Eigen::SparseMatrix<double, Eigen::RowMajor>& targetMat,
-            Eigen::SparseMatrix<double, Eigen::RowMajor> const& sourceMat, unsigned int numStates, unsigned int rowOffset) const
-        {
-            multiplyToMatrix(targetMat, sourceMat, numStates, rowOffset, 0, targetMat.cols());
-        }
+private:
+	bool _enabled = false;
+	Eigen::MatrixXd _L; // L dim: nMoities x nStates
 
-        void multiplyToMatrix(Eigen::SparseMatrix<double, Eigen::RowMajor>& targetMat,
-            Eigen::SparseMatrix<double, Eigen::RowMajor> const& sourceMat, unsigned int numStates,
-            unsigned int rowOffset, Eigen::Index firstColumn, Eigen::Index lastColumn) const
-        {
-            cadet_assert(numStates == static_cast<unsigned int>(_L.cols()));
-            cadet_assert(rowOffset + numStates <= static_cast<unsigned int>(targetMat.rows()));
-            cadet_assert(rowOffset + numStates <= static_cast<unsigned int>(sourceMat.rows()));
-            cadet_assert((firstColumn >= 0) && (firstColumn <= lastColumn));
-            cadet_assert(lastColumn <= targetMat.cols());
-            cadet_assert(lastColumn <= sourceMat.cols());
-            cadet_assert(&targetMat != &sourceMat);
+	void computeLeftNullspace(const std::vector<bool>& equilibriumReactionFlags, const Eigen::MatrixXd& stoichiometry, double rankTolerance)
+	{
+		const unsigned int numEquilibriumReactions = static_cast<unsigned int>(std::count(equilibriumReactionFlags.begin(), equilibriumReactionFlags.end(), true));
+		if (numEquilibriumReactions == 0)
+		{
+			_L = Eigen::MatrixXd::Identity(stoichiometry.rows(), stoichiometry.rows());
+			return;
+		}
 
-            // Clear the transformed row block once.
-            for (unsigned int row = 0; row < numStates; ++row)
-            {
-                for (Eigen::SparseMatrix<double, Eigen::RowMajor>::InnerIterator it(targetMat, rowOffset + row); it; ++it)
-                {
-                    if ((it.col() >= firstColumn) && (it.col() < lastColumn))
-                        it.valueRef() = 0.0;
-                }
-            }
+		Eigen::MatrixXd transposedStoichiometry(numEquilibriumReactions, stoichiometry.rows());
+		unsigned int equilibriumRow = 0;
+		for (unsigned int reaction = 0; reaction < equilibriumReactionFlags.size(); ++reaction)
+		{
+			if (equilibriumReactionFlags[reaction])
+				transposedStoichiometry.row(equilibriumRow++) = stoichiometry.col(reaction).transpose();
+		}
 
-            // Apply L to complete sparse rows.
-            for (unsigned int moiety = 0; moiety < numMoieties(); ++moiety)
-            {
-                const Eigen::Index targetRow = rowOffset + moiety;
-                for (unsigned int state = 0; state < numStates; ++state)
-                {
-                    const double factor = _L(moiety, state);
-                    if (factor == 0.0)
-                        continue;
+		Eigen::JacobiSVD<Eigen::MatrixXd> svd(transposedStoichiometry, Eigen::ComputeFullV);
 
-                    for (Eigen::SparseMatrix<double, Eigen::RowMajor>::InnerIterator it(sourceMat, rowOffset + state); it; ++it)
-                    {
-                        if ((it.col() >= firstColumn) && (it.col() < lastColumn))
-                            targetMat.coeffRef(targetRow, it.col()) += factor * it.value();
-                    }
-                }
-            }
-        }
+		unsigned int rank = 0;
+		for (int singularValue = 0; singularValue < svd.singularValues().size(); ++singularValue)
+		{
+			if (svd.singularValues()(singularValue) > rankTolerance)
+				++rank;
+		}
 
-        struct EigenSparseMatrixEntry
-        {
-            unsigned int sourceRow;
-            Eigen::Index column;
-            double value;
-        };
+		if (numEquilibriumReactions != rank)
+			throw InvalidParameterException("Conserved Moieties: Redundant equilibrium reactions are not supported");
 
-        /**
-         * @brief Replaces a sparse row block in place by its conserved-moiety transformation
-         * @details The affected source entries are preserved in @p scratch before their rows are
-         *          cleared. The scratch capacity is retained between calls. The matrix pattern must
-         *          contain the union of all source row patterns in every conserved-moiety row.
-         */
-        void multiplyToMatrix(Eigen::SparseMatrix<double, Eigen::RowMajor>& matrix, unsigned int numStates, unsigned int rowOffset,
-            Eigen::Index firstColumn, Eigen::Index lastColumn, std::vector<EigenSparseMatrixEntry>& orig) const
-        {
-            cadet_assert(numStates == static_cast<unsigned int>(_L.cols()));
-            cadet_assert(rowOffset + numStates <= static_cast<unsigned int>(matrix.rows()));
-            cadet_assert((firstColumn >= 0) && (firstColumn <= lastColumn));
-            cadet_assert(lastColumn <= matrix.cols());
+		const unsigned int nullity = static_cast<unsigned int>(transposedStoichiometry.cols()) - rank;
+		_L = svd.matrixV().rightCols(nullity).transpose();
+	}
 
-            orig.clear();
-
-            // Save and clear source rows
-            for (unsigned int state = 0; state < numStates; ++state)
-            {
-                for (Eigen::SparseMatrix<double, Eigen::RowMajor>::InnerIterator it(matrix, rowOffset + state); it; ++it)
-                {
-                    if ((it.col() < firstColumn) || (it.col() >= lastColumn))
-                        continue;
-
-                    orig.push_back({state, it.col(), it.value()});
-                    it.valueRef() = 0.0;
-                }
-            }
-
-            // Rebuild conserved rows from the preserved entries
-            for (const EigenSparseMatrixEntry& entry : orig)
-            {
-                for (unsigned int m = 0; m < numMoieties(); ++m)
-                {
-                    const double factor = _L(m, entry.sourceRow);
-                    if (factor == 0.0)
-                        continue;
-
-                    matrix.coeffRef(rowOffset + m, entry.column) += factor * entry.value;
-                }
-            }
-        }
-
-        void multiplyToMatrix(Eigen::SparseMatrix<double, Eigen::RowMajor>& matrix, unsigned int numStates, unsigned int rowOffset,
-            std::vector<EigenSparseMatrixEntry>& scratch) const
-        {
-            multiplyToMatrix(
-                matrix, numStates, rowOffset, 0, matrix.cols(), scratch);
-        }
-
-    };
+};
 
 
-} //model
+} // namespace model
 
-} //cadet
+} // namespace cadet

--- a/src/libcadet/model/reaction/ReactionSystem.hpp
+++ b/src/libcadet/model/reaction/ReactionSystem.hpp
@@ -292,13 +292,8 @@ struct ReactionSystem
             auto& cm = phase.consMoities;
             
             unsigned int totalCols = 0;
-            std::vector<unsigned int> reactionColumnOffset;
-            reactionColumnOffset.reserve(phase.dynReactions.size());
-            
             for (const auto* reaction : phase.dynReactions)
             {
-                reactionColumnOffset.push_back(totalCols);
-
                 if (!reaction)
                     continue;
                 
@@ -333,7 +328,7 @@ struct ReactionSystem
                 colOffset += nReac;
             }
 
-            bool conservedMoitiesSuccess = cm.configure(nStates, std::move(reactionColumnOffset), std::move(eqReactionFlags), std::move(S), rankTol);
+            bool conservedMoitiesSuccess = cm.configure(nStates, eqReactionFlags, S, rankTol);
 
             if (cm.isEnabled() && cm.numEquilibriumReactions() > 0)
             {

--- a/test/ReactionModelTests.cpp
+++ b/test/ReactionModelTests.cpp
@@ -523,9 +523,9 @@ namespace reaction
 		}
 
 		cadet::model::ConservedMoieties cm;
-		REQUIRE(cm.configure(nComp, std::vector<unsigned int>{0u}, std::move(eqReactionFlags), std::move(stoichiometry), 1e-14));
+		REQUIRE(cm.configure(nComp, eqReactionFlags, stoichiometry, 1e-14));
 
-		return cm.getConservedMoietiesMatrix();
+		return cm.conservedMoietyMatrix();
 	}
 
 	void checkNullSpace(const Eigen::MatrixXd& left, const Eigen::MatrixXd& right)

--- a/test/ReactionModels.cpp
+++ b/test/ReactionModels.cpp
@@ -16,12 +16,12 @@
 #include "ColumnTests.hpp"
 #include "ReactionModelFactory.hpp"
 #include "common/JsonParameterProvider.hpp"
+#include "model/reaction/ConservedMoieties.hpp"
 
 #include <cmath>
 #include <memory>
 #include <utility>
 #include <vector>
-
 
 TEST_CASE("MassActionLaw conserved moieties nullspace", "[MassActionLaw],[ReactionModel],[ConservedMoieties],[CI]")
 {
@@ -109,6 +109,103 @@ TEST_CASE("MassActionLaw conserved moieties nullspace", "[MassActionLaw],[Reacti
 		{
 			for (Eigen::Index c = 0; c < L.cols(); ++c)
 				CHECK(std::abs(L(r, c) - expected(r, c)) <= tol);
+		}
+	}
+}
+
+TEST_CASE("Conserved moiety transformations", "[ReactionModel],[ConservedMoieties],[CI]")
+{
+	constexpr double tol = 1e-12;
+
+	Eigen::MatrixXd stoichiometry(3, 1);
+	stoichiometry << -1.0, -1.0, 1.0;
+	const std::vector<bool> equilibriumReactionFlags{true};
+
+	cadet::model::ConservedMoieties cm;
+	REQUIRE(cm.configure(3, equilibriumReactionFlags, stoichiometry, 1e-14));
+	REQUIRE(cm.numMoieties() == 2);
+	REQUIRE(cm.numEquilibriumReactions() == 1);
+
+	const double source[] = {1.0, 2.0, 4.0};
+	double expected[2] = {0.0, 0.0};
+	const Eigen::MatrixXd& L = cm.conservedMoietyMatrix();
+	for (unsigned int moiety = 0; moiety < cm.numMoieties(); ++moiety)
+	{
+		for (unsigned int state = 0; state < 3; ++state)
+			expected[moiety] += L(moiety, state) * source[state];
+	}
+
+	SECTION("Vector")
+	{
+		double result[2];
+		cm.applyToVector(result, source, 3);
+		CHECK(std::abs(result[0] - expected[0]) <= tol);
+		CHECK(std::abs(result[1] - expected[1]) <= tol);
+
+	}
+
+	SECTION("Derivative vector")
+	{
+		double result[3];
+		cm.applyToDerivativeVector(result, source, 3);
+		CHECK(std::abs(result[0] - expected[0]) <= tol);
+		CHECK(std::abs(result[1] - expected[1]) <= tol);
+		CHECK(result[2] == 0.0);
+	}
+
+	SECTION("Sparse matrix and pattern")
+	{
+		std::vector<Eigen::Triplet<double>> entries;
+		entries.emplace_back(0, 0, 9.0);
+		entries.emplace_back(1, 0, 1.0);
+		entries.emplace_back(1, 3, 2.0);
+		entries.emplace_back(2, 1, 3.0);
+		entries.emplace_back(3, 2, 4.0);
+		const Eigen::MatrixXd original = (Eigen::MatrixXd(3, 4) <<
+			1.0, 0.0, 0.0, 2.0,
+			0.0, 3.0, 0.0, 0.0,
+			0.0, 0.0, 4.0, 0.0).finished();
+
+		cm.addPatternToBlocks(entries, 3, 1, 1, 3, 0, 4);
+		Eigen::SparseMatrix<double, Eigen::RowMajor> matrix(5, 4);
+		matrix.setFromTriplets(entries.begin(), entries.end());
+
+		const std::size_t bufferSize = cm.matrixBufferSize(matrix, 3, 1, 0, matrix.cols());
+		std::vector<Eigen::Triplet<double>> buffer(bufferSize);
+		CHECK(bufferSize > 0);
+		cm.applyToMatrix(matrix, 3, 1, 0, matrix.cols(), buffer.data(), buffer.size());
+
+		for (unsigned int moiety = 0; moiety < cm.numMoieties(); ++moiety)
+		{
+			for (unsigned int column = 0; column < 4; ++column)
+			{
+				double transformed = 0.0;
+				for (unsigned int state = 0; state < 3; ++state)
+					transformed += L(moiety, state) * original(state, column);
+				CHECK(std::abs(matrix.coeff(1 + moiety, column) - transformed) <= tol);
+			}
+		}
+		CHECK(matrix.coeff(0, 0) == 9.0);
+	}
+
+	SECTION("Repeated sparse pattern")
+	{
+		std::vector<Eigen::Triplet<double>> entries;
+		entries.emplace_back(1, 0, 1.0);
+		entries.emplace_back(5, 3, 2.0);
+		cm.addPatternToBlocks(entries, 3, 1, 2, 4, 0, 4);
+
+		for (unsigned int moiety = 0; moiety < cm.numMoieties(); ++moiety)
+		{
+			bool firstBlockEntryFound = false;
+			bool secondBlockEntryFound = false;
+			for (const auto& entry : entries)
+			{
+				firstBlockEntryFound = firstBlockEntryFound || ((entry.row() == 1 + moiety) && (entry.col() == 0));
+				secondBlockEntryFound = secondBlockEntryFound || ((entry.row() == 5 + moiety) && (entry.col() == 3));
+			}
+			CHECK(firstBlockEntryFound);
+			CHECK(secondBlockEntryFound);
 		}
 	}
 }


### PR DESCRIPTION
This PR refactors the conserved-moiety implementation 

- Simplify `ConservedMoieties` to store only the computed conserved-moiety matrix `L` and its enabled state.
- Remove redundant data
- Add functions for:
  - vector transformations
  - time-derivative transformations
  - sparse matrix transformations
  - sparse Jacobian-pattern transformations

- Added tests for the conserved-moiety transformation