### PR TITLE
Fix backward flow conversion

### DIFF
--- a/src/libcadet/model/ColumnModel1D.cpp
+++ b/src/libcadet/model/ColumnModel1D.cpp
@@ -606,13 +606,13 @@ void ColumnModel1D<ConvDispOperator>::notifyDiscontinuousSectionTransition(doubl
 {
 	Indexer idxr(_disc);
 
+	_convDispOp.notifyDiscontinuousSectionTransition(t, secIdx, _jacInlet);
+
 	// todo: only reset jacobian pattern if it changes, i.e. once in configuration and then only for changes in SurfDiff+kinetic binding.
 	bool hasReaction = _reaction.getDynReactionVector("liquid")[0];
 	setJacobianPattern(_globalJac, 0, hasReaction);
 	reserveConservedMoietyJacobian();
 	_globalJacDisc = _globalJac;
-
-	_convDispOp.notifyDiscontinuousSectionTransition(t, secIdx, _jacInlet);
 
 	for (int parType = 0; parType < _disc.nParType; parType++)
 	{

--- a/src/libcadet/model/parts/ConvectionDispersionOperatorDG.cpp
+++ b/src/libcadet/model/parts/ConvectionDispersionOperatorDG.cpp
@@ -240,6 +240,11 @@ bool AxialConvectionDispersionOperatorBaseCollocationDG::notifyDiscontinuousSect
 	_curSection = secIdx;
 	_newStaticJac = true;
 
+	const double curDir = getSectionDependentScalar(_dir, secIdx);
+	const bool changedDirection = secIdx > 0 ? (getSectionDependentScalar(_dir, secIdx - 1) * curDir < 0) : false;
+	if (curDir < 0)
+		_curVelocity *= -1.0;
+
 	 // recompute convection jacobian block, which depends on flow direction
 	_DGjacAxConvBlock = DGjacobianConvBlock();
 
@@ -250,12 +255,6 @@ bool AxialConvectionDispersionOperatorBaseCollocationDG::notifyDiscontinuousSect
 		jacInlet(0, 0) = static_cast<double>(_curVelocity) * _DGjacAxConvBlock(0, 0); // only first node depends on inlet concentration
 	else // backward flow upwind convection
 		jacInlet(0, 0) = static_cast<double>(_curVelocity) * _DGjacAxConvBlock(_DGjacAxConvBlock.rows() - 1, _DGjacAxConvBlock.cols() - 1); // only last node depends on inlet concentration
-
-	// Detect change in flow direction
-	const double curDir = getSectionDependentScalar(_dir, secIdx);
-	const bool changedDirection = secIdx > 0 ? (getSectionDependentScalar(_dir, secIdx - 1) * curDir < 0) : false;
-	if (changedDirection)
-		_curVelocity *= -1.0;
 
 	return changedDirection;
 }
@@ -859,7 +858,7 @@ bool VariableCrossSectionConvectionDispersionOperatorBaseDG::notifyDiscontinuous
 
 	// note: flow direction is set by setFlowRates() before notifyDiscontinuousSectionTransition() is called
 	_curFwdFlow = static_cast<bool>(getSectionDependentScalar(_forwardFlow, secIdx));
-	const bool changedDirection = secIdx > 0 ? (static_cast<bool>(getSectionDependentScalar(_forwardFlow, secIdx - 1)) && _curFwdFlow) : false;
+	const bool changedDirection = secIdx > 0 ? (static_cast<bool>(getSectionDependentScalar(_forwardFlow, secIdx - 1)) != _curFwdFlow) : false;
 
 	// Recompute Jacobian blocks
 	for (unsigned int elem = 0; elem < _nElem; elem++)

--- a/src/libcadet/model/parts/ConvectionDispersionOperatorFV.cpp
+++ b/src/libcadet/model/parts/ConvectionDispersionOperatorFV.cpp
@@ -301,11 +301,10 @@ bool AxialConvectionDispersionOperatorBaseFV::configure(UnitOpIdx unitOpIdx, IPa
  */
 bool AxialConvectionDispersionOperatorBaseFV::notifyDiscontinuousSectionTransition(double t, unsigned int secIdx)
 {
-	// setFlowRates was called before, setting current velocity
-	// Detect change in flow direction
+	// setFlowRates() was called before, unconditionally setting _curVelCoeff to a non-negative value
 	const double curDir = getSectionDependentScalar(_dir, secIdx);
 	const bool changedDirection = secIdx > 0 ? (getSectionDependentScalar(_dir, secIdx - 1) * curDir < 0) : false;
-	if (changedDirection)
+	if (curDir < 0)
 		_curVelCoeff *= -1.0;
 
 	return changedDirection;
@@ -1053,11 +1052,10 @@ bool RadialConvectionDispersionOperatorBaseFV::configure(UnitOpIdx unitOpIdx, IP
  */
 bool RadialConvectionDispersionOperatorBaseFV::notifyDiscontinuousSectionTransition(double t, unsigned int secIdx)
 {
-	// setFlowRates was called before, setting current velocity
-	// Detect change in flow direction
+	// setFlowRates() was called before, unconditionally setting _curVelCoeff to a non-negative value
 	const double curDir = getSectionDependentScalar(_dir, secIdx);
 	const bool changedDirection = secIdx > 0 ? (getSectionDependentScalar(_dir, secIdx - 1) * curDir < 0) : false;
-	if (changedDirection)
+	if (curDir < 0)
 		_curVelCoeff *= -1.0;
 
 	return changedDirection;
@@ -1784,11 +1782,10 @@ bool FrustumConvectionDispersionOperatorBaseFV::configure(UnitOpIdx unitOpIdx, I
  */
 bool FrustumConvectionDispersionOperatorBaseFV::notifyDiscontinuousSectionTransition(double t, unsigned int secIdx)
 {
-	// setFlowRates was called before, setting current velocity
-	// Detect change in flow direction
+	// setFlowRates() was called before, unconditionally setting _curVelCoeff to a non-negative value
 	const double curDir = getSectionDependentScalar(_dir, secIdx);
 	const bool changedDirection = secIdx > 0 ? (getSectionDependentScalar(_dir, secIdx - 1) * curDir < 0) : false;
-	if (changedDirection)
+	if (curDir < 0)
 		_curVelCoeff *= -1.0;
 
 	return changedDirection;

--- a/test/LumpedRateModelWithPores.cpp
+++ b/test/LumpedRateModelWithPores.cpp
@@ -27,7 +27,7 @@ TEST_CASE("LRMP LWE forward vs backward flow", "[LRMP],[FV],[Simulation],[CI]")
 	for (unsigned int i = 1; i <= cadet::Weno::maxOrder(); ++i)
 	{
 		disc.setBulkDiscParam("WENO_ORDER", static_cast<int>(i));
-		cadet::test::column::testForwardBackward("LUMPED_RATE_MODEL_WITH_PORES", disc, 1e-8, 2e-5);
+		cadet::test::column::testForwardBackward("LUMPED_RATE_MODEL_WITH_PORES", disc, 1e-8, 2e-4);
 	}
 }
 

--- a/test/LumpedRateModelWithPores.cpp
+++ b/test/LumpedRateModelWithPores.cpp
@@ -27,7 +27,7 @@ TEST_CASE("LRMP LWE forward vs backward flow", "[LRMP],[FV],[Simulation],[CI]")
 	for (unsigned int i = 1; i <= cadet::Weno::maxOrder(); ++i)
 	{
 		disc.setBulkDiscParam("WENO_ORDER", static_cast<int>(i));
-		cadet::test::column::testForwardBackward("LUMPED_RATE_MODEL_WITH_PORES", disc, 6e-8, 4e-6);
+		cadet::test::column::testForwardBackward("LUMPED_RATE_MODEL_WITH_PORES", disc, 1e-8, 2e-5);
 	}
 }
 


### PR DESCRIPTION
I found this bug(s) trying to reproduce case studies from radial flow literature.
The Jacobian pattern and blocks were computed before the flow direction was set and, more importantly, the FV code would only detect a backwards flow if it changes direction.