### PR TITLE
Add van Deemter parameter dependence

### DIFF
--- a/doc/interface/parameter_dependencies_config.rst
+++ b/doc/interface/parameter_dependencies_config.rst
@@ -14,10 +14,19 @@ Group /input/model/unit_XXX
 ``COL_DISPERSION_DEP``
 
    Parameter dependence of column dispersion on the interstitial velocity. Available for all 1D units and both the FV and DG discretization.
+   For the DG discretization, ``DISPERSION_SPATIAL_DEPENDENCE_POLYDEG`` must additionally be set (see below).
 
-   ================  =====================================  =============
-   **Type:** string  **Range:** :math:`\texttt{POWER_LAW}`  **Length:** 1
-   ================  =====================================  =============
+   ================  ===========================================================  =============
+   **Type:** string  **Range:** :math:`\texttt{POWER_LAW}, \texttt{VAN_DEEMTER}`  **Length:** 1
+   ================  ===========================================================  =============
+
+``DISPERSION_SPATIAL_DEPENDENCE_POLYDEG``
+
+   Quadrature polynomial degree used to evaluate the position-dependent (velocity-dependent) dispersion integral when ``COL_DISPERSION_DEP`` is set together with DG bulk discretization. Required in that case only; ignored for FV.
+
+   =============  =========================  =============
+   **Type:** int  **Range:** :math:`\geq 0`  **Length:** 1
+   =============  =========================  =============
 
 Group /input/model/unit_XXX/particle_type_YYY
 ---------------------------------------------
@@ -25,12 +34,12 @@ Group /input/model/unit_XXX/particle_type_YYY
 ``FILM_DIFFUSION_DEP``
 
    Parameter dependence of film diffusion on the interstitial velocity.
-   Available For all 1D unit operations and bothe the FV and DG discretizations.
+   Available For all 1D unit operations and both the FV and DG discretizations.
    For the DG discretization there might be a loss of accuracy since the current implementation only supports a pointwise/"mass-lumped" evaluation.
 
-   ================  =====================================  =============
-   **Type:** string  **Range:** :math:`\texttt{POWER_LAW}`  **Length:** 1
-   ================  =====================================  =============
+   ================  ===========================================================  =============
+   **Type:** string  **Range:** :math:`\texttt{POWER_LAW}, \texttt{VAN_DEEMTER}`  **Length:** 1
+   ================  ===========================================================  =============
 
 
 **Correlations**
@@ -68,10 +77,49 @@ Here, :math:`p_{dep}` is the dependent parameter and :math:`p_{on}` is the param
 ``COL_DISPERSION_DEP_ABS``
 
    Specifies whether or not the absolute value should be computed. Optional, defaults to :math:`1`
-   
+
    =============  ===========================  =============
    **Type:** int  **Range:** :math:`\{0, 1\}`  **Length:** 1
    =============  ===========================  =============
+
+**Van Deemter**
+
+The van Deemter parameter dependence reproduces the classical van Deemter plate-height correlation :math:`H(v) = A + B / |v| + C\, |v|` and applies it to a dispersion-type parameter via the standard equilibrium-dispersive-model relation :math:`D_\mathrm{ax}(v) = H(v)\, v / 2`.
+Concretely,
+
+.. math::
+
+    \begin{aligned}
+        p_{dep} &= p_{dep} \cdot \left( A\, |p_{on}| + B + C\, p_{on}^2 \right) / 2
+    \end{aligned}
+
+Here, :math:`p_{dep}` is the dependent parameter (e.g. ``COL_DISPERSION``) and :math:`p_{on}` is the parameter it depends on (e.g. the local interstitial velocity).
+Using this dependence with the associated base parameter left at its default (dimensionless placeholder :math:`1`) directly evaluates :math:`D_\mathrm{ax}(v) = H(v)\, v / 2` for a local, velocity-dependent plate height :math:`H(v)`.
+Unlike ``POWER_LAW``, the absolute value of :math:`p_{on}` is always taken (there is no ``_ABS`` flag).
+
+``COL_DISPERSION_DEP_A``
+
+   Coefficient :math:`A` (eddy diffusion / flow-independent term) of the van Deemter parameter dependence
+
+   ================  =============================  =============
+   **Type:** double  **Range:** :math:`\mathbb{R}`  **Length:** 1
+   ================  =============================  =============
+
+``COL_DISPERSION_DEP_B``
+
+   Coefficient :math:`B` (longitudinal molecular diffusion term) of the van Deemter parameter dependence
+
+   ================  =============================  =============
+   **Type:** double  **Range:** :math:`\mathbb{R}`  **Length:** 1
+   ================  =============================  =============
+
+``COL_DISPERSION_DEP_C``
+
+   Coefficient :math:`C` (mass transfer resistance term) of the van Deemter parameter dependence
+
+   ================  =============================  =============
+   **Type:** double  **Range:** :math:`\mathbb{R}`  **Length:** 1
+   ================  =============================  =============
 
 
 Parameter-State Dependencies

--- a/src/libcadet/CMakeLists.txt
+++ b/src/libcadet/CMakeLists.txt
@@ -172,6 +172,7 @@ set(LIBCADET_SOURCES
 	${CMAKE_SOURCE_DIR}/src/libcadet/model/paramdep/DummyParameterDependence.cpp
 	${CMAKE_SOURCE_DIR}/src/libcadet/model/paramdep/IdentityParameterDependence.cpp
 	${CMAKE_SOURCE_DIR}/src/libcadet/model/paramdep/PowerLawParameterDependence.cpp
+	${CMAKE_SOURCE_DIR}/src/libcadet/model/paramdep/VanDeemterParameterDependence.cpp
 )
 
 # LIBCADET_NONLINALG_SOURCES holds all source files for LIBCADET_NONLINALG target

--- a/src/libcadet/ParameterDependenceFactory.cpp
+++ b/src/libcadet/ParameterDependenceFactory.cpp
@@ -25,6 +25,7 @@ namespace cadet
 			void registerIdentityParamDependence(std::unordered_map<std::string, std::function<model::IParameterStateDependence*()>>& paramDeps);
 			void registerIdentityParamDependence(std::unordered_map<std::string, std::function<model::IParameterParameterDependence*()>>& paramDeps);
 			void registerPowerLawParamDependence(std::unordered_map<std::string, std::function<model::IParameterParameterDependence*()>>& paramDeps);
+			void registerVanDeemterParamDependence(std::unordered_map<std::string, std::function<model::IParameterParameterDependence*()>>& paramDeps);
 		}
 	}
 
@@ -39,6 +40,7 @@ namespace cadet
 		model::paramdep::registerDummyParamDependence(_paramParamDeps);
 		model::paramdep::registerIdentityParamDependence(_paramParamDeps);
 		model::paramdep::registerPowerLawParamDependence(_paramParamDeps);
+		model::paramdep::registerVanDeemterParamDependence(_paramParamDeps);
 	}
 
 	ParameterDependenceFactory::~ParameterDependenceFactory() { }

--- a/src/libcadet/model/paramdep/VanDeemterParameterDependence.cpp
+++ b/src/libcadet/model/paramdep/VanDeemterParameterDependence.cpp
@@ -1,0 +1,104 @@
+// =============================================================================
+//  CADET
+//
+//  Copyright © 2008-present: The CADET-Core Authors
+//            Please see the AUTHORS.md file.
+//
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the GNU Public License v3.0 (or, at
+//  your option, any later version) which accompanies this distribution, and
+//  is available at http://www.gnu.org/licenses/gpl.html
+// =============================================================================
+
+#include "model/paramdep/ParameterDependenceBase.hpp"
+#include "SimulationTypes.hpp"
+#include "cadet/ParameterId.hpp"
+
+#include <cmath>
+
+namespace cadet
+{
+namespace model
+{
+
+/**
+ * @brief Defines a van Deemter parameter parameter dependence
+ * @details Reproduces a classical van Deemter plate-height correlation,
+ *   H(v) = A + B / |v| + C * |v|,
+ *   applied here to a dispersion coefficient (e.g. COL_DISPERSION) so that
+ *   the *effective* dependence factor returned is
+ *   p_new(p, v) = p * H(v) * |v| / 2 = p * (A * |v| + B + C * v^2) / 2,
+ *   i.e., with the associated base parameter p left at 1 (the default,
+ *   dimensionless placeholder), this directly evaluates the standard
+ *   equilibrium-dispersive-model relation D_ax(v) = H(v) * v / 2 for a
+ *   local, velocity-dependent (van Deemter) plate height H(v) -- allowing
+ *   a genuine A + B/v + C*v flow-rate dependence (as opposed to the single
+ *   monomial v^k achievable with POWER_LAW) to be used with
+ *   COL_DISPERSION_DEP for velocity-varying bulk transport models
+ *   (e.g. GEOMETRY=AXIAL_FLOW_FRUSTUM/RADIAL_FLOW_CYLINDER_SHELL).
+ *   A, B, and C are (meta-)parameters.
+ */
+class VanDeemterParameterParameterDependence : public ParameterParameterDependenceBase
+{
+public:
+
+	VanDeemterParameterParameterDependence() { }
+	virtual ~VanDeemterParameterParameterDependence() CADET_NOEXCEPT { }
+
+	static const char* identifier() { return "VAN_DEEMTER"; }
+	virtual const char* name() const CADET_NOEXCEPT { return VanDeemterParameterParameterDependence::identifier(); }
+
+	CADET_PARAMETERPARAMETERDEPENDENCE_BOILERPLATE
+
+protected:
+	active _a;
+	active _b;
+	active _c;
+
+	virtual bool configureImpl(IParameterProvider& paramProvider, UnitOpIdx unitOpIdx, ParticleTypeIdx parTypeIdx, BoundStateIdx bndIdx, const std::string& name)
+	{
+		const std::string aName = name + "_A";
+		const std::string bName = name + "_B";
+		const std::string cName = name + "_C";
+
+		_a = paramProvider.getDouble(aName);
+		_b = paramProvider.getDouble(bName);
+		_c = paramProvider.getDouble(cName);
+
+		_parameters[makeParamId(hashStringRuntime(aName), unitOpIdx, CompIndep, parTypeIdx, bndIdx, ReactionIndep, SectionIndep)] = &_a;
+		_parameters[makeParamId(hashStringRuntime(bName), unitOpIdx, CompIndep, parTypeIdx, bndIdx, ReactionIndep, SectionIndep)] = &_b;
+		_parameters[makeParamId(hashStringRuntime(cName), unitOpIdx, CompIndep, parTypeIdx, bndIdx, ReactionIndep, SectionIndep)] = &_c;
+
+		return true;
+	}
+
+	template <typename ParamType>
+	ParamType getValueImpl(const ColumnPosition& colPos, int comp, int parType, int bnd) const
+	{
+		return 0.0;
+	}
+
+	template <typename ParamType>
+	ParamType getValueImpl(const ColumnPosition& colPos, int comp, int parType, int bnd, ParamType val) const
+	{
+		using std::abs;
+
+		const ParamType v = abs(val);
+		// H(v) * v / 2 = (A * v + B + C * v^2) / 2
+		return (static_cast<ParamType>(_a) * v + static_cast<ParamType>(_b) + static_cast<ParamType>(_c) * v * v) * ParamType(0.5);
+	}
+
+};
+
+
+namespace paramdep
+{
+	void registerVanDeemterParamDependence(std::unordered_map<std::string, std::function<model::IParameterParameterDependence*()>>& paramDeps)
+	{
+		paramDeps[VanDeemterParameterParameterDependence::identifier()] = []() { return new VanDeemterParameterParameterDependence(); };
+	}
+}  // namespace paramdep
+
+}  // namespace model
+
+}  // namespace cadet

--- a/test/ColumnModel1D.cpp
+++ b/test/ColumnModel1D.cpp
@@ -842,6 +842,36 @@ TEST_CASE("Column_1D as LRMP film diffusion par dep Jacobian analytic vs AD DG",
 	cadet::test::column::testJacobianADVariableFilmDiff("COLUMN_MODEL_1D_LRMP", "DG", false);
 }
 
+TEST_CASE("Column_1D as frustum GRM col dispersion van Deemter par dep Jacobian analytic vs AD FV", "[FrustumColumn1D],[FV],[UnitOp],[Jacobian],[AD],[ParameterDependence],[CI]")
+{
+	cadet::test::column::testJacobianADVariableColDispersionVanDeemter("FRUSTUM_COLUMN_MODEL_1D_GRM", "FV", false);
+}
+
+TEST_CASE("Column_1D as frustum GRM col dispersion van Deemter par dep Jacobian analytic vs AD DG", "[FrustumColumn1D],[DG],[DG1D],[UnitOp],[Jacobian],[AD],[ParameterDependence],[CI]")
+{
+	cadet::test::column::testJacobianADVariableColDispersionVanDeemter("FRUSTUM_COLUMN_MODEL_1D_GRM", "DG", false);
+}
+
+TEST_CASE("Column_1D as frustum LRMP col dispersion van Deemter par dep Jacobian analytic vs AD FV", "[FrustumColumn1D],[FV],[UnitOp],[Jacobian],[AD],[ParameterDependence],[CI]")
+{
+	cadet::test::column::testJacobianADVariableColDispersionVanDeemter("FRUSTUM_COLUMN_MODEL_1D_LRMP", "FV", false);
+}
+
+TEST_CASE("Column_1D as frustum LRMP col dispersion van Deemter par dep Jacobian analytic vs AD DG", "[FrustumColumn1D],[DG],[DG1D],[UnitOp],[Jacobian],[AD],[ParameterDependence],[CI]")
+{
+	cadet::test::column::testJacobianADVariableColDispersionVanDeemter("FRUSTUM_COLUMN_MODEL_1D_LRMP", "DG", false);
+}
+
+TEST_CASE("Column_1D as radial GRM col dispersion van Deemter par dep Jacobian analytic vs AD FV", "[RadialColumn1D],[FV],[UnitOp],[Jacobian],[AD],[ParameterDependence],[CI]")
+{
+	cadet::test::column::testJacobianADVariableColDispersionVanDeemter("RADIAL_COLUMN_MODEL_1D_GRM", "FV", false);
+}
+
+TEST_CASE("Column_1D as radial GRM col dispersion van Deemter par dep Jacobian analytic vs AD DG", "[RadialColumn1D],[DG],[DG1D],[UnitOp],[Jacobian],[AD],[ParameterDependence],[CI]")
+{
+	cadet::test::column::testJacobianADVariableColDispersionVanDeemter("RADIAL_COLUMN_MODEL_1D_GRM", "DG", false);
+}
+
 TEST_CASE("Column_1D as GRM dynamic reactions Jacobian vs AD modified particle", "[AxialColumn1D],[DG],[DG1D],[Jacobian],[AD],[ReactionModel],[CI]")
 {
 	cadet::test::reaction::testUnitJacobianDynamicReactionsAD("COLUMN_MODEL_1D_GRM", "DG", false, true, true, 1e-14);

--- a/test/ColumnTests.cpp
+++ b/test/ColumnTests.cpp
@@ -1273,6 +1273,35 @@ namespace column
 		testJacobianAD(jpp, 1e-14);
 	}
 
+	void testJacobianADVariableColDispersionVanDeemter(const std::string& uoType, const std::string& spatialMethod, bool dynamicBinding)
+	{
+		cadet::JsonParameterProvider jpp = createColumnWithTwoCompLinearBinding(uoType, spatialMethod);
+		setBindingMode(jpp, dynamicBinding);
+		{
+			auto ms = util::makeOptionalGroupScope(jpp, "model");
+			auto us = util::makeOptionalGroupScope(jpp, "unit_000");
+
+			// A, B, C chosen to give an O(1) dependence factor H(v)*v/2 at this test
+			// model's representative velocity scale (~5.75e-4, see testJacobianADVariableFilmDiff
+			// above), so the resulting effective dispersion stays well-conditioned; the exact
+			// values are otherwise arbitrary for a Jacobian-correctness check.
+			jpp.set("COL_DISPERSION_DEP", "VAN_DEEMTER");
+			jpp.set("COL_DISPERSION_DEP_A", 100.0);
+			jpp.set("COL_DISPERSION_DEP_B", 0.5);
+			jpp.set("COL_DISPERSION_DEP_C", 100000.0);
+
+			if (spatialMethod == "DG")
+			{
+				// Required quadrature degree for the variable-dispersion integral whenever
+				// COL_DISPERSION_DEP is set with DG bulk discretization; matches the POLYDEG
+				// set for the bulk discretization by createColumnWithTwoCompLinearJson() above.
+				jpp.set("DISPERSION_SPATIAL_DEPENDENCE_POLYDEG", 3);
+			}
+		}
+
+		testJacobianAD(jpp, 1e-14);
+	}
+
 	void testArrowHeadJacobianFD(cadet::JsonParameterProvider& jpp, double h, double absTol, double relTol)
 	{
 		cadet::IModelBuilder* const mb = cadet::createModelBuilder();

--- a/test/ColumnTests.hpp
+++ b/test/ColumnTests.hpp
@@ -616,6 +616,14 @@ namespace column
 	 */
 	void testJacobianADVariableParSurfDiff(const std::string& uoType, const std::string& spatialMethod, bool dynamicBinding);
 	void testJacobianADVariableFilmDiff(const std::string& uoType, const std::string& spatialMethod, bool dynamicBinding);
+	/**
+	 * @brief Checks the full Jacobian against AD in case of a VAN_DEEMTER-dependent column dispersion coefficient
+	 * @details Checks the analytic Jacobian against the AD Jacobian for COL_DISPERSION_DEP='VAN_DEEMTER'.
+	 * @param [in] uoType Unit operation type
+	 * @param [in] spatialMethod Bulk spatial discretization ("FV" or "DG")
+	 * @param [in] dynamicBinding Determines whether dynamic binding is used
+	 */
+	void testJacobianADVariableColDispersionVanDeemter(const std::string& uoType, const std::string& spatialMethod, bool dynamicBinding);
 
 	/**
 	 * @brief Checks the full Jacobian against AD and FD pattern switching from forward to backward flow and back


### PR DESCRIPTION
The van Deemter parameter dependence reproduces the classical van Deemter plate-height correlation $H(v) = A + B / |v| + C |v|$ and applies it to a dispersion-type parameter via the standard equilibrium-dispersive-model relation $D_\mathrm{ax}(v) = H(v) v / 2$. Concretely,

$$p_{dep} = p_{dep} \cdot \left( A |p_{on}| + B + C p_{on}^2 \right) / 2$$.

This parameter dependence is used to reproduce a conical (frustum) column chromatogram from [Gritti et al., 2019](https://doi.org/10.1016/j.chroma.2019.01.055) where a van Deemter relation for plate height was reported, and without considering that in the model, I could not get the right chromatogram
<img width="543" height="543" alt="image" src="https://github.com/user-attachments/assets/2b6c3cde-fdf3-45dc-9928-a009e4b81dfe" />

