### PR TITLE
Fix parameter dependence film diffusion generalized units

### DIFF
--- a/src/libcadet/model/particle/GeneralRateParticle.cpp
+++ b/src/libcadet/model/particle/GeneralRateParticle.cpp
@@ -305,7 +305,7 @@ namespace model
 		// particle diffusion, including film diffusion boundary condition
 		ResidualType* wantResPtr = wantRes ? resPar : nullptr;
 		linalg::BandedEigenSparseRowIterator jacSafe = wantNonLinJac ? jacBase : linalg::BandedEigenSparseRowIterator{};
-		_parDiffOp->residual(t, secIdx, yPar, yBulk, yDotPar, wantResPtr, jacSafe, typename ParamSens<ParamType>::enabled());
+		_parDiffOp->residual(t, secIdx, yPar, yBulk, yDotPar, wantResPtr, packing.colPos, packing.velocity, jacSafe, typename ParamSens<ParamType>::enabled());
 
 		if (wantRes)
 		{

--- a/src/libcadet/model/parts/ParticleDiffusionOperatorBase.hpp
+++ b/src/libcadet/model/parts/ParticleDiffusionOperatorBase.hpp
@@ -113,13 +113,15 @@ namespace parts
 		 * @param [in] yBulk Pointer to corresponding bulk phase entry in unit state vector
 		 * @param [in] yDotPar Pointer to particle phase derivative entry in unit state vector
 		 * @param [out] resPar Pointer Pointer to particle phase entry in unit residual vector, nullptr if no residual shall be computed
+		 * @param [in] colPos Column position of this particle, needed to evaluate FILM_DIFFUSION_DEP
+		 * @param [in] velocity Interstitial velocity at colPos, needed to evaluate FILM_DIFFUSION_DEP
 		 * @param [in] jacIt Row iterator pointing to the particle phase entry in the unit Jacobian, uninitialized if no Jacobian shall be computed
 		 * @return @c 0 on success, @c -1 on non-recoverable error, and @c +1 on recoverable error
 		 */
-		virtual int residual(double t, unsigned int secIdx, double const* yPar, double const* yBulk, double const* yDotPar, double* resPar, linalg::BandedEigenSparseRowIterator& jacIt, WithoutParamSensitivity) = 0;
-		virtual int residual(double t, unsigned int secIdx, double const* yPar, double const* yBulk, double const* yDotPar, active* resPar, linalg::BandedEigenSparseRowIterator& jacIt, WithParamSensitivity) = 0;
-		virtual int residual(double t, unsigned int secIdx, active const* yPar, active const* yBulk, double const* yDotPar, active* resPar, linalg::BandedEigenSparseRowIterator& jacIt, WithoutParamSensitivity) = 0;
-		virtual int residual(double t, unsigned int secIdx, active const* yPar, active const* yBulk, double const* yDotPar, active* resPar, linalg::BandedEigenSparseRowIterator& jacIt, WithParamSensitivity) = 0;
+		virtual int residual(double t, unsigned int secIdx, double const* yPar, double const* yBulk, double const* yDotPar, double* resPar, const ColumnPosition& colPos, const active& velocity, linalg::BandedEigenSparseRowIterator& jacIt, WithoutParamSensitivity) = 0;
+		virtual int residual(double t, unsigned int secIdx, double const* yPar, double const* yBulk, double const* yDotPar, active* resPar, const ColumnPosition& colPos, const active& velocity, linalg::BandedEigenSparseRowIterator& jacIt, WithParamSensitivity) = 0;
+		virtual int residual(double t, unsigned int secIdx, active const* yPar, active const* yBulk, double const* yDotPar, active* resPar, const ColumnPosition& colPos, const active& velocity, linalg::BandedEigenSparseRowIterator& jacIt, WithoutParamSensitivity) = 0;
+		virtual int residual(double t, unsigned int secIdx, active const* yPar, active const* yBulk, double const* yDotPar, active* resPar, const ColumnPosition& colPos, const active& velocity, linalg::BandedEigenSparseRowIterator& jacIt, WithParamSensitivity) = 0;
 
 		virtual int calcFilmDiffJacobian(unsigned int secIdx, const int offsetCp, const int offsetC, const int nBulkPoints, const int nParType, const double colPorosity, const active* const parTypeVolFrac, const active* const pointVelocity, Eigen::SparseMatrix<double, Eigen::RowMajor>& globalJac, bool outliersOnly = false) = 0;
 		virtual int calcParticleDiffJacobian(const int secIdx, const int colNode, const int offsetLocalCp, Eigen::SparseMatrix<double, Eigen::RowMajor>& globalJac) = 0;

--- a/src/libcadet/model/parts/ParticleDiffusionOperatorDG.cpp
+++ b/src/libcadet/model/parts/ParticleDiffusionOperatorDG.cpp
@@ -515,44 +515,44 @@ namespace parts
 		}
 	}
 
-	int ParticleDiffusionOperatorDG::residual(double t, unsigned int secIdx, double const* yPar, double const* yBulk, double const* yDotPar, double* resPar, linalg::BandedEigenSparseRowIterator& jacIt, WithoutParamSensitivity)
+	int ParticleDiffusionOperatorDG::residual(double t, unsigned int secIdx, double const* yPar, double const* yBulk, double const* yDotPar, double* resPar, const ColumnPosition& colPos, const active& velocity, linalg::BandedEigenSparseRowIterator& jacIt, WithoutParamSensitivity)
 	{
 		if (resPar)
 		{
 			if (jacIt.data())
-				return residualImpl<double, double, double, true, true>(t, secIdx, yPar, yBulk, yDotPar, resPar, jacIt);
+				return residualImpl<double, double, double, true, true>(t, secIdx, yPar, yBulk, yDotPar, resPar, colPos, velocity, jacIt);
 			else
-				return residualImpl<double, double, double, false, true>(t, secIdx, yPar, yBulk, yDotPar, resPar, jacIt);
+				return residualImpl<double, double, double, false, true>(t, secIdx, yPar, yBulk, yDotPar, resPar, colPos, velocity, jacIt);
 		}
 		else if (jacIt.data())
-			return residualImpl<double, double, double, true, false>(t, secIdx, yPar, yBulk, yDotPar, resPar, jacIt);
+			return residualImpl<double, double, double, true, false>(t, secIdx, yPar, yBulk, yDotPar, resPar, colPos, velocity, jacIt);
 		else
 			return -1;
 	}
-	int ParticleDiffusionOperatorDG::residual(double t, unsigned int secIdx, double const* yPar, double const* yBulk, double const* yDotPar, active* resPar, linalg::BandedEigenSparseRowIterator& jacIt, WithParamSensitivity)
+	int ParticleDiffusionOperatorDG::residual(double t, unsigned int secIdx, double const* yPar, double const* yBulk, double const* yDotPar, active* resPar, const ColumnPosition& colPos, const active& velocity, linalg::BandedEigenSparseRowIterator& jacIt, WithParamSensitivity)
 	{
 		 if (jacIt.data())
-			return residualImpl<double, active, active, true, true>(t, secIdx, yPar, yBulk, yDotPar, resPar, jacIt);
+			return residualImpl<double, active, active, true, true>(t, secIdx, yPar, yBulk, yDotPar, resPar, colPos, velocity, jacIt);
 		else
-			 return residualImpl<double, active, active, false, true>(t, secIdx, yPar, yBulk, yDotPar, resPar, jacIt);
+			 return residualImpl<double, active, active, false, true>(t, secIdx, yPar, yBulk, yDotPar, resPar, colPos, velocity, jacIt);
 	}
-	int ParticleDiffusionOperatorDG::residual(double t, unsigned int secIdx, active const* yPar, active const* yBulk, double const* yDotPar, active* resPar, linalg::BandedEigenSparseRowIterator& jacIt, WithoutParamSensitivity)
+	int ParticleDiffusionOperatorDG::residual(double t, unsigned int secIdx, active const* yPar, active const* yBulk, double const* yDotPar, active* resPar, const ColumnPosition& colPos, const active& velocity, linalg::BandedEigenSparseRowIterator& jacIt, WithoutParamSensitivity)
 	{
 		if (jacIt.data())
-			return residualImpl<active, active, double, true, true>(t, secIdx, yPar, yBulk, yDotPar, resPar, jacIt);
+			return residualImpl<active, active, double, true, true>(t, secIdx, yPar, yBulk, yDotPar, resPar, colPos, velocity, jacIt);
 		else
-			return residualImpl<active, active, double, false, true>(t, secIdx, yPar, yBulk, yDotPar, resPar, jacIt);
+			return residualImpl<active, active, double, false, true>(t, secIdx, yPar, yBulk, yDotPar, resPar, colPos, velocity, jacIt);
 	}
-	int ParticleDiffusionOperatorDG::residual(double t, unsigned int secIdx, active const* yPar, active const* yBulk, double const* yDotPar, active* resPar, linalg::BandedEigenSparseRowIterator& jacIt, WithParamSensitivity)
+	int ParticleDiffusionOperatorDG::residual(double t, unsigned int secIdx, active const* yPar, active const* yBulk, double const* yDotPar, active* resPar, const ColumnPosition& colPos, const active& velocity, linalg::BandedEigenSparseRowIterator& jacIt, WithParamSensitivity)
 	{
 		if (jacIt.data())
-			return residualImpl<active, active, active, true, true>(t, secIdx, yPar, yBulk, yDotPar, resPar, jacIt);
+			return residualImpl<active, active, active, true, true>(t, secIdx, yPar, yBulk, yDotPar, resPar, colPos, velocity, jacIt);
 		else
-			return residualImpl<active, active, active, false, true>(t, secIdx, yPar, yBulk, yDotPar, resPar, jacIt);
+			return residualImpl<active, active, active, false, true>(t, secIdx, yPar, yBulk, yDotPar, resPar, colPos, velocity, jacIt);
 	}
 
 	template <typename StateType, typename ResidualType, typename ParamType, bool wantJac, bool wantRes>
-	int ParticleDiffusionOperatorDG::residualImpl(double t, unsigned int secIdx, StateType const* yPar, StateType const* yBulk, double const* yDotPar, ResidualType* resPar, linalg::BandedEigenSparseRowIterator& jacBase)
+	int ParticleDiffusionOperatorDG::residualImpl(double t, unsigned int secIdx, StateType const* yPar, StateType const* yBulk, double const* yDotPar, ResidualType* resPar, const ColumnPosition& colPos, const active& velocity, linalg::BandedEigenSparseRowIterator& jacBase)
 	{
 		// Add the solid entries of the transport jacobian that get overwritten by the binding kernel.
 		// These entries only exist for the combination of dynamic reactions with surface diffusion
@@ -565,12 +565,10 @@ namespace parts
 
 		/* Mobile phase RHS	*/
 
-		const active* const filmDiff = getSectionDependentSlice(_filmDiffusion, _nComp, secIdx);
-
-		// Get film diffusion flux at current node to compute boundary condition
 		for (unsigned int comp = 0; comp < _nComp; comp++)
 		{
-			_localFlux[comp] = filmDiff[comp] * (yBulk[comp * _strideBulkComp] - yPar[(_nParPoints - 1) * strideParNode() + comp]);
+			const active filmDiff_comp = modifiedFilmDiffusion(secIdx, comp, colPos, velocity);
+			_localFlux[comp] = filmDiff_comp * (yBulk[comp * _strideBulkComp] - yPar[(_nParPoints - 1) * strideParNode() + comp]);
 		}
 
 		active const* const parDiff = getSectionDependentSlice(_parDiffusion, _nComp, secIdx);

--- a/src/libcadet/model/parts/ParticleDiffusionOperatorDG.hpp
+++ b/src/libcadet/model/parts/ParticleDiffusionOperatorDG.hpp
@@ -91,10 +91,10 @@ namespace parts
 
 		bool notifyDiscontinuousSectionTransition(double t, unsigned int secIdx);
 
-		int residual(double t, unsigned int secIdx, double const* yPar, double const* yBulk, double const* yDotPar, double* resPar, linalg::BandedEigenSparseRowIterator& jacIt, WithoutParamSensitivity);
-		int residual(double t, unsigned int secIdx, double const* yPar, double const* yBulk, double const* yDotPar, active* resPar, linalg::BandedEigenSparseRowIterator& jacIt, WithParamSensitivity);
-		int residual(double t, unsigned int secIdx, active const* yPar, active const* yBulk, double const* yDotPar, active* resPar, linalg::BandedEigenSparseRowIterator& jacIt, WithoutParamSensitivity);
-		int residual(double t, unsigned int secIdx, active const* yPar, active const* yBulk, double const* yDotPar, active* resPar, linalg::BandedEigenSparseRowIterator& jacIt, WithParamSensitivity);
+		int residual(double t, unsigned int secIdx, double const* yPar, double const* yBulk, double const* yDotPar, double* resPar, const ColumnPosition& colPos, const active& velocity, linalg::BandedEigenSparseRowIterator& jacIt, WithoutParamSensitivity);
+		int residual(double t, unsigned int secIdx, double const* yPar, double const* yBulk, double const* yDotPar, active* resPar, const ColumnPosition& colPos, const active& velocity, linalg::BandedEigenSparseRowIterator& jacIt, WithParamSensitivity);
+		int residual(double t, unsigned int secIdx, active const* yPar, active const* yBulk, double const* yDotPar, active* resPar, const ColumnPosition& colPos, const active& velocity, linalg::BandedEigenSparseRowIterator& jacIt, WithoutParamSensitivity);
+		int residual(double t, unsigned int secIdx, active const* yPar, active const* yBulk, double const* yDotPar, active* resPar, const ColumnPosition& colPos, const active& velocity, linalg::BandedEigenSparseRowIterator& jacIt, WithParamSensitivity);
 
 		std::vector<active> _parOuterSurfAreaPerVolume; //!< Particle element outer sphere surface to volume ratio
 		std::vector<active> _parInnerSurfAreaPerVolume; //!< Particle element inner sphere surface to volume ratio
@@ -146,7 +146,7 @@ namespace parts
 		void parBindingAndReactionPattern(std::vector<Eigen::Triplet<double>>& tripletList, const int offset, const unsigned int colNode);
 
 		template <typename StateType, typename ResidualType, typename ParamType, bool wantJac, bool wantRes>
-		int residualImpl(double t, unsigned int secIdx, StateType const* yPar, StateType const* yBulk, double const* yDotPar, ResidualType* resPar, linalg::BandedEigenSparseRowIterator& jacBase);
+		int residualImpl(double t, unsigned int secIdx, StateType const* yPar, StateType const* yBulk, double const* yDotPar, ResidualType* resPar, const ColumnPosition& colPos, const active& velocity, linalg::BandedEigenSparseRowIterator& jacBase);
 
 		void initializeDG();
 

--- a/src/libcadet/model/parts/ParticleDiffusionOperatorFV.cpp
+++ b/src/libcadet/model/parts/ParticleDiffusionOperatorFV.cpp
@@ -334,44 +334,44 @@ namespace parts
 		return _nParPoints;
 	}
 
-	int ParticleDiffusionOperatorFV::residual(double t, unsigned int secIdx, double const* yPar, double const* yBulk, double const* yDotPar, double* resPar, linalg::BandedEigenSparseRowIterator& jacIt, WithoutParamSensitivity)
+	int ParticleDiffusionOperatorFV::residual(double t, unsigned int secIdx, double const* yPar, double const* yBulk, double const* yDotPar, double* resPar, const ColumnPosition& colPos, const active& velocity, linalg::BandedEigenSparseRowIterator& jacIt, WithoutParamSensitivity)
 	{
 		if (resPar)
 		{
 			if (jacIt.data())
-				return residualImpl<double, double, double, true, true>(t, secIdx, yPar, yBulk, yDotPar, resPar, jacIt);
+				return residualImpl<double, double, double, true, true>(t, secIdx, yPar, yBulk, yDotPar, resPar, colPos, velocity, jacIt);
 			else
-				return residualImpl<double, double, double, false, true>(t, secIdx, yPar, yBulk, yDotPar, resPar, jacIt);
+				return residualImpl<double, double, double, false, true>(t, secIdx, yPar, yBulk, yDotPar, resPar, colPos, velocity, jacIt);
 		}
 		else if (jacIt.data())
-			return residualImpl<double, double, double, true, false>(t, secIdx, yPar, yBulk, yDotPar, resPar, jacIt);
+			return residualImpl<double, double, double, true, false>(t, secIdx, yPar, yBulk, yDotPar, resPar, colPos, velocity, jacIt);
 		else
 			return -1;
 	}
-	int ParticleDiffusionOperatorFV::residual(double t, unsigned int secIdx, double const* yPar, double const* yBulk, double const* yDotPar, active* resPar, linalg::BandedEigenSparseRowIterator& jacIt, WithParamSensitivity)
+	int ParticleDiffusionOperatorFV::residual(double t, unsigned int secIdx, double const* yPar, double const* yBulk, double const* yDotPar, active* resPar, const ColumnPosition& colPos, const active& velocity, linalg::BandedEigenSparseRowIterator& jacIt, WithParamSensitivity)
 	{
 		 if (jacIt.data())
-			return residualImpl<double, active, active, true, true>(t, secIdx, yPar, yBulk, yDotPar, resPar, jacIt);
+			return residualImpl<double, active, active, true, true>(t, secIdx, yPar, yBulk, yDotPar, resPar, colPos, velocity, jacIt);
 		else
-			 return residualImpl<double, active, active, false, true>(t, secIdx, yPar, yBulk, yDotPar, resPar, jacIt);
+			 return residualImpl<double, active, active, false, true>(t, secIdx, yPar, yBulk, yDotPar, resPar, colPos, velocity, jacIt);
 	}
-	int ParticleDiffusionOperatorFV::residual(double t, unsigned int secIdx, active const* yPar, active const* yBulk, double const* yDotPar, active* resPar, linalg::BandedEigenSparseRowIterator& jacIt, WithoutParamSensitivity)
+	int ParticleDiffusionOperatorFV::residual(double t, unsigned int secIdx, active const* yPar, active const* yBulk, double const* yDotPar, active* resPar, const ColumnPosition& colPos, const active& velocity, linalg::BandedEigenSparseRowIterator& jacIt, WithoutParamSensitivity)
 	{
 		if (jacIt.data())
-			return residualImpl<active, active, double, true, true>(t, secIdx, yPar, yBulk, yDotPar, resPar, jacIt);
+			return residualImpl<active, active, double, true, true>(t, secIdx, yPar, yBulk, yDotPar, resPar, colPos, velocity, jacIt);
 		else
-			return residualImpl<active, active, double, false, true>(t, secIdx, yPar, yBulk, yDotPar, resPar, jacIt);
+			return residualImpl<active, active, double, false, true>(t, secIdx, yPar, yBulk, yDotPar, resPar, colPos, velocity, jacIt);
 	}
-	int ParticleDiffusionOperatorFV::residual(double t, unsigned int secIdx, active const* yPar, active const* yBulk, double const* yDotPar, active* resPar, linalg::BandedEigenSparseRowIterator& jacIt, WithParamSensitivity)
+	int ParticleDiffusionOperatorFV::residual(double t, unsigned int secIdx, active const* yPar, active const* yBulk, double const* yDotPar, active* resPar, const ColumnPosition& colPos, const active& velocity, linalg::BandedEigenSparseRowIterator& jacIt, WithParamSensitivity)
 	{
 		if (jacIt.data())
-			return residualImpl<active, active, active, true, true>(t, secIdx, yPar, yBulk, yDotPar, resPar, jacIt);
+			return residualImpl<active, active, active, true, true>(t, secIdx, yPar, yBulk, yDotPar, resPar, colPos, velocity, jacIt);
 		else
-			return residualImpl<active, active, active, false, true>(t, secIdx, yPar, yBulk, yDotPar, resPar, jacIt);
+			return residualImpl<active, active, active, false, true>(t, secIdx, yPar, yBulk, yDotPar, resPar, colPos, velocity, jacIt);
 	}
 
 	template <typename StateType, typename ResidualType, typename ParamType, bool wantJac, bool wantRes>
-	int ParticleDiffusionOperatorFV::residualImpl(double t, unsigned int secIdx, StateType const* yPar, StateType const* yBulk, double const* yDotPar, ResidualType* resPar, linalg::BandedEigenSparseRowIterator& jacBase)
+	int ParticleDiffusionOperatorFV::residualImpl(double t, unsigned int secIdx, StateType const* yPar, StateType const* yBulk, double const* yDotPar, ResidualType* resPar, const ColumnPosition& colPos, const active& velocity, linalg::BandedEigenSparseRowIterator& jacBase)
 	{
 		// Add the solid entries of the transport jacobian that get overwritten by the binding kernel.
 		// These entries only exist for the combination of dynamic reactions with surface diffusion
@@ -382,7 +382,6 @@ namespace parts
 		if (!wantRes)
 			return 0;
 
-		const active* const filmDiff = getSectionDependentSlice(_filmDiffusion, _nComp, secIdx);
 		active const* const parDiff = getSectionDependentSlice(_parDiffusion, _nComp, secIdx);
 		active const* const parSurfDiff = getSectionDependentSlice(_parSurfDiffusion, _strideBound, secIdx);
 
@@ -521,12 +520,14 @@ namespace parts
 		// bead boundary condition in outer bead shell equation
 		for (int comp = 0; comp < _nComp; ++comp)
 		{
+			const ParamType filmDiff_comp = static_cast<ParamType>(modifiedFilmDiffusion(secIdx, comp, colPos, velocity));
+
 			// Discretized film diffusion kf for finite volumes (per component)
 			ParamType kf_FV = 1.0;
 			if (cadet_likely(_boundaryOrderFV == 2))
-				kf_FV = 1.0 / (absOuterShellHalfRadius * static_cast<ParamType>(filmDiff[comp]) / epsP / static_cast<ParamType>(_poreAccessFactor[comp]) / static_cast<ParamType>(parDiff[comp]) + 1.0);
+				kf_FV = 1.0 / (absOuterShellHalfRadius * filmDiff_comp / epsP / static_cast<ParamType>(_poreAccessFactor[comp]) / static_cast<ParamType>(parDiff[comp]) + 1.0);
 
-			ResidualType flux = kf_FV * static_cast<ParamType>(filmDiff[comp]) * (yBulk[comp * strideBulkComp()] - yPar[(_nParPoints - 1) * strideParPoint() + comp]);
+			ResidualType flux = kf_FV * filmDiff_comp * (yBulk[comp * strideBulkComp()] - yPar[(_nParPoints - 1) * strideParPoint() + comp]);
 			resPar[(_nParPoints - 1) * strideParPoint() + comp] += jacPF_val / static_cast<ParamType>(_poreAccessFactor[comp]) * flux;
 		}
 
@@ -540,8 +541,10 @@ namespace parts
 
 			for (int comp = 0; comp < _nComp; ++comp)
 			{
-				// Recalculate kf_FV for surface diffusion (per component)
-				const ParamType kf_FV = (1.0 - static_cast<ParamType>(_parPorosity)) / (1.0 + epsP * static_cast<ParamType>(_poreAccessFactor[comp]) * static_cast<ParamType>(parDiff[comp]) / (absOuterShellHalfRadius * static_cast<ParamType>(filmDiff[comp])));
+				// Recalculate kf_FV for surface diffusion (per component); use the same
+				// FILM_DIFFUSION_DEP-modified value as the boundary condition above.
+				const ParamType filmDiff_comp = static_cast<ParamType>(modifiedFilmDiffusion(secIdx, comp, colPos, velocity));
+				const ParamType kf_FV = (1.0 - static_cast<ParamType>(_parPorosity)) / (1.0 + epsP * static_cast<ParamType>(_poreAccessFactor[comp]) * static_cast<ParamType>(parDiff[comp]) / (absOuterShellHalfRadius * filmDiff_comp));
 
 				const unsigned int nBound = _nBound[comp];
 				ResidualType surfFlux = 0.0;

--- a/src/libcadet/model/parts/ParticleDiffusionOperatorFV.hpp
+++ b/src/libcadet/model/parts/ParticleDiffusionOperatorFV.hpp
@@ -91,10 +91,10 @@ namespace parts
 
 		bool notifyDiscontinuousSectionTransition(double t, unsigned int secIdx);
 
-		int residual(double t, unsigned int secIdx, double const* yPar, double const* yBulk, double const* yDotPar, double* resPar, linalg::BandedEigenSparseRowIterator& jacIt, WithoutParamSensitivity);
-		int residual(double t, unsigned int secIdx, double const* yPar, double const* yBulk, double const* yDotPar, active* resPar, linalg::BandedEigenSparseRowIterator& jacIt, WithParamSensitivity);
-		int residual(double t, unsigned int secIdx, active const* yPar, active const* yBulk, double const* yDotPar, active* resPar, linalg::BandedEigenSparseRowIterator& jacIt, WithoutParamSensitivity);
-		int residual(double t, unsigned int secIdx, active const* yPar, active const* yBulk, double const* yDotPar, active* resPar, linalg::BandedEigenSparseRowIterator& jacIt, WithParamSensitivity);
+		int residual(double t, unsigned int secIdx, double const* yPar, double const* yBulk, double const* yDotPar, double* resPar, const ColumnPosition& colPos, const active& velocity, linalg::BandedEigenSparseRowIterator& jacIt, WithoutParamSensitivity);
+		int residual(double t, unsigned int secIdx, double const* yPar, double const* yBulk, double const* yDotPar, active* resPar, const ColumnPosition& colPos, const active& velocity, linalg::BandedEigenSparseRowIterator& jacIt, WithParamSensitivity);
+		int residual(double t, unsigned int secIdx, active const* yPar, active const* yBulk, double const* yDotPar, active* resPar, const ColumnPosition& colPos, const active& velocity, linalg::BandedEigenSparseRowIterator& jacIt, WithoutParamSensitivity);
+		int residual(double t, unsigned int secIdx, active const* yPar, active const* yBulk, double const* yDotPar, active* resPar, const ColumnPosition& colPos, const active& velocity, linalg::BandedEigenSparseRowIterator& jacIt, WithParamSensitivity);
 
 		std::vector<active> _parOuterSurfAreaPerVolume; //!< Particle element outer sphere surface to volume ratio
 		std::vector<active> _parInnerSurfAreaPerVolume; //!< Particle element inner sphere surface to volume ratio
@@ -155,7 +155,7 @@ namespace parts
 		void parBindingPattern(std::vector<Eigen::Triplet<double>>& tripletList, const int offset, const unsigned int colNode);
 
 		template <typename StateType, typename ResidualType, typename ParamType, bool wantJac, bool wantRes>
-		int residualImpl(double t, unsigned int secIdx, StateType const* yPar, StateType const* yBulk, double const* yDotPar, ResidualType* resPar, linalg::BandedEigenSparseRowIterator& jacBase);
+		int residualImpl(double t, unsigned int secIdx, StateType const* yPar, StateType const* yBulk, double const* yDotPar, ResidualType* resPar, const ColumnPosition& colPos, const active& velocity, linalg::BandedEigenSparseRowIterator& jacBase);
 
 		ParticleDiscretizationMode _parDiscMode; //!< Particle discretization mode
 

--- a/test/ColumnTests.cpp
+++ b/test/ColumnTests.cpp
@@ -1255,9 +1255,14 @@ namespace column
 			auto us = util::makeOptionalGroupScope(jpp, "unit_000");
 
 			// VELOCITY_COEFF is no longer a JSON input field (velocity is now derived from
-			// CROSS_SECTION_AREA*); this is only used as an arbitrary representative scale for the
-			// synthetic film-diffusion dependency below, so the historical value is used directly.
-			const double velocityCoeff = 5.75e-4;
+			// CROSS_SECTION_AREA*). Deliberately chosen well away from the model's actual
+			// interstitial velocity (unlike the historical 5.75e-4, which happened to coincide
+			// with it): this is what exposes a residual/Jacobian (or bulk/particle) inconsistency
+			// in the FILM_DIFFUSION_DEP evaluation, since a calibration point that coincides with
+			// the actual velocity makes the dependence numerically a no-op and would silently hide
+			// such a bug (as it previously did for the bulk<->particle mismatch fixed alongside
+			// this test change; see GeneralRateParticle/ParticleDiffusionOperator{FV,DG}).
+			const double velocityCoeff = 5.75e-4 * 4.0;
 
 			auto ps = util::makeOptionalGroupScope(jpp, "particle_type_000");
 


### PR DESCRIPTION
GeneralRateParticle's bulk-side residual correctly used the velocity-dependent modifiedFilmDiffusion(), but its particle-side boundary condition (in both ParticleDiffusionOperatorDG.cpp and ParticleDiffusionOperatorFV.cpp) used the raw, velocity-independent film diffusion constant. So the bulk was draining mass at one rate and the particle was absorbing it at a different rate. HomogeneousParticle already did this correctly, which is why the bug was isolated to GeneralRateParticle. It happened to be invisible in the existing Jacobian test because that test's calibration velocity coincided with the model's actual velocity, making the bug numerically silent there.