### PR TITLE
Add `FILM_DIFFUSION_DEP` support for generalized units

### DIFF
--- a/doc/interface/parameter_dependencies_config.rst
+++ b/doc/interface/parameter_dependencies_config.rst
@@ -13,8 +13,8 @@ Group /input/model/unit_XXX
 
 ``COL_DISPERSION_DEP``
 
-   Parameter dependence of column dispersion on the interstitial velocity. Available for the arrow-head optimzed (see `FV_ARROW_HEAD_OPTIMIZATION`) LRM, LRMP and GRM units.
-   
+   Parameter dependence of column dispersion on the interstitial velocity. Available for all 1D units and both the FV and DG discretization.
+
    ================  =====================================  =============
    **Type:** string  **Range:** :math:`\texttt{POWER_LAW}`  **Length:** 1
    ================  =====================================  =============
@@ -24,8 +24,10 @@ Group /input/model/unit_XXX/particle_type_YYY
 
 ``FILM_DIFFUSION_DEP``
 
-   Parameter dependence of film diffusion on the interstitial velocity. Available for the arrow-head optimzed (see `FV_ARROW_HEAD_OPTIMIZATION`) LRMP unit.
-   
+   Parameter dependence of film diffusion on the interstitial velocity.
+   Available For all 1D unit operations and bothe the FV and DG discretizations.
+   For the DG discretization there might be a loss of accuracy since the current implementation only supports a pointwise/"mass-lumped" evaluation.
+
    ================  =====================================  =============
    **Type:** string  **Range:** :math:`\texttt{POWER_LAW}`  **Length:** 1
    ================  =====================================  =============

--- a/src/libcadet/model/ColumnModel1D.cpp
+++ b/src/libcadet/model/ColumnModel1D.cpp
@@ -748,9 +748,13 @@ void ColumnModel1D<ConvDispOperator>::extractJacobianFromAD(active const* const 
 
 	/* Add analytically derived flux entries (only those that are part of the outlier bands) */
 	// todo extract these entries instead of analytical calculation?
+	std::vector<active> pointVelocities(_disc.nPoints);
+	for (unsigned int pt = 0; pt < _disc.nPoints; ++pt)
+		pointVelocities[pt] = _convDispOp.currentVelocity(_convDispOp.relativeCoordinate(pt));
+
 	for (unsigned int parType = 0; parType < _disc.nParType; parType++)
 	{
-		_particles[parType]->calcFilmDiffJacobian(_disc.curSection, idxr.offsetCp(ParticleTypeIndex{static_cast<unsigned int>(parType)}), idxr.offsetC(), _disc.nPoints, _disc.nParType, static_cast<double>(_colPorosity), &_parTypeVolFrac[0], _globalJac, true);
+		_particles[parType]->calcFilmDiffJacobian(_disc.curSection, idxr.offsetCp(ParticleTypeIndex{static_cast<unsigned int>(parType)}), idxr.offsetC(), _disc.nPoints, _disc.nParType, static_cast<double>(_colPorosity), &_parTypeVolFrac[0], &pointVelocities[0], _globalJac, true);
 	}
 
 	const auto& cm = _reaction.conservedMoieties("liquid");
@@ -1053,11 +1057,13 @@ int ColumnModel1D<ConvDispOperator>::residualImpl(double t, unsigned int secIdx,
 				);
 			}
 
+			const active pointVelocity = _convDispOp.currentVelocity(_convDispOp.relativeCoordinate(colNode));
 			model::columnPackingParameters packing
 			{
 				_parTypeVolFrac[parType + _disc.nParType * colNode],
 				_colPorosity,
-				ColumnPosition{ _convDispOp.relativeCoordinate(colNode), 0.0, 0.0 }
+				ColumnPosition{ _convDispOp.relativeCoordinate(colNode), 0.0, 0.0 },
+				pointVelocity
 			};
 
 

--- a/src/libcadet/model/ColumnModel1D.hpp
+++ b/src/libcadet/model/ColumnModel1D.hpp
@@ -606,9 +606,13 @@ protected:
 			}
 		}
 
+		std::vector<active> pointVelocities(_disc.nPoints);
+		for (unsigned int pt = 0; pt < _disc.nPoints; ++pt)
+			pointVelocities[pt] = _convDispOp.currentVelocity(_convDispOp.relativeCoordinate(pt));
+
 		for (unsigned int parType = 0; parType < _disc.nParType; parType++)
 		{
-			_particles[parType]->calcFilmDiffJacobian(secIdx, idxr.offsetCp(ParticleTypeIndex{ static_cast<unsigned int>(parType) }), idxr.offsetC(), _disc.nPoints, _disc.nParType, static_cast<double>(_colPorosity), &_parTypeVolFrac[0], _globalJac);
+			_particles[parType]->calcFilmDiffJacobian(secIdx, idxr.offsetCp(ParticleTypeIndex{ static_cast<unsigned int>(parType) }), idxr.offsetC(), _disc.nPoints, _disc.nParType, static_cast<double>(_colPorosity), &_parTypeVolFrac[0], &pointVelocities[0], _globalJac);
 		}
 
 		return _globalJac.isCompressed(); // check if the jacobian estimation fits the pattern

--- a/src/libcadet/model/ColumnModel2D.cpp
+++ b/src/libcadet/model/ColumnModel2D.cpp
@@ -1119,7 +1119,8 @@ int ColumnModel2D::residualImpl(double t, unsigned int secIdx, StateType const* 
 			{
 				_parTypeVolFrac[colPoint * _disc.nParType + parType],
 				_convDispOp.columnPorosity(radElem),
-				ColumnPosition{ _convDispOp.relativeAxialCoordinate(axPoint), _convDispOp.relativeRadialCoordinate(radPoint), 0.0 }
+				ColumnPosition{ _convDispOp.relativeAxialCoordinate(axPoint), _convDispOp.relativeRadialCoordinate(radPoint), 0.0 },
+				_convDispOp.currentVelocity(radElem)
 			};
 
 			_particles[parType]->residual(t, secIdx,

--- a/src/libcadet/model/ColumnModel2D.hpp
+++ b/src/libcadet/model/ColumnModel2D.hpp
@@ -226,7 +226,8 @@ protected:
 				for (unsigned int r = 0; r < _disc.radNElem; r++)
 				{
 					const unsigned int colNode = z * _disc.radNPoints + r * _disc.radNNodes;
-					_particles[parType]->calcFilmDiffJacobian(secIdx, idxr.offsetCp(ParticleTypeIndex{ static_cast<unsigned int>(parType) }, ParticleIndex{ static_cast<unsigned int>(colNode) }) - idxr.offsetC(), colNode * idxr.strideColRadialNode(), _disc.radNNodes, _disc.nParType, static_cast<double>(_convDispOp.columnPorosity(r)), &_parTypeVolFrac[colNode * _disc.nParType], _globalJac);
+					const std::vector<active> pointVelocities(_disc.radNNodes, _convDispOp.currentVelocity(r));
+					_particles[parType]->calcFilmDiffJacobian(secIdx, idxr.offsetCp(ParticleTypeIndex{ static_cast<unsigned int>(parType) }, ParticleIndex{ static_cast<unsigned int>(colNode) }) - idxr.offsetC(), colNode * idxr.strideColRadialNode(), _disc.radNNodes, _disc.nParType, static_cast<double>(_convDispOp.columnPorosity(r)), &_parTypeVolFrac[colNode * _disc.nParType], &pointVelocities[0], _globalJac);
 				}
 			}
 		}

--- a/src/libcadet/model/particle/GeneralRateParticle.cpp
+++ b/src/libcadet/model/particle/GeneralRateParticle.cpp
@@ -310,7 +310,6 @@ namespace model
 		if (wantRes)
 		{
 			// film diffusion bulk eq. term
-			active const* const filmDiff = _parDiffOp->getFilmDiffusion(secIdx);
 			const ParamType invBetaC = 1.0 / static_cast<ParamType>(packing.colPorosity) - 1.0;
 			const ParamType jacCF_val = invBetaC * static_cast<ParamType>(surfaceToVolumeRatio());
 
@@ -318,9 +317,11 @@ namespace model
 			for (unsigned int comp = 0; comp < _nComp; ++comp)
 			{
 				ParamType discretizedFilmDiffusionFactor = static_cast<ParamType>(_parDiffOp->discretizedFilmDiffusionFactor(comp));
+				// FILM_DIFFUSION_DEP evaluated pointwise at this bulk point's position/velocity
+				const ParamType filmDiff_comp = static_cast<ParamType>(_parDiffOp->modifiedFilmDiffusion(secIdx, comp, packing.colPos, packing.velocity));
 
 				// + 1/Beta^c * (surfaceToVolumeRatio^p_j) * d_j * (k_f * [c^b - c^p])
-				resBulk[comp] += discretizedFilmDiffusionFactor * static_cast<ParamType>(filmDiff[comp]) * jacCF_val * static_cast<ParamType>(packing.parTypeVolFrac) * (yBulk[comp] - yPar[(nDiscPoints() - 1) * stridePoint() + comp]);
+				resBulk[comp] += discretizedFilmDiffusionFactor * filmDiff_comp * jacCF_val * static_cast<ParamType>(packing.parTypeVolFrac) * (yBulk[comp] - yPar[(nDiscPoints() - 1) * stridePoint() + comp]);
 			}
 		}
 
@@ -339,9 +340,9 @@ namespace model
 		return _parDiffOp->calcParticleDiffJacobian(secIdx, colNode, offsetLocalCp, globalJac);
 	}
 	
-	int GeneralRateParticle::calcFilmDiffJacobian(unsigned int secIdx, const int offsetCp, const int offsetC, const int nBulkPoints, const int nParType, const double colPorosity, const active* const parTypeVolFrac, Eigen::SparseMatrix<double, RowMajor>& globalJac, bool outliersOnly)
+	int GeneralRateParticle::calcFilmDiffJacobian(unsigned int secIdx, const int offsetCp, const int offsetC, const int nBulkPoints, const int nParType, const double colPorosity, const active* const parTypeVolFrac, const active* const pointVelocity, Eigen::SparseMatrix<double, RowMajor>& globalJac, bool outliersOnly)
 	{
-		return _parDiffOp->calcFilmDiffJacobian(secIdx, offsetCp, offsetC, nBulkPoints, nParType, colPorosity, parTypeVolFrac, globalJac, outliersOnly);
+		return _parDiffOp->calcFilmDiffJacobian(secIdx, offsetCp, offsetC, nBulkPoints, nParType, colPorosity, parTypeVolFrac, pointVelocity, globalJac, outliersOnly);
 	}
 
 	bool GeneralRateParticle::setParameter(const ParameterId& pId, double value)

--- a/src/libcadet/model/particle/GeneralRateParticle.hpp
+++ b/src/libcadet/model/particle/GeneralRateParticle.hpp
@@ -126,7 +126,7 @@ namespace parts
 
 		unsigned int jacobianNNZperParticle() const override;
 		int calcParticleDiffJacobian(const int secIdx, const int colNode, const int offsetLocalCp, Eigen::SparseMatrix<double, RowMajor>& globalJac) override;
-		int calcFilmDiffJacobian(unsigned int secIdx, const int offsetCp, const int offsetC, const int nBulkPoints, const int nParType, const double colPorosity, const active* const parTypeVolFrac, Eigen::SparseMatrix<double, RowMajor>& globalJac, bool crossDepsOnly = false) override;
+		int calcFilmDiffJacobian(unsigned int secIdx, const int offsetCp, const int offsetC, const int nBulkPoints, const int nParType, const double colPorosity, const active* const parTypeVolFrac, const active* const pointVelocity, Eigen::SparseMatrix<double, RowMajor>& globalJac, bool crossDepsOnly = false) override;
 
 		bool setParameter(const ParameterId& pId, double value) override;
 		bool setParameter(const ParameterId& pId, int value) override;

--- a/src/libcadet/model/particle/HomogeneousParticle.cpp
+++ b/src/libcadet/model/particle/HomogeneousParticle.cpp
@@ -43,13 +43,14 @@ namespace model
 	/**
 	 * @brief Creates a HomogeneousParticle
 	 */
-	HomogeneousParticle::HomogeneousParticle() : _boundOffset(nullptr)
+	HomogeneousParticle::HomogeneousParticle() : _boundOffset(nullptr), _filmDiffusionDep(nullptr)
 	{
 	}
 
 	HomogeneousParticle::~HomogeneousParticle() CADET_NOEXCEPT
 	{
 		delete[] _boundOffset;
+		delete _filmDiffusionDep;
 	}
 
 	bool HomogeneousParticle::configureModelDiscretization(IParameterProvider& paramProvider, const IConfigHelper& helper, const int nComp, const int parTypeIdx, const int nParType, const int strideBulkComp)
@@ -89,6 +90,19 @@ namespace model
 		if (!_nBound)
 			_nBound = std::make_shared<unsigned int[]>(_nComp);
 		std::copy_n(nBound.begin(), _nComp, _nBound.get());
+
+		// ==== Construct film diffusion parameter dependence (e.g. on velocity), mirrors COL_DISPERSION_DEP
+		delete _filmDiffusionDep;
+		_filmDiffusionDep = nullptr;
+		_filmDiffusionDepTypeDep = true;
+		if (paramProvider.exists("FILM_DIFFUSION_DEP"))
+		{
+			const std::string paramDepName = paramProvider.getString("FILM_DIFFUSION_DEP");
+			_filmDiffusionDep = helper.createParameterParameterDependence(paramDepName);
+			if (!_filmDiffusionDep)
+				throw InvalidParameterException("Unknown parameter dependence " + paramDepName + " in FILM_DIFFUSION_DEP for particle type " + std::to_string(_parTypeIdx));
+			_filmDiffusionDep->configureModelDiscretization(paramProvider);
+		}
 
 		// Precompute offsets and total number of bound states (DOFs in solid phase)
 		if (!_boundOffset)
@@ -229,6 +243,15 @@ namespace model
 		bool filmDiffParTypeDep = paramProvider.exists("FILM_DIFFUSION_PARTYPE_DEPENDENT") ? paramProvider.getBool("FILM_DIFFUSION_PARTYPE_DEPENDENT") : true;
 		_filmDiffusionMode = readAndRegisterMultiplexCompSecParam(paramProvider, parameters, _filmDiffusion, "FILM_DIFFUSION", _nComp, _parTypeIdx, filmDiffParTypeDep, unitOpIdx);
 
+		bool filmDiffDepConfSuccess = true;
+		if (_filmDiffusionDep)
+		{
+			_filmDiffusionDepTypeDep = paramProvider.exists("FILM_DIFFUSION_DEP_PARTYPE_DEPENDENT") ? paramProvider.getBool("FILM_DIFFUSION_DEP_PARTYPE_DEPENDENT") : true;
+			filmDiffDepConfSuccess = _filmDiffusionDep->configure(paramProvider, unitOpIdx, _filmDiffusionDepTypeDep ? static_cast<ParticleTypeIdx>(_parTypeIdx) : ParTypeIndep, BoundStateIndep, "FILM_DIFFUSION_DEP");
+			if (!filmDiffDepConfSuccess)
+				throw InvalidParameterException("Failed to configure film diffusion parameter dependency (FILM_DIFFUSION_DEP) for particle type " + std::to_string(_parTypeIdx));
+		}
+
 		if (paramProvider.exists("PORE_ACCESSIBILITY"))
 		{
 			bool poreAccessParTypeDep = paramProvider.exists("PORE_ACCESSIBILITY_PARTYPE_DEPENDENT") ? paramProvider.getBool("PORE_ACCESSIBILITY_PARTYPE_DEPENDENT") : true;
@@ -301,7 +324,7 @@ namespace model
 
 		paramProvider.popScope(); // particle_type_{:03}
 
-		return bindingConfSuccess && dynReactionConfSuccess;
+		return bindingConfSuccess && dynReactionConfSuccess && filmDiffDepConfSuccess;
 	}
 
 	bool HomogeneousParticle::notifyDiscontinuousSectionTransition(double t, unsigned int secIdx)
@@ -396,14 +419,15 @@ namespace model
 		// Film diffusion flux
 		if (wantRes)
 		{
-			const active* const filmDiff = getSectionDependentSlice(_filmDiffusion, _nComp, secIdx);
-
 			for (unsigned int comp = 0; comp < _nComp; ++comp)
 			{
+				// FILM_DIFFUSION_DEP evaluated pointwise at this bulk point's position/velocity
+				const ParamType filmDiff_comp = static_cast<ParamType>(modifiedFilmDiffusion(secIdx, comp, packing.colPos, packing.velocity));
+
 				// flux into particle
-				resPar[comp] += jacPF_val / static_cast<ParamType>(_poreAccessFactor[comp]) * static_cast<ParamType>(filmDiff[comp]) * (yBulk[comp * _strideBulkComp] - yPar[comp]);
+				resPar[comp] += jacPF_val / static_cast<ParamType>(_poreAccessFactor[comp]) * filmDiff_comp * (yBulk[comp * _strideBulkComp] - yPar[comp]);
 				// flux into bulk
-				resBulk[comp] += jacCF_val * static_cast<ParamType>(filmDiff[comp]) * static_cast<ParamType>(packing.parTypeVolFrac) * (yBulk[comp] - yPar[comp]);
+				resBulk[comp] += jacCF_val * filmDiff_comp * static_cast<ParamType>(packing.parTypeVolFrac) * (yBulk[comp] - yPar[comp]);
 			}
 		}
 
@@ -438,7 +462,7 @@ namespace model
 		return 1;
 	}
 	
-	int HomogeneousParticle::calcFilmDiffJacobian(unsigned int secIdx, const int offsetCp, const int offsetC, const int nBulkPoints, const int nParType, const double colPorosity, const active* const parTypeVolFrac, Eigen::SparseMatrix<double, RowMajor>& globalJac, bool crossDepsOnly)
+	int HomogeneousParticle::calcFilmDiffJacobian(unsigned int secIdx, const int offsetCp, const int offsetC, const int nBulkPoints, const int nParType, const double colPorosity, const active* const parTypeVolFrac, const active* const pointVelocity, Eigen::SparseMatrix<double, RowMajor>& globalJac, bool crossDepsOnly)
 	{
 		const double invBetaC = 1.0 / static_cast<double>(colPorosity) - 1.0;
 
@@ -448,7 +472,6 @@ namespace model
 		// Ordering of diffusion:
 		// sec0type0comp0, sec0type0comp1, sec0type0comp2, sec0type1comp0, sec0type1comp1, sec0type1comp2,
 		// sec1type0comp0, sec1type0comp1, sec1type0comp2, sec1type1comp0, sec1type1comp1, sec1type1comp2, ...
-		active const* const filmDiff = getSectionDependentSlice(_filmDiffusion, _nComp, secIdx);
 		active const* const poreAccFactor = _poreAccessFactor.data();
 
 		linalg::BandedEigenSparseRowIterator jacC(globalJac, offsetC);
@@ -456,27 +479,31 @@ namespace model
 
 		for (unsigned int colNode = 0; colNode < nBulkPoints; colNode++, jacP += _strideBound)
 		{
+			// FILM_DIFFUSION_DEP is evaluated pointwise at this bulk point's local velocity
+			// (mass-lumped, same fidelity as FV's own midpoint-rule approximation of this term).
+			// Position is a no-op for the only supported dependency (POWER_LAW), which only uses velocity.
 			for (unsigned int comp = 0; comp < _nComp; comp++, ++jacC, ++jacP) {
+				const double filmDiff_comp = static_cast<double>(modifiedFilmDiffusion(secIdx, comp, ColumnPosition{ 0.0, 0.0, 0.0 }, pointVelocity[colNode]));
 
 				// add Cl on Cl entries (added since already set in bulk jacobian)
 				// row: already at bulk phase. already at current node and component.
 				// col: already at bulk phase. already at current node and component.
 				if (!crossDepsOnly)
-					jacC[0] += jacCF_val * static_cast<double>(filmDiff[comp]) * static_cast<double>(parTypeVolFrac[_parTypeIdx + nParType * colNode]);
+					jacC[0] += jacCF_val * filmDiff_comp * static_cast<double>(parTypeVolFrac[_parTypeIdx + nParType * colNode]);
 				// add Cl on Cp entries
 				// row: already at bulk phase. already at current node and component.
 				// col: jump to particle phase
-				jacC[jacP.row() - jacC.row()] = -jacCF_val * static_cast<double>(filmDiff[comp]) * static_cast<double>(parTypeVolFrac[_parTypeIdx + nParType * colNode]);
+				jacC[jacP.row() - jacC.row()] = -jacCF_val * filmDiff_comp * static_cast<double>(parTypeVolFrac[_parTypeIdx + nParType * colNode]);
 
 				// add Cp on Cp entries
 				// row: already at particle. already at current node and liquid state.
 				// col: already at particle. already at current node and liquid state.
 				if (!crossDepsOnly)
-					jacP[0] = -jacPF_val / static_cast<double>(poreAccFactor[comp]) * static_cast<double>(filmDiff[comp]);
+					jacP[0] = -jacPF_val / static_cast<double>(poreAccFactor[comp]) * filmDiff_comp;
 				// add Cp on Cl entries
 				// row: already at particle. already at current node and liquid state.
 				// col: go to flux of current parType and adjust for offsetC. jump over previous colNodes and add component offset
-				jacP[jacC.row() - jacP.row()] = jacPF_val / static_cast<double>(poreAccFactor[comp]) * static_cast<double>(filmDiff[comp]);
+				jacP[jacC.row() - jacP.row()] = jacPF_val / static_cast<double>(poreAccFactor[comp]) * filmDiff_comp;
 			}
 		}
 
@@ -494,16 +521,34 @@ namespace model
 		if (singleTypeMultiplexCompTypeSecParameterValue(pId, hashString("FILM_DIFFUSION"), _filmDiffusionMode, _filmDiffusion, _nComp, _parTypeIdx, value, nullptr))
 			return true;
 
+		if ((!_filmDiffusionDepTypeDep || pId.particleType == _parTypeIdx) && _filmDiffusionDep && _filmDiffusionDep->hasParameter(pId))
+		{
+			_filmDiffusionDep->setParameter(pId, value);
+			return true;
+		}
+
 		return false;
 	}
 
 	bool HomogeneousParticle::setParameter(const ParameterId& pId, int value)
 	{
+		if ((!_filmDiffusionDepTypeDep || pId.particleType == _parTypeIdx) && _filmDiffusionDep && _filmDiffusionDep->hasParameter(pId))
+		{
+			_filmDiffusionDep->setParameter(pId, value);
+			return true;
+		}
+
 		return false;
 	}
 
 	bool HomogeneousParticle::setParameter(const ParameterId& pId, bool value)
 	{
+		if ((!_filmDiffusionDepTypeDep || pId.particleType == _parTypeIdx) && _filmDiffusionDep && _filmDiffusionDep->hasParameter(pId))
+		{
+			_filmDiffusionDep->setParameter(pId, value);
+			return true;
+		}
+
 		return false;
 	}
 
@@ -520,6 +565,12 @@ namespace model
 
 		if (singleTypeMultiplexCompTypeSecParameterValue(pId, hashString("FILM_DIFFUSION"), _filmDiffusionMode, _filmDiffusion, _nComp, _parTypeIdx, value, &sensParams))
 			return true;
+
+		if ((!_filmDiffusionDepTypeDep || pId.particleType == _parTypeIdx) && _filmDiffusionDep)
+		{
+			active* const param = _filmDiffusionDep->getParameter(pId);
+			if (param) { param->setValue(value); return true; }
+		}
 
 		return false;
 	}
@@ -548,6 +599,17 @@ namespace model
 		{
 			LOG(Debug) << "Found parameter " << pId << ": Dir " << adDirection << " is set to " << adValue;
 			return true;
+		}
+
+		if ((!_filmDiffusionDepTypeDep || pId.particleType == _parTypeIdx) && _filmDiffusionDep)
+		{
+			active* const param = _filmDiffusionDep->getParameter(pId);
+			if (param)
+			{
+				LOG(Debug) << "Found parameter " << pId << " in film diffusion parameter dependence: Dir " << adDirection << " is set to " << adValue;
+				param->setADValue(adDirection, adValue);
+				return true;
+			}
 		}
 
 		return false;

--- a/src/libcadet/model/particle/HomogeneousParticle.cpp
+++ b/src/libcadet/model/particle/HomogeneousParticle.cpp
@@ -43,7 +43,7 @@ namespace model
 	/**
 	 * @brief Creates a HomogeneousParticle
 	 */
-	HomogeneousParticle::HomogeneousParticle() : _boundOffset(nullptr), _filmDiffusionDep(nullptr)
+	HomogeneousParticle::HomogeneousParticle() : _filmDiffusionDep(nullptr), _boundOffset(nullptr)
 	{
 	}
 

--- a/src/libcadet/model/particle/HomogeneousParticle.hpp
+++ b/src/libcadet/model/particle/HomogeneousParticle.hpp
@@ -30,6 +30,7 @@
 #include "linalg/BandedEigenSparseRowIterator.hpp"
 #include "model/parts/DGToolbox.hpp"
 #include "model/ParameterMultiplexing.hpp"
+#include "model/ParameterDependence.hpp"
 
 #include "LoggingUtils.hpp"
 #include "Logging.hpp"
@@ -103,6 +104,20 @@ namespace parts
 		inline const active& getPorosity() const CADET_NOEXCEPT  override { return _parPorosity; }
 		inline const active* getPoreAccessFactor() const CADET_NOEXCEPT  override { return &_poreAccessFactor[0]; }
 		inline const active* getFilmDiffusion(const unsigned int secIdx) const CADET_NOEXCEPT { return getSectionDependentSlice(_filmDiffusion, _nComp, secIdx); }
+		/**
+		 * @brief Returns the film diffusion coefficient for a given component, position, and (velocity-dependent) parameter dependence
+		 * @details Evaluates FILM_DIFFUSION_DEP (defaults to CONSTANT_ONE, i.e. no dependence) pointwise at the given
+		 *          normalized column position and interstitial velocity, mirroring ParticleDiffusionOperatorBase's
+		 *          identically named helper used by GeneralRateParticle.
+		 */
+		template <typename ParamType>
+		active modifiedFilmDiffusion(unsigned int secIdx, unsigned int comp, const ColumnPosition& colPos, const ParamType& velocity) const
+		{
+			const active kf = getFilmDiffusion(secIdx)[comp];
+			if (!_filmDiffusionDep)
+				return kf;
+			return kf * _filmDiffusionDep->getValue(colPos, comp, _filmDiffusionDepTypeDep ? static_cast<int>(_parTypeIdx) : ParTypeIndep, BoundStateIndep, velocity);
+		}
 
 		inline int nDiscPoints() const CADET_NOEXCEPT  override { return 1; }
 		inline int strideParBlock() const CADET_NOEXCEPT  override { return nDiscPoints() * stridePoint(); }
@@ -113,7 +128,7 @@ namespace parts
 
 		unsigned int jacobianNNZperParticle() const override;
 		int calcParticleDiffJacobian(const int secIdx, const int colNode, const int offsetLocalCp, Eigen::SparseMatrix<double, RowMajor>& globalJac) override;
-		int calcFilmDiffJacobian(unsigned int secIdx, const int offsetCp, const int offsetC, const int nBulkPoints, const int nParType, const double colPorosity, const active* const parTypeVolFrac, Eigen::SparseMatrix<double, RowMajor>& globalJac, bool crossDepsOnly = false) override;
+		int calcFilmDiffJacobian(unsigned int secIdx, const int offsetCp, const int offsetC, const int nBulkPoints, const int nParType, const double colPorosity, const active* const parTypeVolFrac, const active* const pointVelocity, Eigen::SparseMatrix<double, RowMajor>& globalJac, bool crossDepsOnly = false) override;
 
 		bool setParameter(const ParameterId& pId, double value) override;
 		bool setParameter(const ParameterId& pId, int value) override;
@@ -135,6 +150,8 @@ namespace parts
 		/* diffusion */
 		std::vector<active> _filmDiffusion; //!< Particle diffusion coefficient \f$ D_p \f$
 		MultiplexMode _filmDiffusionMode;
+		IParameterParameterDependence* _filmDiffusionDep; //!< Parameter dependence of film diffusion on (e.g.) velocity, nullptr if FILM_DIFFUSION_DEP is not configured
+		bool _filmDiffusionDepTypeDep; //!< Determines whether parameter dependence of film diffusion is particle type dependent
 		std::vector<active> _poreAccessFactor; //!< Pore accessibility factor \f$ F_{\text{acc}} \f$
 		MultiplexMode _poreAccessFactorMode;
 

--- a/src/libcadet/model/particle/ParticleModel.hpp
+++ b/src/libcadet/model/particle/ParticleModel.hpp
@@ -118,6 +118,7 @@ namespace cadet
 			const active& parTypeVolFrac;
 			const active& colPorosity;
 			ColumnPosition colPos;
+			const active& velocity; //!< Interstitial velocity at colPos, used to evaluate FILM_DIFFUSION_DEP
 		};
 
 		/**
@@ -210,8 +211,9 @@ namespace cadet
 			 * @brief calculates the film diffusion Jacobian
 			 * @return 1 if jacobain calculation fits the predefined pattern of the jacobian, 0 if not
 			 * @param [in] parTypeVolFrac pointer to the particle type volume fractions in column-position-major order
+			 * @param [in] pointVelocity pointer to the interstitial velocity at each bulk point (size nBulkPoints), used to evaluate FILM_DIFFUSION_DEP
 			 */
-			virtual int calcFilmDiffJacobian(unsigned int secIdx, const int offsetCp, const int offsetC, const int nBulkPoints, const int nParType, const double colPorosity, const active* const parTypeVolFrac, Eigen::SparseMatrix<double, Eigen::RowMajor>& globalJac, bool crossDepsOnly = false) = 0;
+			virtual int calcFilmDiffJacobian(unsigned int secIdx, const int offsetCp, const int offsetC, const int nBulkPoints, const int nParType, const double colPorosity, const active* const parTypeVolFrac, const active* const pointVelocity, Eigen::SparseMatrix<double, Eigen::RowMajor>& globalJac, bool crossDepsOnly = false) = 0;
 
 			virtual bool setParameter(const ParameterId& pId, double value) = 0;
 			virtual bool setParameter(const ParameterId& pId, int value) = 0;

--- a/src/libcadet/model/parts/ConvectionDispersionOperatorDG.cpp
+++ b/src/libcadet/model/parts/ConvectionDispersionOperatorDG.cpp
@@ -981,6 +981,27 @@ void VariableCrossSectionConvectionDispersionOperatorBaseDG::computeOperators(co
 	}
 }
 
+active VariableCrossSectionConvectionDispersionOperatorBaseDG::currentVelocity(double pos) const CADET_NOEXCEPT
+{
+	const double pi = 3.14159265358979323846;
+	switch (_geometryType)
+	{
+	case GeometryType::RadialFlowCylinderShell:
+	{
+		const active radius = pos * (_radiusXEnd - _radiusXStart) + _radiusXStart;
+		return _QOverEps / (2.0 * pi * _colHeight * radius);
+	}
+	case GeometryType::AxialFlowFrustum:
+	{
+		const active radius = pos * (_radiusXEnd - _radiusXStart) + _radiusXStart;
+		return _QOverEps / (pi * radius * radius);
+	}
+	case GeometryType::AxialFlowCylinder:
+	default:
+		return _QOverEps / (pi * _radiusXStart * _radiusXStart);
+	}
+}
+
 void VariableCrossSectionConvectionDispersionOperatorBaseDG::computeGeometryAxial()
 {
 	_crossSectionArea.resize(_nPoints);

--- a/src/libcadet/model/parts/ConvectionDispersionOperatorDG.hpp
+++ b/src/libcadet/model/parts/ConvectionDispersionOperatorDG.hpp
@@ -894,6 +894,13 @@ namespace parts
 			return x / static_cast<double>(_bedLength);
 		}
 
+		/**
+		 * @brief Returns the interstitial velocity at a given normalized position
+		 * @param [in] pos Normalized position in [0, 1] (column inlet = 0, column outlet = 1),
+		 *             same convention as relativeCoordinate() and *ConvectionDispersionOperatorBaseFV::currentVelocity()
+		 */
+		active currentVelocity(double pos) const CADET_NOEXCEPT;
+
 		inline const double* nodes() const CADET_NOEXCEPT { return &_nodes[0]; }
 		inline const active* currentDispersion(const int secIdx) const CADET_NOEXCEPT { return getSectionDependentSlice(_colDispersion, _nComp, secIdx); }
 		inline bool dispersionCompIndep() const CADET_NOEXCEPT { return _dispersionCompIndep; }

--- a/src/libcadet/model/parts/ParticleDiffusionOperatorBase.cpp
+++ b/src/libcadet/model/parts/ParticleDiffusionOperatorBase.cpp
@@ -25,7 +25,7 @@ namespace model
 
 namespace parts
 {
-	ParticleDiffusionOperatorBase::ParticleDiffusionOperatorBase() : _parDepSurfDiffusion(nullptr), _reqBinding(nullptr), _boundOffset(nullptr)
+	ParticleDiffusionOperatorBase::ParticleDiffusionOperatorBase() : _parDepSurfDiffusion(nullptr), _filmDiffusionDep(nullptr), _reqBinding(nullptr), _boundOffset(nullptr)
 	{
 	}
 
@@ -33,6 +33,7 @@ namespace parts
 	{
 		delete[] _boundOffset;
 		delete[] _parDepSurfDiffusion;
+		delete _filmDiffusionDep;
 	}
 	
 	bool ParticleDiffusionOperatorBase::configureModelDiscretization(IParameterProvider& paramProvider, const IConfigHelper& helper, const int nComp, const int parTypeIdx, const int nParType, const int strideBulkComp)
@@ -79,6 +80,19 @@ namespace parts
 		_hasParDepSurfDiffusion = false;
 		_paramDepSurfDiffTypeDep =  false;
 		_parDepSurfDiffusion = nullptr;
+
+		// ==== Construct film diffusion parameter dependence (e.g. on velocity), mirrors COL_DISPERSION_DEP
+		delete _filmDiffusionDep;
+		_filmDiffusionDep = nullptr;
+		_filmDiffusionDepTypeDep = true;
+		if (paramProvider.exists("FILM_DIFFUSION_DEP"))
+		{
+			const std::string paramDepName = paramProvider.getString("FILM_DIFFUSION_DEP");
+			_filmDiffusionDep = helper.createParameterParameterDependence(paramDepName);
+			if (!_filmDiffusionDep)
+				throw InvalidParameterException("Unknown parameter dependence " + paramDepName + " in FILM_DIFFUSION_DEP for particle type " + std::to_string(_parTypeIdx));
+			_filmDiffusionDep->configureModelDiscretization(paramProvider);
+		}
 
 		_hasSurfaceDiffusion = paramProvider.exists("HAS_SURFACE_DIFFUSION") ? paramProvider.getBool("HAS_SURFACE_DIFFUSION") : false;
 
@@ -174,6 +188,15 @@ namespace parts
 		bool filmDiffParTypeDep = paramProvider.exists("FILM_DIFFUSION_PARTYPE_DEPENDENT") ? paramProvider.getBool("FILM_DIFFUSION_PARTYPE_DEPENDENT") : true;
 		_filmDiffusionMode = readAndRegisterMultiplexCompSecParam(paramProvider, parameters, _filmDiffusion, "FILM_DIFFUSION", _nComp, _parTypeIdx, filmDiffParTypeDep, unitOpIdx);
 
+		bool filmDiffDepConfSuccess = true;
+		if (_filmDiffusionDep)
+		{
+			_filmDiffusionDepTypeDep = paramProvider.exists("FILM_DIFFUSION_DEP_PARTYPE_DEPENDENT") ? paramProvider.getBool("FILM_DIFFUSION_DEP_PARTYPE_DEPENDENT") : true;
+			filmDiffDepConfSuccess = _filmDiffusionDep->configure(paramProvider, unitOpIdx, _filmDiffusionDepTypeDep ? static_cast<ParticleTypeIdx>(_parTypeIdx) : ParTypeIndep, BoundStateIndep, "FILM_DIFFUSION_DEP");
+			if (!filmDiffDepConfSuccess)
+				throw InvalidParameterException("Failed to configure film diffusion parameter dependency (FILM_DIFFUSION_DEP) for particle type " + std::to_string(_parTypeIdx));
+		}
+
 		if (paramProvider.exists("PORE_ACCESSIBILITY"))
 		{
 			bool poreAccessParTypeDep = paramProvider.exists("PORE_ACCESSIBILITY_PARTYPE_DEPENDENT") ? paramProvider.getBool("PORE_ACCESSIBILITY_PARTYPE_DEPENDENT") : true;
@@ -216,7 +239,7 @@ namespace parts
 			}
 		}
 
-		return parSurfDiffDepConfSuccess;
+		return parSurfDiffDepConfSuccess && filmDiffDepConfSuccess;
 	}
 
 	bool ParticleDiffusionOperatorBase::notifyDiscontinuousSectionTransition(double t, unsigned int secIdx)
@@ -246,6 +269,12 @@ namespace parts
 			if (_parDepSurfDiffusion && _parDepSurfDiffusion->setParameter(pId, value))
 				return true;
 
+		if ((!_filmDiffusionDepTypeDep || pId.particleType == _parTypeIdx) && _filmDiffusionDep && _filmDiffusionDep->hasParameter(pId))
+		{
+			_filmDiffusionDep->setParameter(pId, value);
+			return true;
+		}
+
 		return false;
 	}
 
@@ -255,6 +284,12 @@ namespace parts
 			if (_parDepSurfDiffusion && _parDepSurfDiffusion->setParameter(pId, value))
 				return true;
 
+		if ((!_filmDiffusionDepTypeDep || pId.particleType == _parTypeIdx) && _filmDiffusionDep && _filmDiffusionDep->hasParameter(pId))
+		{
+			_filmDiffusionDep->setParameter(pId, value);
+			return true;
+		}
+
 		return false;
 	}
 
@@ -263,6 +298,12 @@ namespace parts
 		if (!_paramDepSurfDiffTypeDep || pId.particleType == _parTypeIdx)
 			if (_parDepSurfDiffusion && _parDepSurfDiffusion->setParameter(pId, value))
 				return true;
+
+		if ((!_filmDiffusionDepTypeDep || pId.particleType == _parTypeIdx) && _filmDiffusionDep && _filmDiffusionDep->hasParameter(pId))
+		{
+			_filmDiffusionDep->setParameter(pId, value);
+			return true;
+		}
 
 		return false;
 	}
@@ -289,6 +330,12 @@ namespace parts
 		if (model::setSensitiveParameterValue(pId, value, sensParams, std::vector< IParameterStateDependence*>(1, _parDepSurfDiffusion), _paramDepSurfDiffTypeDep))
 			return true;
 
+		if ((!_filmDiffusionDepTypeDep || pId.particleType == _parTypeIdx) && _filmDiffusionDep)
+		{
+			active* const param = _filmDiffusionDep->getParameter(pId);
+			if (param) { param->setValue(value); return true; }
+		}
+
 		return false;
 	}
 
@@ -310,6 +357,17 @@ namespace parts
 		{
 			LOG(Debug) << "Found parameter " << pId << " in surface diffusion parameter dependence: Dir " << adDirection << " is set to " << adValue;
 			return true;
+		}
+
+		if ((!_filmDiffusionDepTypeDep || pId.particleType == _parTypeIdx) && _filmDiffusionDep)
+		{
+			active* const param = _filmDiffusionDep->getParameter(pId);
+			if (param)
+			{
+				LOG(Debug) << "Found parameter " << pId << " in film diffusion parameter dependence: Dir " << adDirection << " is set to " << adValue;
+				param->setADValue(adDirection, adValue);
+				return true;
+			}
 		}
 
 		if (singleTypeMultiplexTypeParameterAD(pId, hashString("PAR_RADIUS"), _parRadiusParTypeDep, _parRadius, _parTypeIdx, adDirection, adValue, sensParams))

--- a/src/libcadet/model/parts/ParticleDiffusionOperatorBase.cpp
+++ b/src/libcadet/model/parts/ParticleDiffusionOperatorBase.cpp
@@ -25,7 +25,7 @@ namespace model
 
 namespace parts
 {
-	ParticleDiffusionOperatorBase::ParticleDiffusionOperatorBase() : _parDepSurfDiffusion(nullptr), _filmDiffusionDep(nullptr), _reqBinding(nullptr), _boundOffset(nullptr)
+	ParticleDiffusionOperatorBase::ParticleDiffusionOperatorBase() : _filmDiffusionDep(nullptr), _parDepSurfDiffusion(nullptr), _reqBinding(nullptr), _boundOffset(nullptr)
 	{
 	}
 

--- a/src/libcadet/model/parts/ParticleDiffusionOperatorBase.hpp
+++ b/src/libcadet/model/parts/ParticleDiffusionOperatorBase.hpp
@@ -26,6 +26,7 @@
 #include "SimulationTypes.hpp"
 #include "ParamReaderHelper.hpp"
 #include "model/ParameterMultiplexing.hpp"
+#include "model/ParameterDependence.hpp"
 #include "linalg/BandedEigenSparseRowIterator.hpp"
 
 #include <unordered_map>
@@ -120,7 +121,7 @@ namespace parts
 		virtual int residual(double t, unsigned int secIdx, active const* yPar, active const* yBulk, double const* yDotPar, active* resPar, linalg::BandedEigenSparseRowIterator& jacIt, WithoutParamSensitivity) = 0;
 		virtual int residual(double t, unsigned int secIdx, active const* yPar, active const* yBulk, double const* yDotPar, active* resPar, linalg::BandedEigenSparseRowIterator& jacIt, WithParamSensitivity) = 0;
 
-		virtual int calcFilmDiffJacobian(unsigned int secIdx, const int offsetCp, const int offsetC, const int nBulkPoints, const int nParType, const double colPorosity, const active* const parTypeVolFrac, Eigen::SparseMatrix<double, Eigen::RowMajor>& globalJac, bool outliersOnly = false) = 0;
+		virtual int calcFilmDiffJacobian(unsigned int secIdx, const int offsetCp, const int offsetC, const int nBulkPoints, const int nParType, const double colPorosity, const active* const parTypeVolFrac, const active* const pointVelocity, Eigen::SparseMatrix<double, Eigen::RowMajor>& globalJac, bool outliersOnly = false) = 0;
 		virtual int calcParticleDiffJacobian(const int secIdx, const int colNode, const int offsetLocalCp, Eigen::SparseMatrix<double, Eigen::RowMajor>& globalJac) = 0;
 		
 		/**
@@ -179,6 +180,21 @@ namespace parts
 		inline const active& getPorosity() const CADET_NOEXCEPT { return _parPorosity; }
 		inline const active* getPoreAccessFactor() const CADET_NOEXCEPT { return &_poreAccessFactor[0]; }
 		inline const active* getFilmDiffusion(const unsigned int secIdx) const CADET_NOEXCEPT { return getSectionDependentSlice(_filmDiffusion, _nComp, secIdx); }
+		/**
+		 * @brief Returns the film diffusion coefficient for a given component, position, and (velocity-dependent) parameter dependence
+		 * @details Evaluates FILM_DIFFUSION_DEP (defaults to CONSTANT_ONE, i.e. no dependence) pointwise at the given
+		 *          normalized column position and interstitial velocity, mirroring how COL_DISPERSION_DEP is evaluated
+		 *          pointwise in the bulk operator (see ConvectionDispersionOperator{FV,DG}). The caller (unit operation)
+		 *          is responsible for supplying the local velocity, since only it has access to the bulk operator.
+		 */
+		template <typename ParamType>
+		active modifiedFilmDiffusion(unsigned int secIdx, unsigned int comp, const ColumnPosition& colPos, const ParamType& velocity) const
+		{
+			const active kf = getFilmDiffusion(secIdx)[comp];
+			if (!_filmDiffusionDep)
+				return kf;
+			return kf * _filmDiffusionDep->getValue(colPos, comp, _filmDiffusionDepTypeDep ? static_cast<int>(_parTypeIdx) : ParTypeIndep, BoundStateIndep, velocity);
+		}
 		inline IParameterStateDependence* getParDepSurfDiffusion() const CADET_NOEXCEPT { return _parDepSurfDiffusion; }
 		inline bool paramDepSurfDiffParTypeIndep() const CADET_NOEXCEPT { return !_paramDepSurfDiffTypeDep; }
 		inline MultiplexMode parDiffMode() const CADET_NOEXCEPT { return _parDiffusionMode; }
@@ -207,6 +223,8 @@ namespace parts
 		/* diffusion rates */
 		std::vector<active> _filmDiffusion; //!< Film diffusion coefficient \f$ k_f \f$
 		MultiplexMode _filmDiffusionMode; //!< Determines the multiplex of film diffusion, needed for sensitivitites
+		IParameterParameterDependence* _filmDiffusionDep; //!< Parameter dependence of film diffusion on (e.g.) velocity, nullptr if FILM_DIFFUSION_DEP is not configured
+		bool _filmDiffusionDepTypeDep; //!< Determines whether parameter dependence of film diffusion is particle type dependent
 		std::vector<active> _parDiffusion; //!< Particle diffusion coefficient \f$ D_p \f$
 		MultiplexMode _parDiffusionMode; //!< Determines the multiplex of particle diffusion, needed for sensitivitites
 		std::vector<active> _parSurfDiffusion; //!< Particle surface diffusion coefficient \f$ D_s \f$

--- a/src/libcadet/model/parts/ParticleDiffusionOperatorDG.cpp
+++ b/src/libcadet/model/parts/ParticleDiffusionOperatorDG.cpp
@@ -1575,35 +1575,35 @@ namespace parts
 		return true;
 	}
 
-	int ParticleDiffusionOperatorDG::calcFilmDiffJacobian(unsigned int secIdx, const int offsetCp, const int offsetC, const int nBulkPoints, const int nParType, const double colPorosity, const active* const parTypeVolFrac, Eigen::SparseMatrix<double, RowMajor>& globalJac, bool outliersOnly)
+	int ParticleDiffusionOperatorDG::calcFilmDiffJacobian(unsigned int secIdx, const int offsetCp, const int offsetC, const int nBulkPoints, const int nParType, const double colPorosity, const active* const parTypeVolFrac, const active* const pointVelocity, Eigen::SparseMatrix<double, RowMajor>& globalJac, bool outliersOnly)
 	{
 		// lifting matrix entry for exact integration scheme depends on metrics for sphere and cylinder
 		double exIntLiftContribution = static_cast<double>(_Ir[_nParElem - 1][_nParNode - 1]);
 		if (_parGeomSurfToVol == _SurfVolRatioSlab)
 			exIntLiftContribution = 1.0;
 
-		// Ordering of diffusion:
-		// sec0type0comp0, sec0type0comp1, sec0type0comp2, sec0type1comp0, sec0type1comp1, sec0type1comp2,
-		// sec1type0comp0, sec1type0comp1, sec1type0comp2, sec1type1comp0, sec1type1comp1, sec1type1comp2, ...
-		active const* const filmDiff = getSectionDependentSlice(_filmDiffusion, _nComp, secIdx);
-
 		linalg::BandedEigenSparseRowIterator jacCl(globalJac, offsetC);
 		linalg::BandedEigenSparseRowIterator jacCp(globalJac, offsetCp + (_nParPoints - 1) * strideParNode()); // iterator at the outer particle boundary
 
 		for (unsigned int blk = 0; blk < nBulkPoints; blk++)
 		{
+			// FILM_DIFFUSION_DEP is evaluated pointwise at this bulk point's local velocity
+			// (mass-lumped, same fidelity as FV's own midpoint-rule approximation of this term).
+			// Position is a no-op for the only supported dependency (POWER_LAW), which only uses velocity.
 			for (unsigned int comp = 0; comp < _nComp; comp++, ++jacCp, ++jacCl) {
+				const active filmDiff_comp = modifiedFilmDiffusion(secIdx, comp, ColumnPosition{ 0.0, 0.0, 0.0 }, pointVelocity[blk]);
+
 				// add Cl on Cl entries (added since these entries are also touched by bulk jacobian)
 				// row: already at bulk phase. already at current node and component.
 				// col: already at bulk phase. already at current node and component.
 				if (!outliersOnly)
-					jacCl[0] += static_cast<double>(filmDiff[comp]) * (1.0 - colPorosity) / colPorosity
+					jacCl[0] += static_cast<double>(filmDiff_comp) * (1.0 - colPorosity) / colPorosity
 					* _parGeomSurfToVol / static_cast<double>(_parRadius)
 					* static_cast<double>(parTypeVolFrac[_parTypeIdx + blk * nParType]);
 				// add Cl on Cp entries
 				// row: already at bulk phase. already at current node and component.
 				// col: go to current particle phase entry.
-				jacCl[jacCp.row() - jacCl.row()] = -static_cast<double>(filmDiff[comp]) * (1.0 - colPorosity) / colPorosity
+				jacCl[jacCp.row() - jacCl.row()] = -static_cast<double>(filmDiff_comp) * (1.0 - colPorosity) / colPorosity
 					* _parGeomSurfToVol / static_cast<double>(_parRadius)
 					* static_cast<double>(parTypeVolFrac[_parTypeIdx + blk * nParType]);
 
@@ -1614,11 +1614,11 @@ namespace parts
 					// col: original entry at outer node.
 					if (!outliersOnly) // Cp on Cp
 						jacCp[entry - jacCp.row()]
-						+= static_cast<double>(filmDiff[comp]) * 2.0 / static_cast<double>(_deltaR[0]) * _parInvMM[_nParElem - 1](node, _nParNode - 1) * exIntLiftContribution / static_cast<double>(_parPorosity) / static_cast<double>(_poreAccessFactor[comp]);
+						+= static_cast<double>(filmDiff_comp) * 2.0 / static_cast<double>(_deltaR[0]) * _parInvMM[_nParElem - 1](node, _nParNode - 1) * exIntLiftContribution / static_cast<double>(_parPorosity) / static_cast<double>(_poreAccessFactor[comp]);
 					// row: already at particle. Already at current node and liquid state.
 					// col: go to current bulk phase.
 					jacCp[jacCl.row() - jacCp.row()]
-						= -static_cast<double>(filmDiff[comp]) * 2.0 / static_cast<double>(_deltaR[0]) * _parInvMM[_nParElem - 1](node, _nParNode - 1) * exIntLiftContribution / static_cast<double>(_parPorosity) / static_cast<double>(_poreAccessFactor[comp]);
+						= -static_cast<double>(filmDiff_comp) * 2.0 / static_cast<double>(_deltaR[0]) * _parInvMM[_nParElem - 1](node, _nParNode - 1) * exIntLiftContribution / static_cast<double>(_parPorosity) / static_cast<double>(_poreAccessFactor[comp]);
 				}
 				// set back iterator to first node as required by component loop
 				jacCp += _nParNode * strideParNode();

--- a/src/libcadet/model/parts/ParticleDiffusionOperatorDG.hpp
+++ b/src/libcadet/model/parts/ParticleDiffusionOperatorDG.hpp
@@ -127,7 +127,7 @@ namespace parts
 			return static_cast<double>((_deltaR[element] * element + 0.5 * _deltaR[element] * (1 + _parNodes[node])) / (_parRadius - _parCoreRadius));
 		}
 
-		int calcFilmDiffJacobian(unsigned int secIdx, const int offsetCp, const int offsetC, const int nBulkPoints, const int nParType, const double colPorosity, const active* const parTypeVolFrac, Eigen::SparseMatrix<double, RowMajor>& globalJac, bool outliersOnly = false);
+		int calcFilmDiffJacobian(unsigned int secIdx, const int offsetCp, const int offsetC, const int nBulkPoints, const int nParType, const double colPorosity, const active* const parTypeVolFrac, const active* const pointVelocity, Eigen::SparseMatrix<double, RowMajor>& globalJac, bool outliersOnly = false);
 
 		int writeParticleCoordinates(double* coords) const;
 

--- a/src/libcadet/model/parts/ParticleDiffusionOperatorFV.cpp
+++ b/src/libcadet/model/parts/ParticleDiffusionOperatorFV.cpp
@@ -839,12 +839,11 @@ namespace parts
 		return 1;
 	}
 
-	int ParticleDiffusionOperatorFV::calcFilmDiffJacobian(unsigned int secIdx, const int offsetCp, const int offsetC, const int nBulkPoints, const int nParType, const double colPorosity, const active* const parTypeVolFrac, Eigen::SparseMatrix<double, RowMajor>& globalJac, bool outliersOnly)
+	int ParticleDiffusionOperatorFV::calcFilmDiffJacobian(unsigned int secIdx, const int offsetCp, const int offsetC, const int nBulkPoints, const int nParType, const double colPorosity, const active* const parTypeVolFrac, const active* const pointVelocity, Eigen::SparseMatrix<double, RowMajor>& globalJac, bool outliersOnly)
 	{
 		// Ordering of diffusion:
 		// sec0type0comp0, sec0type0comp1, sec0type0comp2, sec0type1comp0, sec0type1comp1, sec0type1comp2,
 		// sec1type0comp0, sec1type0comp1, sec1type0comp2, sec1type1comp0, sec1type1comp1, sec1type1comp2, ...
-		active const* const filmDiff = getSectionDependentSlice(_filmDiffusion, _nComp, secIdx);
 		active const* const parDiff = getSectionDependentSlice(_parDiffusion, _nComp, secIdx);
 		const double epsP = static_cast<double>(_parPorosity);
 		const double outerAreaPerVolume = static_cast<double>(_parOuterSurfAreaPerVolume[_nParPoints - 1]);
@@ -855,17 +854,22 @@ namespace parts
 
 		for (int blk = 0; blk < nBulkPoints; blk++)
 		{
+			// FILM_DIFFUSION_DEP is evaluated pointwise at this bulk point's local velocity
+			// (mass-lumped, same fidelity as FV's own midpoint-rule approximation of this term).
+			// Position is a no-op for the only supported dependency (POWER_LAW), which only uses velocity.
 			for (int comp = 0; comp < _nComp; comp++, ++jacCp, ++jacCl) {
+				const active filmDiff_comp = modifiedFilmDiffusion(secIdx, comp, ColumnPosition{ 0.0, 0.0, 0.0 }, pointVelocity[blk]);
+
 				// Discretized film diffusion kf for finite volumes (per component)
 				double kf_FV = 0.0;
 				if (cadet_likely(_boundaryOrderFV == 2))
 				{
 					const double absOuterShellHalfRadius = 0.5 * static_cast<double>(_deltaR[_nParPoints - 1]);
-					kf_FV = 1.0 / (absOuterShellHalfRadius / epsP / static_cast<double>(_poreAccessFactor[comp]) / static_cast<double>(parDiff[comp]) + 1.0 / static_cast<double>(filmDiff[comp]));
+					kf_FV = 1.0 / (absOuterShellHalfRadius / epsP / static_cast<double>(_poreAccessFactor[comp]) / static_cast<double>(parDiff[comp]) + 1.0 / static_cast<double>(filmDiff_comp));
 				}
 				else
 				{
-					kf_FV = static_cast<double>(filmDiff[comp]);
+					kf_FV = static_cast<double>(filmDiff_comp);
 				}
 
 				// Cb on Cb entries (added since these entries are also touched by bulk jacobian)
@@ -894,7 +898,7 @@ namespace parts
 					active const* const parCenterRadius = _parCenterRadius.data();
 					const double absOuterShellHalfRadius = 0.5 * static_cast<double>(_deltaR[_nParPoints - 1]);
 
-					kf_FV = (1.0 - static_cast<double>(_parPorosity)) / (1.0 + epsP * static_cast<double>(_poreAccessFactor[comp]) * static_cast<double>(parDiff[comp]) / (absOuterShellHalfRadius * static_cast<double>(filmDiff[comp])));
+					kf_FV = (1.0 - static_cast<double>(_parPorosity)) / (1.0 + epsP * static_cast<double>(_poreAccessFactor[comp]) * static_cast<double>(parDiff[comp]) / (absOuterShellHalfRadius * static_cast<double>(filmDiff_comp)));
 
 					const double dr = static_cast<double>(parCenterRadius[_nParPoints - 1]) - static_cast<double>(parCenterRadius[_nParPoints - 2]);
 

--- a/src/libcadet/model/parts/ParticleDiffusionOperatorFV.hpp
+++ b/src/libcadet/model/parts/ParticleDiffusionOperatorFV.hpp
@@ -124,7 +124,7 @@ namespace parts
 			return static_cast<double>(std::accumulate(&_deltaR[0], &_deltaR[cellIdx], _deltaR[cellIdx] * 0.5) / (_parRadius - _parCoreRadius));
 		}
 
-		int calcFilmDiffJacobian(unsigned int secIdx, const int offsetCp, const int offsetC, const int nBulkPoints, const int nParType, const double colPorosity, const active* const parTypeVolFrac, Eigen::SparseMatrix<double, RowMajor>& globalJac, bool outliersOnly = false);
+		int calcFilmDiffJacobian(unsigned int secIdx, const int offsetCp, const int offsetC, const int nBulkPoints, const int nParType, const double colPorosity, const active* const parTypeVolFrac, const active* const pointVelocity, Eigen::SparseMatrix<double, RowMajor>& globalJac, bool outliersOnly = false);
 
 		int writeParticleCoordinates(double* coords) const;
 

--- a/test/ColumnModel1D.cpp
+++ b/test/ColumnModel1D.cpp
@@ -822,6 +822,26 @@ TEST_CASE("Column_1D as GRM does not support surf diff par dep", "[AxialColumn1D
 	);
 }
 
+TEST_CASE("Column_1D as GRM film diffusion par dep Jacobian analytic vs AD FV", "[AxialColumn1D],[FV],[UnitOp],[Jacobian],[AD],[ParameterDependence],[CI]")
+{
+	cadet::test::column::testJacobianADVariableFilmDiff("COLUMN_MODEL_1D_GRM", "FV", false);
+}
+
+TEST_CASE("Column_1D as GRM film diffusion par dep Jacobian analytic vs AD DG", "[AxialColumn1D],[DG],[DG1D],[UnitOp],[Jacobian],[AD],[ParameterDependence],[CI]")
+{
+	cadet::test::column::testJacobianADVariableFilmDiff("COLUMN_MODEL_1D_GRM", "DG", false);
+}
+
+TEST_CASE("Column_1D as LRMP film diffusion par dep Jacobian analytic vs AD FV", "[AxialColumn1D],[FV],[UnitOp],[Jacobian],[AD],[ParameterDependence],[CI]")
+{
+	cadet::test::column::testJacobianADVariableFilmDiff("COLUMN_MODEL_1D_LRMP", "FV", false);
+}
+
+TEST_CASE("Column_1D as LRMP film diffusion par dep Jacobian analytic vs AD DG", "[AxialColumn1D],[DG],[DG1D],[UnitOp],[Jacobian],[AD],[ParameterDependence],[CI]")
+{
+	cadet::test::column::testJacobianADVariableFilmDiff("COLUMN_MODEL_1D_LRMP", "DG", false);
+}
+
 TEST_CASE("Column_1D as GRM dynamic reactions Jacobian vs AD modified particle", "[AxialColumn1D],[DG],[DG1D],[Jacobian],[AD],[ReactionModel],[CI]")
 {
 	cadet::test::reaction::testUnitJacobianDynamicReactionsAD("COLUMN_MODEL_1D_GRM", "DG", false, true, true, 1e-14);


### PR DESCRIPTION
This PR adds film diffusion parameter-dependence on interstitial velocity
to the GeneralRateParticle and
HomogeneousParticle which are used in the generalized units, based a pointwise evaluation at each bulk discrete point.
Adds a `velocity` field to columnPackingParameters (populated by ColumnModel1D/ColumnModel2D via a new currentVelocity(pos) accessor on the DG bulk operator) and a modifiedFilmDiffusion() helper on ParticleDiffusionOperatorBase/HomogeneousParticle that evaluates the dependency pointwise at each bulk point, mirroring the accuracy level finite-volume already uses for this term.

Note: the point-wise implementation reduces the DG formal order to 2nd order.

Added tests verifying the analytic Jacobian against AD for GRM and LRMP particle models.