### PR TITLE
Add bulk dispersion dependence in collocation DG axial cylinder discretization

### DIFF
--- a/src/libcadet/model/parts/ConvectionDispersionOperatorDG.cpp
+++ b/src/libcadet/model/parts/ConvectionDispersionOperatorDG.cpp
@@ -227,6 +227,15 @@ bool AxialConvectionDispersionOperatorBaseCollocationDG::configure(UnitOpIdx uni
 	return true;
 }
 
+double AxialConvectionDispersionOperatorBaseCollocationDG::effectiveDispersion(const int secIdx, const int comp) const CADET_NOEXCEPT
+{
+	const double baseDispersion = static_cast<double>(currentDispersion(secIdx)[comp]);
+	if (!_dispersionDep)
+		return baseDispersion;
+
+	return baseDispersion * _dispersionDep->getValue(ColumnPosition{ 0.0, 0.0, 0.0 }, comp, ParTypeIndep, BoundStateIndep, static_cast<double>(_curVelocity));
+}
+
 /**
  * @brief Notifies the operator that a discontinuous section transition is in progress
  * @details In addition to changing flow direction internally, if necessary, the function returns whether
@@ -348,7 +357,12 @@ int AxialConvectionDispersionOperatorBaseCollocationDG::residualImpl(const IMode
 			_resC.setZero();
 
 		const ParamType u = static_cast<ParamType>(_curVelocity);
-		const ParamType d_ax = static_cast<ParamType>(getSectionDependentSlice(_colDispersion, _nComp, secIdx)[comp]);
+		// Apply the (velocity dependent) COL_DISPERSION_DEP factor. This geometry has a constant
+		// cross section and hence a constant interstitial velocity, so the resulting coefficient is
+		// still constant along the column and can be evaluated once per component. Without a
+		// dependence configured, _dispersionDep is CONSTANT_ONE and this is a no-op.
+		const ParamType d_ax = static_cast<ParamType>(getSectionDependentSlice(_colDispersion, _nComp, secIdx)[comp])
+			* _dispersionDep->getValue(ColumnPosition{ 0.0, 0.0, 0.0 }, comp, ParTypeIndep, BoundStateIndep, u);
 
 		// ===================================//
 		// reset cache                        //

--- a/src/libcadet/model/parts/ConvectionDispersionOperatorDG.hpp
+++ b/src/libcadet/model/parts/ConvectionDispersionOperatorDG.hpp
@@ -117,6 +117,15 @@ namespace parts
 		inline const double* nodes() const CADET_NOEXCEPT { return &_nodes[0]; }
 		inline const active& currentVelocity() const CADET_NOEXCEPT { return _curVelocity; }
 		inline const active* currentDispersion(const int secIdx) const CADET_NOEXCEPT { return getSectionDependentSlice(_colDispersion, _nComp, secIdx); }
+		/**
+		 * @brief Column dispersion including the COL_DISPERSION_DEP factor, as a plain double
+		 * @details This geometry has a constant cross section and hence a constant interstitial
+		 *          velocity, so a velocity dependent COL_DISPERSION_DEP yields a coefficient that is
+		 *          still constant along the column and can simply be evaluated once here. Used by the
+		 *          analytic Jacobian; the residual applies the same factor in its own arithmetic type
+		 *          so that parameter sensitivities are propagated.
+		 */
+		double effectiveDispersion(const int secIdx, const int comp) const CADET_NOEXCEPT;
 		inline bool dispersionCompIndep() const CADET_NOEXCEPT { return _dispersionCompIndep; }
 
 		inline unsigned int nComp() const CADET_NOEXCEPT { return _nComp; }
@@ -665,6 +674,7 @@ namespace parts
 				for (unsigned int element = 1; element < _nElem - 1; element++) {
 					for (unsigned int i = 0; i < dispBlock.rows(); i++, jacIt += strideColBound) {
 						for (unsigned int comp = 0; comp < _nComp; comp++, ++jacIt) {
+							const double d_ax = effectiveDispersion(_curSection, comp);
 							for (unsigned int j = 0; j < dispBlock.cols(); j++) {
 								// pattern is more sparse than a nNodes x 3*nNodes block.
 								if ((j >= _nNodes - 1 && j <= 2 * _nNodes) ||
@@ -672,7 +682,7 @@ namespace parts
 									(i == _nNodes - 1 && j >= _nNodes - 1))
 									// row: iterator is at current node i and current component comp
 									// col: start at previous element and jump to node j
-									jacIt[-strideColElement() + (j - i) * strideColNode()] = dispBlock(i, j) * static_cast<double>(currentDispersion(_curSection)[comp]);
+									jacIt[-strideColElement() + (j - i) * strideColNode()] = dispBlock(i, j) * d_ax;
 							}
 						}
 					}
@@ -689,6 +699,7 @@ namespace parts
 
 				for (unsigned int i = 0; i < dispBlock.rows(); i++, jacIt += strideColBound) {
 					for (unsigned int comp = 0; comp < _nComp; comp++, ++jacIt) {
+						const double d_ax = effectiveDispersion(_curSection, comp);
 						for (unsigned int j = _nNodes; j < dispBlock.cols(); j++) {
 							// pattern is more sparse than a nNodes x 2*nNodes block.
 							if ((j >= _nNodes - 1 && j <= 2 * _nNodes) ||
@@ -696,7 +707,7 @@ namespace parts
 								(i == _nNodes - 1 && j >= _nNodes - 1))
 								// row: iterator is at current node i and current component comp
 								// col: jump to node j
-								jacIt[((j - _nNodes) - i) * strideColNode()] = dispBlock(i, j) * static_cast<double>(currentDispersion(_curSection)[comp]);
+								jacIt[((j - _nNodes) - i) * strideColNode()] = dispBlock(i, j) * d_ax;
 						}
 					}
 				}
@@ -705,10 +716,11 @@ namespace parts
 				linalg::BandedEigenSparseRowIterator jacIt(jacobian, offC); // row iterator starting at first element and component
 				for (unsigned int i = 0; i < dispBlock.rows(); i++, jacIt += strideColBound) {
 					for (unsigned int comp = 0; comp < _nComp; comp++, ++jacIt) {
+						const double d_ax = effectiveDispersion(_curSection, comp);
 						for (unsigned int j = _nNodes; j < _nNodes * 2u; j++) {
 							// row: iterator is at current node i and current component comp
 							// col: jump to node j
-							jacIt[((j - _nNodes) - i) * strideColNode()] = dispBlock(i, j) * static_cast<double>(currentDispersion(_curSection)[comp]);
+							jacIt[((j - _nNodes) - i) * strideColNode()] = dispBlock(i, j) * d_ax;
 						}
 					}
 				}
@@ -721,6 +733,7 @@ namespace parts
 
 				for (unsigned int i = 0; i < dispBlock.rows(); i++, jacIt += strideColBound) {
 					for (unsigned int comp = 0; comp < _nComp; comp++, ++jacIt) {
+						const double d_ax = effectiveDispersion(_curSection, comp);
 						for (unsigned int j = 0; j < 2 * _nNodes; j++) {
 							// pattern is more sparse than a nNodes x 2*nNodes block.
 							if ((j >= _nNodes - 1 && j <= 2 * _nNodes) ||
@@ -728,7 +741,7 @@ namespace parts
 								(i == _nNodes - 1 && j >= _nNodes - 1))
 								// row: iterator is at current node i and current component comp
 								// col: start at previous element and jump to node j
-								jacIt[-strideColElement() + (j - i) * strideColNode()] = dispBlock(i, j) * static_cast<double>(currentDispersion(_curSection)[comp]);
+								jacIt[-strideColElement() + (j - i) * strideColNode()] = dispBlock(i, j) * d_ax;
 						}
 					}
 				}

--- a/test/ColumnModel1D.cpp
+++ b/test/ColumnModel1D.cpp
@@ -887,6 +887,39 @@ TEST_CASE("Column_1D as radial GRM col dispersion power law par dep Jacobian ana
 	cadet::test::column::testJacobianADVariableColDispersionPowerLaw("RADIAL_COLUMN_MODEL_1D_GRM", "DG", false);
 }
 
+TEST_CASE("Column_1D as GRM col dispersion par dep is applied by collocation DG", "[AxialColumn1D],[DG],[DG1D],[Simulation],[ParameterDependence],[CI]")
+{
+	// The collocation DG operator used to configure COL_DISPERSION_DEP and then never evaluate it,
+	// so the dependence was silently ignored. Both settings below describe the same physics: the
+	// LWE model's axial cylinder geometry is dimensioned for an interstitial velocity of exactly
+	// 5.75e-4, so D(v) = (COL_DISPERSION / 5.75e-4) * |v| reproduces the reference setting's plain,
+	// constant COL_DISPERSION. They must therefore give the same result.
+	const double velocity = 5.75e-4;
+
+	cadet::JsonParameterProvider jpp1 = createLWE("COLUMN_MODEL_1D_GRM", "DG");
+	cadet::JsonParameterProvider jpp2 = createLWE("COLUMN_MODEL_1D_GRM", "DG");
+	cadet::test::column::DGParams disc(1, 3, 8); // collocation DG
+	disc.setDisc(jpp1);
+	disc.setDisc(jpp2);
+
+	jpp1.pushScope("model");
+	jpp1.pushScope("unit_000");
+	const double baseDispersion = jpp1.getDouble("COL_DISPERSION");
+	jpp1.set("COL_DISPERSION", baseDispersion / velocity);
+	jpp1.set("COL_DISPERSION_DEP", "POWER_LAW");
+	jpp1.set("COL_DISPERSION_DEP_BASE", 1.0);
+	jpp1.set("COL_DISPERSION_DEP_EXPONENT", 1.0);
+	jpp1.popScope();
+	jpp1.popScope();
+
+	cadet::test::column::testEqualResults(jpp1, jpp2, 1e-10, 1e-8, 0);
+}
+
+TEST_CASE("Column_1D as GRM col dispersion power law par dep Jacobian analytic vs AD collocation DG", "[AxialColumn1D],[DG],[DG1D],[UnitOp],[Jacobian],[AD],[ParameterDependence],[CI]")
+{
+	cadet::test::column::testJacobianADVariableColDispersionPowerLaw("COLUMN_MODEL_1D_GRM", "DG", false, true);
+}
+
 TEST_CASE("Column_1D as GRM dynamic reactions Jacobian vs AD modified particle", "[AxialColumn1D],[DG],[DG1D],[Jacobian],[AD],[ReactionModel],[CI]")
 {
 	cadet::test::reaction::testUnitJacobianDynamicReactionsAD("COLUMN_MODEL_1D_GRM", "DG", false, true, true, 1e-14);

--- a/test/ColumnTests.cpp
+++ b/test/ColumnTests.cpp
@@ -1307,13 +1307,19 @@ namespace column
 		testJacobianAD(jpp, 1e-14);
 	}
 
-	void testJacobianADVariableColDispersionPowerLaw(const std::string& uoType, const std::string& spatialMethod, bool dynamicBinding)
+	void testJacobianADVariableColDispersionPowerLaw(const std::string& uoType, const std::string& spatialMethod, bool dynamicBinding, bool useCollocationDG)
 	{
 		cadet::JsonParameterProvider jpp = createColumnWithTwoCompLinearBinding(uoType, spatialMethod);
 		setBindingMode(jpp, dynamicBinding);
 		{
 			auto ms = util::makeOptionalGroupScope(jpp, "model");
 			auto us = util::makeOptionalGroupScope(jpp, "unit_000");
+
+			if (useCollocationDG)
+			{
+				auto ds = util::makeOptionalGroupScope(jpp, "discretization");
+				jpp.set("USE_COLLOCATION_DG", 1);
+			}
 
 			// D(x) = COL_DISPERSION * |v(x)|, i.e. COL_DISPERSION acts as a dispersivity. Note that
 			// this dependence vanishes identically at zero velocity, so a nonzero flow rate has to be

--- a/test/ColumnTests.hpp
+++ b/test/ColumnTests.hpp
@@ -635,8 +635,9 @@ namespace column
 	 * @param [in] uoType Unit operation type
 	 * @param [in] spatialMethod Spatial discretization method
 	 * @param [in] dynamicBinding Determines whether dynamic binding is used
+	 * @param [in] useCollocationDG Selects the collocation DG bulk operator (axial cylinder only)
 	 */
-	void testJacobianADVariableColDispersionPowerLaw(const std::string& uoType, const std::string& spatialMethod, bool dynamicBinding);
+	void testJacobianADVariableColDispersionPowerLaw(const std::string& uoType, const std::string& spatialMethod, bool dynamicBinding, bool useCollocationDG = false);
 
 	/**
 	 * @brief Checks the full Jacobian against AD and FD pattern switching from forward to backward flow and back


### PR DESCRIPTION
AxialConvectionDispersionOperatorBaseCollocationDG already created and configured a COL_DISPERSION_DEP parameter dependence but never evaluated it: both its residual and its analytic Jacobian used the raw COL_DISPERSION coefficient.
This commit fixes that in view of future spatially dependent porosities,
where the velocity in an axial cylinder column can actually vary.