### PR TITLE
Fix parameter dependent section slices in FV film diffusion for generalized units

### DIFF
--- a/src/libcadet/model/ColumnModelBuilder.cpp
+++ b/src/libcadet/model/ColumnModelBuilder.cpp
@@ -90,20 +90,53 @@ namespace model
 			throw InvalidParameterException("Unsupported column geometry " + colGeometry + " was specified for unit " + std::to_string(uoId));
 		}
 
+		// The dedicated arrow-head FV unit operations (LRM, LRMP, GRM) discretize the particles with FV as well, i.e.
+		// they cannot represent a particle discretization that differs from the bulk one. Determine the particle
+		// discretization of general rate particles up front, so that a mixed bulk/particle discretization is routed
+		// to the modular ColumnModel1D, which combines any bulk with any particle discretization.
+		// Only general rate particles are spatially resolved, all other particle models ignore SPATIAL_METHOD.
+		std::string parDiscName = "FV";
+		if (paramProvider.getInt("NPARTYPE") > 0 && paramProvider.exists("particle_type_000"))
+		{
+			paramProvider.pushScope("particle_type_000");
+
+			const bool filmDiffusion = paramProvider.exists("HAS_FILM_DIFFUSION") ? paramProvider.getBool("HAS_FILM_DIFFUSION") : true;
+			const bool poreDiffusion = paramProvider.exists("HAS_PORE_DIFFUSION") ? paramProvider.getBool("HAS_PORE_DIFFUSION") : false;
+			const bool surfaceDiffusion = paramProvider.exists("HAS_SURFACE_DIFFUSION") ? paramProvider.getBool("HAS_SURFACE_DIFFUSION") : false;
+			const bool generalRateParticle = (filmDiffusion && (poreDiffusion || surfaceDiffusion)) || uoType == "GENERAL_RATE_MODEL" || uoType == "GRM";
+
+			if (generalRateParticle && paramProvider.exists("discretization"))
+			{
+				paramProvider.pushScope("discretization");
+
+				if (paramProvider.exists("SPATIAL_METHOD"))
+					parDiscName = paramProvider.getString("SPATIAL_METHOD");
+
+				paramProvider.popScope(); // discretization
+			}
+
+			paramProvider.popScope(); // particle_type_000
+		}
+
 		paramProvider.pushScope("discretization");
 		
 		const std::string discName = paramProvider.getString("SPATIAL_METHOD");
 
-		// ARROW_HEAD_OPTIMIZATION defaults to true for FV, preserving the existing block-structured
-		// (arrow-head) Jacobian solver in the dedicated FV unit operation classes.
+		// ARROW_HEAD_OPTIMIZATION defaults to true for FV bulk and FV particle discretization, preserving the
+		// existing block-structured (arrow-head) Jacobian solver in the dedicated FV unit operation classes.
 		// Set it to false to route FV through ColumnModel1D (global sparse solver).
 		const bool arrowHeadOpt = paramProvider.exists("FV_ARROW_HEAD_OPTIMIZATION")
 			? paramProvider.getBool("FV_ARROW_HEAD_OPTIMIZATION")
-			: discName == "FV";
+			: (discName == "FV" && parDiscName == "FV");
 
 		if (arrowHeadOpt && discName != "FV")
 		{
 			throw InvalidParameterException("FV_ARROW_HEAD_OPTIMIZATION is only available for FV discretization but " + discName + " was specifiedfor unit " + std::to_string(uoId));
+		}
+
+		if (arrowHeadOpt && parDiscName != "FV")
+		{
+			throw InvalidParameterException("FV_ARROW_HEAD_OPTIMIZATION requires FV discretization of the particles but " + parDiscName + " was specified for unit " + std::to_string(uoId));
 		}
 
 		bool axialCollocationDG = (colGeometry == "AXIAL_FLOW_CYLINDER");

--- a/src/libcadet/model/particle/GeneralRateParticle.cpp
+++ b/src/libcadet/model/particle/GeneralRateParticle.cpp
@@ -316,7 +316,7 @@ namespace model
 			// Add flux to column void / bulk volume using discretized film diffusion
 			for (unsigned int comp = 0; comp < _nComp; ++comp)
 			{
-				ParamType discretizedFilmDiffusionFactor = static_cast<ParamType>(_parDiffOp->discretizedFilmDiffusionFactor(comp));
+				const ParamType discretizedFilmDiffusionFactor = static_cast<ParamType>(_parDiffOp->discretizedFilmDiffusionFactor(secIdx, comp, packing.colPos, packing.velocity));
 				// FILM_DIFFUSION_DEP evaluated pointwise at this bulk point's position/velocity
 				const ParamType filmDiff_comp = static_cast<ParamType>(_parDiffOp->modifiedFilmDiffusion(secIdx, comp, packing.colPos, packing.velocity));
 

--- a/src/libcadet/model/parts/ParticleDiffusionOperatorBase.hpp
+++ b/src/libcadet/model/parts/ParticleDiffusionOperatorBase.hpp
@@ -202,7 +202,13 @@ namespace parts
 		inline MultiplexMode parDiffMode() const CADET_NOEXCEPT { return _parDiffusionMode; }
 		inline MultiplexMode parSurfDiffMode() const CADET_NOEXCEPT { return _parSurfDiffusionMode; }
 		
-		virtual active discretizedFilmDiffusionFactor(const int comp) const CADET_NOEXCEPT { return active(1.0); }
+		/**
+		 * @brief Returns the discretization dependent correction factor of the film diffusion coefficient
+		 * @details The bulk phase film diffusion flux is computed as factor * modifiedFilmDiffusion() * (c^b - c^p).
+		 *          The factor must be evaluated with the same (section and FILM_DIFFUSION_DEP dependent) coefficients
+		 *          that the particle side boundary condition uses, otherwise both sides of the flux disagree.
+		 */
+		virtual active discretizedFilmDiffusionFactor(const unsigned int secIdx, const int comp, const ColumnPosition& colPos, const active& velocity) const CADET_NOEXCEPT { return active(1.0); }
 
 	protected:
 

--- a/src/libcadet/model/parts/ParticleDiffusionOperatorFV.hpp
+++ b/src/libcadet/model/parts/ParticleDiffusionOperatorFV.hpp
@@ -142,10 +142,17 @@ namespace parts
 
 		bool setSensitiveParameter(std::unordered_set<active*>& sensParams, const ParameterId& pId, unsigned int adDirection, double adValue);
 
-		active discretizedFilmDiffusionFactor(const int comp) const CADET_NOEXCEPT
+		active discretizedFilmDiffusionFactor(const unsigned int secIdx, const int comp, const ColumnPosition& colPos, const active& velocity) const CADET_NOEXCEPT
 		{
 			if (_boundaryOrderFV == 2 && nDiscPoints() > 1)
-				return 1.0 / (0.5 * _deltaR[_nParPoints - 1] * _filmDiffusion[comp] / _parPorosity / _poreAccessFactor[comp] / _parDiffusion[comp] + 1.0);
+			{
+				// Use the section dependent slices and the FILM_DIFFUSION_DEP modified film diffusion, i.e. exactly the
+				// coefficients that residualImpl() and calcFilmDiffJacobian() use for the outer shell boundary condition.
+				const active filmDiff = modifiedFilmDiffusion(secIdx, comp, colPos, velocity);
+				active const* const parDiff = getSectionDependentSlice(_parDiffusion, _nComp, secIdx);
+
+				return 1.0 / (0.5 * _deltaR[_nParPoints - 1] * filmDiff / _parPorosity / _poreAccessFactor[comp] / parDiff[comp] + 1.0);
+			}
 			else
 				return active(1.0);
 		}

--- a/test/ColumnModel1D.cpp
+++ b/test/ColumnModel1D.cpp
@@ -186,6 +186,16 @@ TEST_CASE("Column_1D as GRM linear pulse vs analytic solution with bulk DG and p
 	cadet::test::column::testAnalyticBenchmark("COLUMN_MODEL_1D_GRM", "/data/grm-pulseBenchmark.data", false, false, *discDGFV, "DGFV", 6e-5, 1e-7);
 }
 
+TEST_CASE("Column_1D as GRM linear pulse vs analytic solution with bulk FV and particle DG discretization", "[AxialColumn1D],[FVDG],[Simulation],[Analytic],[CI]")
+{
+	// Regression test: an FV bulk discretization combined with a DG particle discretization must be routed to
+	// ColumnModel1D. The arrow head FV unit operations discretize the particles with FV only and used to be
+	// selected for any FV bulk discretization, which made this combination fail during configuration.
+	auto discFVDG = cadet::test::column::createFVDGParams(512, 3, 0, 3, 1); // 512 axial FV cells, as in the pure FV analytic benchmarks
+	cadet::test::column::testAnalyticBenchmark("COLUMN_MODEL_1D_GRM", "/data/grm-pulseBenchmark.data", true, true, *discFVDG, "FVDG", 6e-5, 1e-7);
+	cadet::test::column::testAnalyticBenchmark("COLUMN_MODEL_1D_GRM", "/data/grm-pulseBenchmark.data", false, false, *discFVDG, "FVDG", 6e-5, 1e-7);
+}
+
 TEST_CASE("Column_1D as LRMP linear pulse vs analytic solution", "[AxialColumn1D],[DG],[DG1D],[Simulation],[Analytic],[CI]")
 {
 	cadet::test::column::DGParams disc;

--- a/test/ColumnModel1D.cpp
+++ b/test/ColumnModel1D.cpp
@@ -196,6 +196,42 @@ TEST_CASE("Column_1D as GRM linear pulse vs analytic solution with bulk FV and p
 	cadet::test::column::testAnalyticBenchmark("COLUMN_MODEL_1D_GRM", "/data/grm-pulseBenchmark.data", false, false, *discFVDG, "FVDG", 6e-5, 1e-7);
 }
 
+TEST_CASE("Column_1D as GRM with FV particles is invariant to an equivalent constant FILM_DIFFUSION_DEP", "[AxialColumn1D],[DGFV],[Simulation],[ParameterDependence],[CI]")
+{
+	// Regression test: the FV particle operator corrects k_f for the resistance of the outer half shell. That
+	// correction has to be evaluated with the FILM_DIFFUSION_DEP modified k_f, just like the particle side
+	// boundary condition, otherwise the bulk and the particle side of the film diffusion flux disagree.
+	// A POWER_LAW dependence with exponent 0 and base b is a constant factor b, so scaling FILM_DIFFUSION by
+	// 1/b must reproduce the unmodified simulation exactly.
+	const double base = 4.0;
+
+	cadet::JsonParameterProvider jpp1 = createLWE("COLUMN_MODEL_1D_GRM", "DGFV");
+	cadet::JsonParameterProvider jpp2 = createLWE("COLUMN_MODEL_1D_GRM", "DGFV");
+
+	auto disc = cadet::test::column::createDGFVParams(0, 3, 8, 0, 0, 4);
+	disc->setDisc(jpp1);
+	disc->setDisc(jpp2);
+
+	jpp2.pushScope("model");
+	jpp2.pushScope("unit_000");
+	jpp2.pushScope("particle_type_000");
+
+	std::vector<double> filmDiff = jpp2.getDoubleArray("FILM_DIFFUSION");
+	for (double& fd : filmDiff)
+		fd /= base;
+
+	jpp2.set("FILM_DIFFUSION", filmDiff);
+	jpp2.set("FILM_DIFFUSION_DEP", std::string("POWER_LAW"));
+	jpp2.set("FILM_DIFFUSION_DEP_BASE", base);
+	jpp2.set("FILM_DIFFUSION_DEP_EXPONENT", 0.0);
+
+	jpp2.popScope();
+	jpp2.popScope();
+	jpp2.popScope();
+
+	cadet::test::column::testEqualResults(jpp1, jpp2, 1e-10, 1e-8, 0);
+}
+
 TEST_CASE("Column_1D as LRMP linear pulse vs analytic solution", "[AxialColumn1D],[DG],[DG1D],[Simulation],[Analytic],[CI]")
 {
 	cadet::test::column::DGParams disc;

--- a/test/JsonTestModels.cpp
+++ b/test/JsonTestModels.cpp
@@ -157,7 +157,6 @@ json createColumnWithSMAJson(const std::string& uoType, const std::string& spati
 		if (bulkMethod == "FV")
 		{
 			disc["NCOL"] = 16;
-			discPar["NCELLS"] = 4;
 			disc["MAX_KRYLOV"] = 0;
 			disc["GS_TYPE"] = 1;
 			disc["MAX_RESTARTS"] = 10;
@@ -1256,7 +1255,6 @@ json createLinearBenchmarkColumnJson(bool dynamicBinding, bool nonBinding, const
 		if (bulkMethod == "FV")
 		{
 			disc["NCOL"] = 512;
-			parDisc["NCELLS"] = 4;
 			if (model2D)
 				disc["NRAD"] = 3;
 


### PR DESCRIPTION
For bulk FV discretizations, the model builder always checked for arrowhead optimization no matter which particle discretization was specified, disabling the combination of bulk FV and particle DG. This PR fixes the model builder accordingly.
Additionally, the FV film diffusion discretization used the raw film and pore diffusion coefficients instead of the appropriate parameter dependent section slice, which this PR also fixes.