### PR TITLE
Fix GRM_FV reading multiple particle type `has_surface_diffusion`

### DIFF
--- a/src/libcadet/model/GeneralRateModel.cpp
+++ b/src/libcadet/model/GeneralRateModel.cpp
@@ -460,34 +460,39 @@ bool GeneralRateModel<ConvDispOperator>::configureModelDiscretization(IParameter
 		_parDepSurfDiffusion = std::vector<IParameterStateDependence*>(_disc.nParType, nullptr);
 	}
 
+	paramProvider.popScope();
+
 	if (optimizeParticleJacobianBandwidth)
 	{
 		// Check whether surface diffusion is present
 		_hasSurfaceDiffusion = std::vector<bool>(_disc.nParType, false);
-		if (paramProvider.exists("SURFACE_DIFFUSION"))
+		for (unsigned int i = 0; i < _disc.nParType; ++i)
 		{
-			const std::vector<double> surfDiff = paramProvider.getDoubleArray("SURFACE_DIFFUSION");
-			for (unsigned int i = 0; i < _disc.nParType; ++i)
+			// Assume particle surface diffusion if a parameter dependence is present
+			if (_parDepSurfDiffusion[i])
 			{
-				// Assume particle surface diffusion if a parameter dependence is present
-				if (_parDepSurfDiffusion[i])
-				{
-					_hasSurfaceDiffusion[i] = true;
-					continue;
-				}
+				_hasSurfaceDiffusion[i] = true;
+				continue;
+			}
 
-				double const* const lsd = surfDiff.data() + _disc.nBoundBeforeType[i];
+			paramProvider.pushScope("particle_type_" + std::string(3 - std::to_string(i).length(), '0') + std::to_string(i));
 
-				// Check surface diffusion coefficients of each particle type
-				for (unsigned int j = 0; j < _disc.strideBound[i]; ++j)
+			if (paramProvider.exists("SURFACE_DIFFUSION"))
+			{
+				const std::vector<double> surfDiff = paramProvider.getDoubleArray("SURFACE_DIFFUSION");
+
+				// Check surface diffusion coefficients of this particle type
+				for (unsigned int j = 0; j < surfDiff.size(); ++j)
 				{
-					if (lsd[j] != 0.0)
+					if (surfDiff[j] != 0.0)
 					{
 						_hasSurfaceDiffusion[i] = true;
 						break;
 					}
 				}
 			}
+
+			paramProvider.popScope();
 		}
 	}
 	else
@@ -495,8 +500,6 @@ bool GeneralRateModel<ConvDispOperator>::configureModelDiscretization(IParameter
 		// Assume that surface diffusion is present
 		_hasSurfaceDiffusion = std::vector<bool>(_disc.nParType, true);
 	}
-
-	paramProvider.popScope();
 
 	const bool transportSuccess = _convDispOp.configureModelDiscretization(paramProvider, helper, _disc.nComp, _disc.nCol);
 


### PR DESCRIPTION
SURFACE_DIFFUSION is read from each particle type's own scope (as in configure()), not from a single multiplexed array spanning all particle types. Reading it once from particle_type_000 and indexing into it via nBoundBeforeType[i] (as done previously) is wrong for i > 0 and reads out of bounds of the (only strideBound[0]-sized) array.

This lead to a memory access bug in the test "optimizeParticleJacobianBandwidth", making it flaky