### PR TITLE
Fix section recomputation of variable cross section DG operators

### DIFF
--- a/src/libcadet/model/parts/ConvectionDispersionOperatorDG.cpp
+++ b/src/libcadet/model/parts/ConvectionDispersionOperatorDG.cpp
@@ -860,12 +860,7 @@ bool VariableCrossSectionConvectionDispersionOperatorBaseDG::notifyDiscontinuous
 	_curFwdFlow = static_cast<bool>(getSectionDependentScalar(_forwardFlow, secIdx));
 	const bool changedDirection = secIdx > 0 ? (static_cast<bool>(getSectionDependentScalar(_forwardFlow, secIdx - 1)) != _curFwdFlow) : false;
 
-	// Some model parameters are baked into the DG operators but may be updated at section
-	// transitions. This has to happen BEFORE the Jacobian blocks below are recomputed, since they
-	// are assembled from these operators: with a velocity dependent COL_DISPERSION_DEP, the
-	// operators built at configure() time are evaluated at zero interstitial velocity (the flow
-	// rate is only known once the network is connected), so recomputing them afterwards would leave
-	// the analytic Jacobian holding a dispersion contribution that does not match the residual.
+	// Some model parameters are baked into the DG operators but may be updated at section transitions
 	computeOperators(secIdx);
 
 	// Recompute Jacobian blocks

--- a/src/libcadet/model/parts/ConvectionDispersionOperatorDG.cpp
+++ b/src/libcadet/model/parts/ConvectionDispersionOperatorDG.cpp
@@ -860,6 +860,14 @@ bool VariableCrossSectionConvectionDispersionOperatorBaseDG::notifyDiscontinuous
 	_curFwdFlow = static_cast<bool>(getSectionDependentScalar(_forwardFlow, secIdx));
 	const bool changedDirection = secIdx > 0 ? (static_cast<bool>(getSectionDependentScalar(_forwardFlow, secIdx - 1)) != _curFwdFlow) : false;
 
+	// Some model parameters are baked into the DG operators but may be updated at section
+	// transitions. This has to happen BEFORE the Jacobian blocks below are recomputed, since they
+	// are assembled from these operators: with a velocity dependent COL_DISPERSION_DEP, the
+	// operators built at configure() time are evaluated at zero interstitial velocity (the flow
+	// rate is only known once the network is connected), so recomputing them afterwards would leave
+	// the analytic Jacobian holding a dispersion contribution that does not match the residual.
+	computeOperators(secIdx);
+
 	// Recompute Jacobian blocks
 	for (unsigned int elem = 0; elem < _nElem; elem++)
 	{
@@ -872,9 +880,6 @@ bool VariableCrossSectionConvectionDispersionOperatorBaseDG::notifyDiscontinuous
 		jacInlet = _DGjacConvBlocks[0].col(0);
 	else
 		jacInlet = _DGjacConvBlocks[_nElem - 1].col(_DGjacConvBlocks[_nElem - 1].cols() - 1);
-
-	// some model parameters are baked into the DG operators but may be updated at section transitions
-	computeOperators(secIdx);
 
 	return changedDirection;
 }

--- a/test/ColumnModel1D.cpp
+++ b/test/ColumnModel1D.cpp
@@ -872,6 +872,21 @@ TEST_CASE("Column_1D as radial GRM col dispersion van Deemter par dep Jacobian a
 	cadet::test::column::testJacobianADVariableColDispersionVanDeemter("RADIAL_COLUMN_MODEL_1D_GRM", "DG", false);
 }
 
+TEST_CASE("Column_1D as axial GRM col dispersion power law par dep Jacobian analytic vs AD DG", "[AxialColumn1D],[DG],[DG1D],[UnitOp],[Jacobian],[AD],[ParameterDependence],[CI]")
+{
+	cadet::test::column::testJacobianADVariableColDispersionPowerLaw("COLUMN_MODEL_1D_GRM", "DG", false);
+}
+
+TEST_CASE("Column_1D as frustum GRM col dispersion power law par dep Jacobian analytic vs AD DG", "[FrustumColumn1D],[DG],[DG1D],[UnitOp],[Jacobian],[AD],[ParameterDependence],[CI]")
+{
+	cadet::test::column::testJacobianADVariableColDispersionPowerLaw("FRUSTUM_COLUMN_MODEL_1D_GRM", "DG", false);
+}
+
+TEST_CASE("Column_1D as radial GRM col dispersion power law par dep Jacobian analytic vs AD DG", "[RadialColumn1D],[DG],[DG1D],[UnitOp],[Jacobian],[AD],[ParameterDependence],[CI]")
+{
+	cadet::test::column::testJacobianADVariableColDispersionPowerLaw("RADIAL_COLUMN_MODEL_1D_GRM", "DG", false);
+}
+
 TEST_CASE("Column_1D as GRM dynamic reactions Jacobian vs AD modified particle", "[AxialColumn1D],[DG],[DG1D],[Jacobian],[AD],[ReactionModel],[CI]")
 {
 	cadet::test::reaction::testUnitJacobianDynamicReactionsAD("COLUMN_MODEL_1D_GRM", "DG", false, true, true, 1e-14);

--- a/test/ColumnTests.cpp
+++ b/test/ColumnTests.cpp
@@ -1307,6 +1307,47 @@ namespace column
 		testJacobianAD(jpp, 1e-14);
 	}
 
+	void testJacobianADVariableColDispersionPowerLaw(const std::string& uoType, const std::string& spatialMethod, bool dynamicBinding)
+	{
+		cadet::JsonParameterProvider jpp = createColumnWithTwoCompLinearBinding(uoType, spatialMethod);
+		setBindingMode(jpp, dynamicBinding);
+		{
+			auto ms = util::makeOptionalGroupScope(jpp, "model");
+			auto us = util::makeOptionalGroupScope(jpp, "unit_000");
+
+			// D(x) = COL_DISPERSION * |v(x)|, i.e. COL_DISPERSION acts as a dispersivity. Note that
+			// this dependence vanishes identically at zero velocity, so a nonzero flow rate has to be
+			// imposed below for this test to exercise anything at all.
+			// Rescale COL_DISPERSION by the representative interstitial velocity of this test model
+			// (see createColumnWithTwoCompLinearJson(): all three geometries are dimensioned for
+			// v ~ 5.75e-4 at the flow rate imposed below), so that the resulting effective dispersion
+			// stays at the same magnitude as the constant-dispersion default and hence contributes to
+			// the Jacobian at the same magnitude instead of being swamped by the other blocks.
+			const double baseDispersion = jpp.getDouble("COL_DISPERSION");
+			jpp.set("COL_DISPERSION", baseDispersion / 5.75e-4);
+			jpp.set("COL_DISPERSION_DEP", "POWER_LAW");
+			jpp.set("COL_DISPERSION_DEP_BASE", 1.0);
+			jpp.set("COL_DISPERSION_DEP_EXPONENT", 1.0);
+
+			if (spatialMethod == "DG")
+			{
+				// Required quadrature degree for the variable-dispersion integral whenever
+				// COL_DISPERSION_DEP is set with DG bulk discretization; matches the POLYDEG
+				// set for the bulk discretization by createColumnWithTwoCompLinearJson() above.
+				jpp.set("DISPERSION_SPATIAL_DEPENDENCE_POLYDEG", 3);
+			}
+		}
+
+		// Impose the flow rate the test models' geometry was dimensioned for (see
+		// createColumnWithTwoCompLinearJson()), so that the interstitial velocity -- and hence the
+		// velocity dependent dispersion coefficient -- is nonzero and, for the radial and frustum
+		// geometries, actually varies over the column (by a factor of ~4 here).
+		const double pi = 3.14159265358979323846;
+		const double flowRate = 5.75e-4 * (pi * 0.01 * 0.01) * 0.37;
+
+		testJacobianAD(jpp, 1e-14, std::numeric_limits<float>::epsilon() * 100.0, { flowRate });
+	}
+
 	void testArrowHeadJacobianFD(cadet::JsonParameterProvider& jpp, double h, double absTol, double relTol)
 	{
 		cadet::IModelBuilder* const mb = cadet::createModelBuilder();

--- a/test/ColumnTests.hpp
+++ b/test/ColumnTests.hpp
@@ -626,6 +626,19 @@ namespace column
 	void testJacobianADVariableColDispersionVanDeemter(const std::string& uoType, const std::string& spatialMethod, bool dynamicBinding);
 
 	/**
+	 * @brief Checks the analytic Jacobian against AD for a POWER_LAW COL_DISPERSION_DEP
+	 * @details Unlike VAN_DEEMTER (whose dependence factor is nonzero at zero velocity), POWER_LAW
+	 *          collapses to zero dispersion when no flow rate is set, so this test explicitly imposes
+	 *          a nonzero volumetric flow rate. For the non-axial geometries that is also what makes
+	 *          the dispersion coefficient genuinely position dependent, since the interstitial
+	 *          velocity varies with the position dependent cross section area.
+	 * @param [in] uoType Unit operation type
+	 * @param [in] spatialMethod Spatial discretization method
+	 * @param [in] dynamicBinding Determines whether dynamic binding is used
+	 */
+	void testJacobianADVariableColDispersionPowerLaw(const std::string& uoType, const std::string& spatialMethod, bool dynamicBinding);
+
+	/**
 	 * @brief Checks the full Jacobian against AD and FD pattern switching from forward to backward flow and back
 	 * @details Checks the analytic Jacobian against the AD Jacobian and checks both against the FD pattern.
 	 *          Checks both forward and backward flow mode as well as switching between them.


### PR DESCRIPTION
Fixes #779 

VariableCrossSectionConvectionDispersionOperatorBaseDG caches its per-element DG operators (_invMM_A_times_ST_AD, _dispAtInterfaces) in computeOperators().
notifyDiscontinuousSectionTransition() rebuilt the analytic Jacobian blocks from those cached operators BEFORE refreshing them, so the Jacobian was always one step behind the residual.

This matters most with a velocity dependent COL_DISPERSION_DEP: the operators are first built in configure(), where the flow rate (which is needed in the operators) is not known yet and still zero. For POWER_LAW that makes the cached dispersion identically zero (base * pow(abs(0), exponent)), so the analytic Jacobian carried no dispersion contribution at all while the residual used the correct, velocity dependent one. IDAS then had to shrink its step size until the alpha/h * I term dominated the iteration matrix enough for the modified Newton iteration to converge. The result was a correct solution reached with a huge number of tiny steps, getting worse with mesh refinement.